### PR TITLE
Add admin operator authorization endpoints and service methods

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/AdminControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/AdminControllerRest.java
@@ -1,0 +1,28 @@
+package it.sensorplatform.controller.rest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import it.sensorplatform.service.AdminService;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminControllerRest {
+
+    @Autowired
+    private AdminService adminService;
+
+    @PostMapping("/{adminId}/authorize/{operatorId}")
+    public void authorizeOperator(@PathVariable Long adminId, @PathVariable Long operatorId) {
+        adminService.authorizeOperator(adminId, operatorId);
+    }
+
+    @DeleteMapping("/{adminId}/authorize/{operatorId}")
+    public void removeAuthorizedOperator(@PathVariable Long adminId, @PathVariable Long operatorId) {
+        adminService.removeAuthorizedOperator(adminId, operatorId);
+    }
+}

--- a/src/main/java/it/sensorplatform/service/AdminService.java
+++ b/src/main/java/it/sensorplatform/service/AdminService.java
@@ -1,5 +1,6 @@
 package it.sensorplatform.service;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,6 +8,8 @@ import org.springframework.stereotype.Service;
 
 import it.sensorplatform.model.Admin;
 import it.sensorplatform.repository.AdminRepository;
+import it.sensorplatform.repository.CredentialsRepository;
+import it.sensorplatform.model.Credentials;
 import jakarta.transaction.Transactional;
 
 @Service
@@ -14,6 +17,9 @@ public class AdminService {
 
         @Autowired
         private AdminRepository adminRepository;
+
+        @Autowired
+        private CredentialsRepository credentialsRepository;
 
         @Transactional
         public Admin getAdmin(Long id) {
@@ -28,6 +34,35 @@ public class AdminService {
 
         public Iterable<Admin> getAllAdmins() {
                 return adminRepository.findAll();
+        }
+
+        @Transactional
+        public Admin authorizeOperator(Long adminId, Long operatorId) {
+                Admin admin = adminRepository.findById(adminId).orElseThrow();
+                Credentials operator = credentialsRepository.findById(operatorId).orElseThrow();
+
+                if (admin.getAuthorizedOperators() == null) {
+                        admin.setAuthorizedOperators(new ArrayList<>());
+                }
+
+                if (!admin.getAuthorizedOperators().contains(operator)) {
+                        admin.getAuthorizedOperators().add(operator);
+                        adminRepository.save(admin);
+                }
+
+                return admin;
+        }
+
+        @Transactional
+        public Admin removeAuthorizedOperator(Long adminId, Long operatorId) {
+                Admin admin = adminRepository.findById(adminId).orElseThrow();
+                Credentials operator = credentialsRepository.findById(operatorId).orElseThrow();
+
+                if (admin.getAuthorizedOperators() != null && admin.getAuthorizedOperators().remove(operator)) {
+                        adminRepository.save(admin);
+                }
+
+                return admin;
         }
 }
 

--- a/src/test/java/it/sensorplatform/test/AdminServiceTests.java
+++ b/src/test/java/it/sensorplatform/test/AdminServiceTests.java
@@ -1,0 +1,56 @@
+package it.sensorplatform.test;
+
+import it.sensorplatform.model.Admin;
+import it.sensorplatform.model.Credentials;
+import it.sensorplatform.repository.AdminRepository;
+import it.sensorplatform.repository.CredentialsRepository;
+import it.sensorplatform.service.AdminService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class AdminServiceTests {
+
+    @Autowired
+    private AdminService adminService;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private CredentialsRepository credentialsRepository;
+
+    @Test
+    void authorizeAndRemoveOperator() {
+        Credentials adminCred = new Credentials();
+        adminCred.setUsername("admin1");
+        adminCred.setEmail("admin@example.com");
+        adminCred.setPassword("pass");
+        adminCred.setRole("ROLE_ADMIN");
+        credentialsRepository.save(adminCred);
+
+        Admin admin = new Admin();
+        admin.setCredentials(adminCred);
+        adminRepository.save(admin);
+
+        Credentials operatorCred = new Credentials();
+        operatorCred.setUsername("operator1");
+        operatorCred.setEmail("op@example.com");
+        operatorCred.setPassword("pass");
+        operatorCred.setRole("ROLE_OP");
+        credentialsRepository.save(operatorCred);
+
+        adminService.authorizeOperator(admin.getId(), operatorCred.getId());
+        Admin updated = adminService.getAdmin(admin.getId());
+        assertTrue(updated.getAuthorizedOperators().contains(operatorCred));
+
+        adminService.removeAuthorizedOperator(admin.getId(), operatorCred.getId());
+        Admin updatedAfterRemoval = adminService.getAdmin(admin.getId());
+        assertFalse(updatedAfterRemoval.getAuthorizedOperators().contains(operatorCred));
+    }
+}


### PR DESCRIPTION
## Summary
- add AdminService methods to grant or revoke operator authorization
- expose REST endpoints for admins to authorize operators
- test admin operator authorization service logic

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68b851459d788323878bd0816ead9202