### PR TITLE
Use operator authorization flag in groups view

### DIFF
--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -16,10 +16,12 @@ import it.sensorplatform.model.Credentials;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.model.Group;
 import it.sensorplatform.model.Project;
+import it.sensorplatform.model.Admin;
 import it.sensorplatform.service.CredentialsService;
 import it.sensorplatform.service.DeviceService;
 import it.sensorplatform.service.GroupService;
 import it.sensorplatform.service.ProjectService;
+import it.sensorplatform.service.AdminService;
 
 
 import static it.sensorplatform.model.Credentials.SUPERADMIN_ROLE;
@@ -48,11 +50,14 @@ public class GroupController {
 	@Autowired
 	private CredentialsService credentialsService;
 
-	@Autowired
-	private ProjectService projectService;
+@Autowired
+private ProjectService projectService;
 
-	@Autowired
-	private DeviceService deviceService;
+@Autowired
+private DeviceService deviceService;
+
+@Autowired
+private AdminService adminService;
 
 	@GetMapping(value = "/admin/group/{id}")
 	public String group(@PathVariable("id") Long projectId,
@@ -67,16 +72,22 @@ public class GroupController {
 			model.addAttribute("fire", this.projectService.getProjectByName("FIRE"));
 			model.addAttribute("volcano", this.projectService.getProjectByName("VOLCANO"));
 			return "admin/adminHome";
-		} else {
-			Project project = this.projectService.getProjectById(projectId);
-			
-			//List<Credentials> operators = credentialsService.findOperatorsByProject(project);
-			//model.addAttribute("operators", operators);
-			
-			Set<Group> groups;
-			if (groupName != null && !groupName.isEmpty()) {
-				groups = groupService.findByNameStartingWithIgnoreCaseAndCredentials(groupName, credentials);
-			} else {
+                } else {
+                        Project project = this.projectService.getProjectById(projectId);
+
+                        //List<Credentials> operators = credentialsService.findOperatorsByProject(project);
+                        //model.addAttribute("operators", operators);
+
+                        Admin admin = credentials.getAdmin();
+                        if (admin != null) {
+                                admin = this.adminService.getAdmin(admin.getId());
+                                model.addAttribute("authorizedOperators", admin.getAuthorizedOperators());
+                        }
+
+                        Set<Group> groups;
+                        if (groupName != null && !groupName.isEmpty()) {
+                                groups = groupService.findByNameStartingWithIgnoreCaseAndCredentials(groupName, credentials);
+                        } else {
 				groups = groupService.findAllByCredentials(credentials);
 			}
 			Set<Device> devices = deviceService.findAllByEmailAndProjectId(credentials.getEmail(), projectId);

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -304,7 +304,6 @@
                           `/admin/removeOperator/${encodeURIComponent(mac)}/${PROJECT_ID}`;
                         const ADMIN_ID = /*[[${user.admin != null ? user.admin.id : 0}]]*/ 0;
                         const AUTH_OP_URL = (opId) => `/api/admin/${ADMIN_ID}/authorize/${opId}`;
-                        const AUTHORIZED_OPS = /*[[${authorizedOperators != null ? authorizedOperators.![id] : {}}]]*/ [];
 
 			const modal = document.getElementById('assignOperatorModal');
 			const form = document.getElementById('assignOperatorForm');
@@ -393,7 +392,7 @@
                                                 const authTd = document.createElement('td');
                                                 const cb = document.createElement('input');
                                                 cb.type = 'checkbox';
-                                                cb.checked = AUTHORIZED_OPS.includes(o.id);
+                                                cb.checked = o.authorized;
                                                 cb.addEventListener('change', () => toggleAuthorization(o.id, cb.checked));
                                                 authTd.appendChild(cb);
                                                 tr.appendChild(nameTd);


### PR DESCRIPTION
## Summary
- Inject AdminService into GroupController and expose authorized operators in model
- Render authorized operators in groups view using `o.authorized` instead of AUTHORIZED_OPS array

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9a2bfbb08323b5cd923dc0a061fb