### PR TITLE
Handle device state when removing operator

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -304,13 +304,16 @@ public class DeviceController {
 	@PostMapping("/admin/removeOperator/{macAddress}/{projectId}")
 	public String removeOperatorfromDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress, 
 										 RedirectAttributes ra) {
-		Device d = deviceService.findByMacAddress(macAddress);
-		
-		d.setOperator(null);
-		deviceService.save(d);
-		ra.addFlashAttribute("successMessage", "Operator removed.");
-		return "redirect:/admin/group/"+projectId;
-	}
+                Device d = deviceService.findByMacAddress(macAddress);
+
+                d.setOperator(null);
+                d.setLatitude(null);
+                d.setLongitude(null);
+                d.setActivated(false);
+                deviceService.save(d);
+                ra.addFlashAttribute("successMessage", "Operator removed.");
+                return "redirect:/admin/group/"+projectId;
+        }
 	
 	public void loadDeviceDTO(List<Device> devices, Model model) {
 		List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),


### PR DESCRIPTION
## Summary
- Reset device coordinates and activation when removing an operator

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b852cba7dc8323b9d70e46e2d805b0