### PR TITLE
Add activation status to devices and surface in admin view

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -316,10 +316,10 @@ public class DeviceController {
         }
 	
 	public void loadDeviceDTO(List<Device> devices, Model model) {
-		List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),
-				d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername()))
-				.collect(Collectors.toList());
-		Collections.sort(deviceDTOs, new Comparator<DeviceDTO>() {
+                List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),
+                                d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
+                                .collect(Collectors.toList());
+                Collections.sort(deviceDTOs, new Comparator<DeviceDTO>() {
 
 			@Override
 			public int compare(DeviceDTO d1, DeviceDTO d2) {

--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -270,10 +270,10 @@ private AdminService adminService;
 				return d1.getName().compareTo(d2.getName());
 			}
 		});
-		List<DeviceDTO> deviceDTOs = orderedDevices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),
-				d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername()))
-				.collect(Collectors.toList());
-		model.addAttribute("devices", deviceDTOs);
-	}
+                List<DeviceDTO> deviceDTOs = orderedDevices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),
+                                d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
+                                .collect(Collectors.toList());
+                model.addAttribute("devices", deviceDTOs);
+        }
 
 }

--- a/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
@@ -33,7 +33,7 @@ public class GroupControllerRest {
     public List<DeviceDTO> getDevicesByGroupId(@PathVariable("groupId") Long groupId) {
         List<Device> devices = groupService.findGroupById(groupId).getDevices();
         return devices.stream()
-                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername()))
+                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
                 .collect(Collectors.toList());
     }
     
@@ -43,7 +43,7 @@ public class GroupControllerRest {
 		Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
         List<Device> devices = groupService.findGroupByNameAndCredentials(groupName, credentials).getDevices();
         return devices.stream()
-                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername()))
+                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
                 .collect(Collectors.toList());
     }
     
@@ -62,7 +62,8 @@ public class GroupControllerRest {
                 device.getLongitude(),
                 device.getLatitude(),
                 device.getTod() != null ? device.getTod().getName() : null,
-                device.getVisibleUsername()
+                device.getVisibleUsername(),
+                device.isActivated()
             ))
             .toList();
     }

--- a/src/main/java/it/sensorplatform/dto/DeviceDTO.java
+++ b/src/main/java/it/sensorplatform/dto/DeviceDTO.java
@@ -9,21 +9,23 @@ public class DeviceDTO {
 	private String macAddress;
 	private Double longitude;
 	private Double latitude;
-	private String emailOwner;
-	private String devEui;
-	private String tod;
-	private String operator;
-	
-	public DeviceDTO(String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator) {
-		this.name = name;
-		this.macAddress = macAddress;
-		this.emailOwner=emailOwner;
-		this.devEui=devEui;
-		this.longitude = longitude;
-		this.latitude = latitude;
-		this.tod=tod;
-		this.operator=operator;
-	}
+        private String emailOwner;
+        private String devEui;
+        private String tod;
+        private String operator;
+        private boolean activated;
+
+        public DeviceDTO(String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator, boolean activated) {
+                this.name = name;
+                this.macAddress = macAddress;
+                this.emailOwner=emailOwner;
+                this.devEui=devEui;
+                this.longitude = longitude;
+                this.latitude = latitude;
+                this.tod=tod;
+                this.operator=operator;
+                this.activated = activated;
+        }
 
 	public String getEmailOwner() {
 		return emailOwner;
@@ -77,18 +79,26 @@ public class DeviceDTO {
 		return tod;
 	}
 
-	public void setTod(String tod) {
-		this.tod = tod;
-	}
-	
+        public void setTod(String tod) {
+                this.tod = tod;
+        }
 
-	public String getOperator() {
-		return operator;
-	}
 
-	public void setOperator(String operator) {
-		this.operator = operator;
-	}
+        public String getOperator() {
+                return operator;
+        }
+
+        public void setOperator(String operator) {
+                this.operator = operator;
+        }
+
+        public boolean isActivated() {
+                return activated;
+        }
+
+        public void setActivated(boolean activated) {
+                this.activated = activated;
+        }
 
 	@Override
 	public int hashCode() {

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -137,6 +137,7 @@
                                                           <th scope="col">Mac Address</th>
                                                           <th scope="col">Type of device</th>
                                                           <th scope="col">Operator</th>
+                                                          <th scope="col">Activated</th>
                                                           <th scope="col">Actions</th>
 
                                                   </tr>
@@ -149,6 +150,7 @@
                                                           <td>
                                                                   <span th:if="${device.operator != null}" th:text="${device.operator}">Operator</span>
                                                           </td>
+                                                          <td th:text="${device.activated}"></td>
                                                           <td>
                                                                   <!-- Edit (icona a matita) -->
                                                                   <a th:href="@{'/device/' + ${project.id} + '/' + ${device.macAddress}}"


### PR DESCRIPTION
## Summary
- track device activation in `DeviceDTO`
- include activation flag when loading device DTOs in controllers and REST endpoints
- show activation status in admin groups page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for it.fourspark:ltrad:1.0: The following artifacts could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9b26e4dc8323b0aa1a0d18415130