### PR TITLE
Add packet filtering service

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/PacketControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/PacketControllerRest.java
@@ -1,0 +1,28 @@
+package it.sensorplatform.controller.rest;
+
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.service.PacketService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST endpoint that receives generic JSON packets and delegates the
+ * handling to {@link PacketService} which implements the filtering logic.
+ */
+@RestController
+@RequestMapping("/api/packets")
+public class PacketControllerRest {
+
+    private final PacketService packetService;
+
+    public PacketControllerRest(PacketService packetService) {
+        this.packetService = packetService;
+    }
+
+    @PostMapping
+    public ResponseEntity<PacketService.Result> handle(@RequestBody PacketDTO packet) {
+        PacketService.Result result = packetService.handlePacket(packet);
+        return ResponseEntity.ok(result);
+    }
+}
+

--- a/src/main/java/it/sensorplatform/dto/PacketDTO.java
+++ b/src/main/java/it/sensorplatform/dto/PacketDTO.java
@@ -1,0 +1,66 @@
+package it.sensorplatform.dto;
+
+import java.util.Map;
+
+/**
+ * Generic DTO representing a JSON packet sent by a device or an operator.
+ * It contains minimal routing information used by the platform.
+ */
+public class PacketDTO {
+
+    private String macAddress;
+    private Long projectId;
+    private boolean activation;
+    private Double latitude;
+    private Double longitude;
+    private Map<String, Object> payload;
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(Long projectId) {
+        this.projectId = projectId;
+    }
+
+    public boolean isActivation() {
+        return activation;
+    }
+
+    public void setActivation(boolean activation) {
+        this.activation = activation;
+    }
+
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(Double latitude) {
+        this.latitude = latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(Double longitude) {
+        this.longitude = longitude;
+    }
+
+    public Map<String, Object> getPayload() {
+        return payload;
+    }
+
+    public void setPayload(Map<String, Object> payload) {
+        this.payload = payload;
+    }
+}
+

--- a/src/main/java/it/sensorplatform/model/Device.java
+++ b/src/main/java/it/sensorplatform/model/Device.java
@@ -40,9 +40,12 @@ public class Device {
 	@Column(unique = true, nullable = false)
 	private String macAddress;
 	
-	@NotBlank
-	@Column(nullable = true)
-	private String emailOwner;
+        @NotBlank
+        @Column(nullable = true)
+        private String emailOwner;
+
+        @Column(nullable = false)
+        private boolean activated = false;
 	
 	@ManyToOne
 	private Project project;
@@ -144,9 +147,17 @@ public class Device {
 	}
 
 	
-	public void setEmailOwner(String emailOwner) {
-		this.emailOwner = emailOwner;
-	}
+        public void setEmailOwner(String emailOwner) {
+                this.emailOwner = emailOwner;
+        }
+
+        public boolean isActivated() {
+                return activated;
+        }
+
+        public void setActivated(boolean activated) {
+                this.activated = activated;
+        }
 
 
 	public Group getGroup() {

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -1,0 +1,81 @@
+package it.sensorplatform.service;
+
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Project;
+import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.repository.ProjectRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Service that applies the device/project filter logic described in the
+ * specification. It handles three cases:
+ *  1. unknown device -> register it with activation=false
+ *  2. known device with activation flag -> update device activation and location
+ *  3. known device without activation flag -> forward data to IngestService
+ */
+@Service
+public class PacketService {
+
+    private final DeviceRepository deviceRepository;
+    private final ProjectRepository projectRepository;
+    private final IngestService ingestService;
+
+    public PacketService(DeviceRepository deviceRepository,
+                         ProjectRepository projectRepository,
+                         IngestService ingestService) {
+        this.deviceRepository = deviceRepository;
+        this.projectRepository = projectRepository;
+        this.ingestService = ingestService;
+    }
+
+    public enum Result { NEW_DEVICE, ACTIVATION, DATA }
+
+    /**
+     * Process an incoming packet according to device/project state.
+     */
+    public Result handlePacket(PacketDTO packet) {
+        if (packet.getMacAddress() == null || packet.getMacAddress().isBlank()) {
+            throw new IllegalArgumentException("macAddress is required");
+        }
+
+        Optional<Device> existing = deviceRepository.findByMacAddress(packet.getMacAddress());
+        if (existing.isEmpty()) {
+            // Case 1: device not present -> register
+            Device device = new Device();
+            device.setMacAddress(packet.getMacAddress());
+            device.setName(packet.getMacAddress());
+            device.setEmailOwner("");
+            device.setActivated(false);
+            device.setLatitude(packet.getLatitude() != null ? packet.getLatitude() : 0d);
+            device.setLongitude(packet.getLongitude() != null ? packet.getLongitude() : 0d);
+            if (packet.getProjectId() != null) {
+                Project p = projectRepository.findById(packet.getProjectId()).orElse(null);
+                device.setProject(p);
+            }
+            deviceRepository.save(device);
+            return Result.NEW_DEVICE;
+        }
+
+        Device device = existing.get();
+
+        if (packet.isActivation()) {
+            // Case 3: activation packet -> update flags and location
+            device.setActivated(true);
+            if (packet.getLatitude() != null) device.setLatitude(packet.getLatitude());
+            if (packet.getLongitude() != null) device.setLongitude(packet.getLongitude());
+            deviceRepository.save(device);
+            return Result.ACTIVATION;
+        }
+
+        // Case 2: normal data packet -> forward metrics to ingest service
+        Map<String, Object> payload = packet.getPayload();
+        ingestService.process(device.getMacAddress(), device.getDevEui(), Instant.now(), payload);
+        return Result.DATA;
+    }
+}
+

--- a/src/test/java/it/sensorplatform/test/PacketServiceTests.java
+++ b/src/test/java/it/sensorplatform/test/PacketServiceTests.java
@@ -1,0 +1,108 @@
+package it.sensorplatform.test;
+
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Project;
+import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.repository.ProjectRepository;
+import it.sensorplatform.service.IngestService;
+import it.sensorplatform.service.PacketService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class PacketServiceTests {
+
+    @Autowired
+    private PacketService packetService;
+
+    @Autowired
+    private DeviceRepository deviceRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private IngestService ingestService;
+
+    @Test
+    void registersNewDeviceWhenUnknown() {
+        Project project = new Project();
+        project.setName("demo");
+        projectRepository.save(project);
+
+        PacketDTO dto = new PacketDTO();
+        dto.setMacAddress("AA:BB:CC");
+        dto.setProjectId(project.getId());
+        PacketService.Result res = packetService.handlePacket(dto);
+
+        assertEquals(PacketService.Result.NEW_DEVICE, res);
+        Device saved = deviceRepository.findByMacAddress("AA:BB:CC").orElseThrow();
+        assertFalse(saved.isActivated());
+        assertEquals(project.getId(), saved.getProject().getId());
+    }
+
+    @Test
+    void forwardsDataForKnownDevice() {
+        Project project = new Project();
+        project.setName("demo");
+        projectRepository.save(project);
+
+        Device device = new Device();
+        device.setName("d1");
+        device.setMacAddress("AA:DD:EE");
+        device.setEmailOwner("");
+        device.setActivated(false);
+        device.setLatitude(0d);
+        device.setLongitude(0d);
+        device.setProject(project);
+        deviceRepository.save(device);
+
+        PacketDTO dto = new PacketDTO();
+        dto.setMacAddress("AA:DD:EE");
+        dto.setPayload(Map.of("temp", 22));
+
+        PacketService.Result res = packetService.handlePacket(dto);
+        assertEquals(PacketService.Result.DATA, res);
+        assertEquals(1, ingestService.last("AA:DD:EE", 1).size());
+    }
+
+    @Test
+    void activatesDeviceWhenFlagPresent() {
+        Project project = new Project();
+        project.setName("demo");
+        projectRepository.save(project);
+
+        Device device = new Device();
+        device.setName("d1");
+        device.setMacAddress("AA:FF:00");
+        device.setEmailOwner("");
+        device.setActivated(false);
+        device.setLatitude(0d);
+        device.setLongitude(0d);
+        device.setProject(project);
+        deviceRepository.save(device);
+
+        PacketDTO dto = new PacketDTO();
+        dto.setMacAddress("AA:FF:00");
+        dto.setActivation(true);
+        dto.setLatitude(45.0);
+        dto.setLongitude(7.0);
+
+        PacketService.Result res = packetService.handlePacket(dto);
+        assertEquals(PacketService.Result.ACTIVATION, res);
+
+        Device updated = deviceRepository.findByMacAddress("AA:FF:00").orElseThrow();
+        assertTrue(updated.isActivated());
+        assertEquals(45.0, updated.getLatitude());
+        assertEquals(7.0, updated.getLongitude());
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend `Device` model with an activation flag
- add `PacketService` with logic for new device registration, activation, or data forwarding
- expose `/api/packets` endpoint for generic JSON packet ingestion
- cover packet flow with integration tests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b716bec1748323ac5c21957e84bda3