### PR TITLE
Add Admin entity with credential links

### DIFF
--- a/src/main/java/it/sensorplatform/model/Admin.java
+++ b/src/main/java/it/sensorplatform/model/Admin.java
@@ -1,0 +1,79 @@
+package it.sensorplatform.model;
+
+import java.util.List;
+import java.util.Objects;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.ManyToMany;
+
+@Entity
+public class Admin {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        private Long id;
+
+        @OneToOne
+        private Credentials credentials;
+
+        @OneToMany(mappedBy = "employer")
+        private List<Credentials> operators;
+
+        @ManyToMany
+        private List<Credentials> authorizedOperators;
+
+        public Long getId() {
+                return id;
+        }
+
+        public void setId(Long id) {
+                this.id = id;
+        }
+
+        public Credentials getCredentials() {
+                return credentials;
+        }
+
+        public void setCredentials(Credentials credentials) {
+                this.credentials = credentials;
+        }
+
+        public List<Credentials> getOperators() {
+                return operators;
+        }
+
+        public void setOperators(List<Credentials> operators) {
+                this.operators = operators;
+        }
+
+        public List<Credentials> getAuthorizedOperators() {
+                return authorizedOperators;
+        }
+
+        public void setAuthorizedOperators(List<Credentials> authorizedOperators) {
+                this.authorizedOperators = authorizedOperators;
+        }
+
+        @Override
+        public int hashCode() {
+                return Objects.hash(id);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+                if (this == obj)
+                        return true;
+                if (obj == null)
+                        return false;
+                if (getClass() != obj.getClass())
+                        return false;
+                Admin other = (Admin) obj;
+                return Objects.equals(id, other.id);
+        }
+}
+

--- a/src/main/java/it/sensorplatform/model/Credentials.java
+++ b/src/main/java/it/sensorplatform/model/Credentials.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotBlank;
 
 @Entity
@@ -51,17 +52,39 @@ public class Credentials {
 	@Column(nullable = true)
 	private String visibleUsername;
 	
-	@OneToMany
-	private List<Device> device;
+        @OneToMany
+        private List<Device> device;
+
+        @OneToOne(mappedBy = "credentials")
+        private Admin admin;
+
+        @ManyToOne
+        private Admin employer;
 	
 	
 	public List<Device> getDevice() {
 		return device;
 	}
 
-	public void setDevice(List<Device> device) {
-		this.device = device;
-	}
+        public void setDevice(List<Device> device) {
+                this.device = device;
+        }
+
+        public Admin getAdmin() {
+                return admin;
+        }
+
+        public void setAdmin(Admin admin) {
+                this.admin = admin;
+        }
+
+        public Admin getEmployer() {
+                return employer;
+        }
+
+        public void setEmployer(Admin employer) {
+                this.employer = employer;
+        }
 
 	public User getUser() {
 		return user;

--- a/src/main/java/it/sensorplatform/repository/AdminRepository.java
+++ b/src/main/java/it/sensorplatform/repository/AdminRepository.java
@@ -1,0 +1,11 @@
+package it.sensorplatform.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import it.sensorplatform.model.Admin;
+
+@Repository
+public interface AdminRepository extends CrudRepository<Admin, Long> {
+}
+

--- a/src/main/java/it/sensorplatform/service/AdminService.java
+++ b/src/main/java/it/sensorplatform/service/AdminService.java
@@ -1,0 +1,33 @@
+package it.sensorplatform.service;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import it.sensorplatform.model.Admin;
+import it.sensorplatform.repository.AdminRepository;
+import jakarta.transaction.Transactional;
+
+@Service
+public class AdminService {
+
+        @Autowired
+        private AdminRepository adminRepository;
+
+        @Transactional
+        public Admin getAdmin(Long id) {
+                Optional<Admin> result = adminRepository.findById(id);
+                return result.orElse(null);
+        }
+
+        @Transactional
+        public Admin saveAdmin(Admin admin) {
+                return adminRepository.save(admin);
+        }
+
+        public Iterable<Admin> getAllAdmins() {
+                return adminRepository.findAll();
+        }
+}
+


### PR DESCRIPTION
## Summary
- introduce Admin entity relating credentials, operators, and authorized operators
- link Credentials to Admin via owning and employer associations
- provide Admin repository and service for persistence and querying

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b84f1ec83883238d96dd2085486c1d