### PR TITLE
Use typed fallback List for operators

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/OperatorControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/OperatorControllerRest.java
@@ -39,7 +39,7 @@ public class OperatorControllerRest {
         List<Credentials> authorized = admin.getAuthorizedOperators() != null ?
                 admin.getAuthorizedOperators() : List.of();
 
-        return (admin.getOperators() != null ? admin.getOperators() : List.of())
+        return (admin.getOperators() != null ? admin.getOperators() : List.<Credentials>of())
                 .stream()
                 .map(c -> new OperatorDTO(
                         c.getId(),


### PR DESCRIPTION
## Summary
- Ensure operators list fallback uses typed `List<Credentials>`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8575d633c83239fcd3174282bd136