### PR TITLE
Use status strings for device activation

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -309,7 +309,7 @@ public class DeviceController {
                 d.setOperator(null);
                 d.setLatitude(null);
                 d.setLongitude(null);
-                d.setActivated(false);
+                d.setStatus("deactivated");
                 deviceService.save(d);
                 ra.addFlashAttribute("successMessage", "Operator removed.");
                 return "redirect:/admin/group/"+projectId;
@@ -317,7 +317,7 @@ public class DeviceController {
 	
 	public void loadDeviceDTO(List<Device> devices, Model model) {
                 List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),
-                                d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
+                                d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
                                 .collect(Collectors.toList());
                 Collections.sort(deviceDTOs, new Comparator<DeviceDTO>() {
 

--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -271,7 +271,7 @@ private AdminService adminService;
 			}
 		});
                 List<DeviceDTO> deviceDTOs = orderedDevices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),
-                                d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
+                                d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
                                 .collect(Collectors.toList());
                 model.addAttribute("devices", deviceDTOs);
         }

--- a/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
@@ -33,7 +33,7 @@ public class GroupControllerRest {
     public List<DeviceDTO> getDevicesByGroupId(@PathVariable("groupId") Long groupId) {
         List<Device> devices = groupService.findGroupById(groupId).getDevices();
         return devices.stream()
-                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
+                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
                 .collect(Collectors.toList());
     }
     
@@ -43,7 +43,7 @@ public class GroupControllerRest {
 		Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
         List<Device> devices = groupService.findGroupByNameAndCredentials(groupName, credentials).getDevices();
         return devices.stream()
-                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.isActivated()))
+                .map(d -> new DeviceDTO(d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
                 .collect(Collectors.toList());
     }
     
@@ -63,7 +63,7 @@ public class GroupControllerRest {
                 device.getLatitude(),
                 device.getTod() != null ? device.getTod().getName() : null,
                 device.getVisibleUsername(),
-                device.isActivated()
+                device.getStatus()
             ))
             .toList();
     }

--- a/src/main/java/it/sensorplatform/dto/DeviceDTO.java
+++ b/src/main/java/it/sensorplatform/dto/DeviceDTO.java
@@ -13,9 +13,9 @@ public class DeviceDTO {
         private String devEui;
         private String tod;
         private String operator;
-        private boolean activated;
+        private String status;
 
-        public DeviceDTO(String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator, boolean activated) {
+        public DeviceDTO(String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator, String status) {
                 this.name = name;
                 this.macAddress = macAddress;
                 this.emailOwner=emailOwner;
@@ -24,7 +24,7 @@ public class DeviceDTO {
                 this.latitude = latitude;
                 this.tod=tod;
                 this.operator=operator;
-                this.activated = activated;
+                this.status = status;
         }
 
 	public String getEmailOwner() {
@@ -92,12 +92,12 @@ public class DeviceDTO {
                 this.operator = operator;
         }
 
-        public boolean isActivated() {
-                return activated;
+        public String getStatus() {
+                return status;
         }
 
-        public void setActivated(boolean activated) {
-                this.activated = activated;
+        public void setStatus(String status) {
+                this.status = status;
         }
 
 	@Override

--- a/src/main/java/it/sensorplatform/model/Device.java
+++ b/src/main/java/it/sensorplatform/model/Device.java
@@ -12,7 +12,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 
 @Entity
@@ -42,8 +41,8 @@ public class Device {
         @Column(nullable = true)
         private String emailOwner;
 
-        @Column(nullable = false)
-        private boolean activated = false;
+        @Column(name="status")
+        private String status = "deactivated";
 	
 	@ManyToOne
 	private Project project;
@@ -149,12 +148,12 @@ public class Device {
                 this.emailOwner = emailOwner;
         }
 
-        public boolean isActivated() {
-                return activated;
+        public String getStatus() {
+                return status;
         }
 
-        public void setActivated(boolean activated) {
-                this.activated = activated;
+        public void setStatus(String status) {
+                this.status = status;
         }
 
 

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -50,7 +50,7 @@ public class PacketService {
             device.setMacAddress(packet.getMacAddress());
             device.setName(packet.getMacAddress());
             device.setEmailOwner("");
-            device.setActivated(false);
+            device.setStatus("deactivated");
             device.setLatitude(packet.getLatitude() != null ? packet.getLatitude() : 0d);
             device.setLongitude(packet.getLongitude() != null ? packet.getLongitude() : 0d);
             if (packet.getProjectId() != null) {
@@ -65,7 +65,7 @@ public class PacketService {
 
         if (packet.isActivation()) {
             // Case 3: activation packet -> update flags and location
-            device.setActivated(true);
+            device.setStatus("activated");
             if (packet.getLatitude() != null) device.setLatitude(packet.getLatitude());
             if (packet.getLongitude() != null) device.setLongitude(packet.getLongitude());
             deviceRepository.save(device);

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -55,28 +55,28 @@ insert into project_tods(project_id, tods_id)values(101, 3)
 -- 5. Dispositivi (devono esistere i gruppi e i progetti)
 
 /* MIMI - Roma, gruppo compatto */
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850001, 12.460101, 1, 1, 1, 'flamy003@gmail.com', '21:06:1C:EC:E7:20', 'Blue1', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850302, 12.460402, 1, 2, 1, 'flamy003@gmail.com', '34:09:1C:EC:E7:21', 'Blue2', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850503, 12.460703, 1, 3, 1, 'flamy003@gmail.com', '56:08:1C:EC:E7:22', 'Blue3', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850804, 12.461004, 1, 4, 1, 'flamy003@gmail.com', '15:05:1B:EC:E7:23', 'Blue4', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.851005, 12.461305, 1, 5, 1, 'flamy003@gmail.com', '17:04:1C:EC:E7:24', 'Blue5', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, activated)values(41.851206, 12.461606, 1, 6, 1, 'flamy003@gmail.com', '18:03:1C:EC:E7:25', 'Blue6', 1, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850001, 12.460101, 1, 1, 1, 'flamy003@gmail.com', '21:06:1C:EC:E7:20', 'Blue1', 1, 5, 'activated');
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850302, 12.460402, 1, 2, 1, 'flamy003@gmail.com', '34:09:1C:EC:E7:21', 'Blue2', 1, 5, 'activated');
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850503, 12.460703, 1, 3, 1, 'flamy003@gmail.com', '56:08:1C:EC:E7:22', 'Blue3', 1, 5, 'activated');
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850804, 12.461004, 1, 4, 1, 'flamy003@gmail.com', '15:05:1B:EC:E7:23', 'Blue4', 1, 5, 'activated');
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.851005, 12.461305, 1, 5, 1, 'flamy003@gmail.com', '17:04:1C:EC:E7:24', 'Blue5', 1, 5, 'activated');
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, status)values(41.851206, 12.461606, 1, 6, 1, 'flamy003@gmail.com', '18:03:1C:EC:E7:25', 'Blue6', 1, 'deactivated');
 
 /* KUCA - sparsi nel nord Italia */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.440001, 10.995001, 7, 51, 'luca.bussi@outlook.it','11:06:1C:EC:E8:26', 'Red1', 2, 6, true);  -- Verona
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(44.494889, 11.342616, 8, 51, 'luca.bussi@outlook.it','14:06:1C:EC:E8:27', 'Red2', 2, 6, true);  -- Bologna
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.070339, 7.686864, 9, 51, 'luca.bussi@outlook.it','15:06:1C:EC:E8:28', 'Red3', 2, 6, true);   -- Torino
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(46.062008, 11.121083, 10, 51, 'luca.bussi@outlook.it', '23:06:1C:EC:E8:29', 'Red4', 2, 6, true); -- Trento
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.649526, 13.776818, 11, 51, 'luca.bussi@outlook.it', '39:06:1C:EC:E8:30', 'Red5', 2, 6, true); -- Trieste
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(44.801485, 10.327903, 12, 51, 'luca.bussi@outlook.it', '4A:06:1C:EC:E8:31', 'Red6', 2, 6, true); -- Parma
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.440001, 10.995001, 7, 51, 'luca.bussi@outlook.it','11:06:1C:EC:E8:26', 'Red1', 2, 6, 'activated');  -- Verona
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(44.494889, 11.342616, 8, 51, 'luca.bussi@outlook.it','14:06:1C:EC:E8:27', 'Red2', 2, 6, 'activated');  -- Bologna
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.070339, 7.686864, 9, 51, 'luca.bussi@outlook.it','15:06:1C:EC:E8:28', 'Red3', 2, 6, 'activated');   -- Torino
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(46.062008, 11.121083, 10, 51, 'luca.bussi@outlook.it', '23:06:1C:EC:E8:29', 'Red4', 2, 6, 'activated'); -- Trento
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.649526, 13.776818, 11, 51, 'luca.bussi@outlook.it', '39:06:1C:EC:E8:30', 'Red5', 2, 6, 'activated'); -- Trieste
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(44.801485, 10.327903, 12, 51, 'luca.bussi@outlook.it', '4A:06:1C:EC:E8:31', 'Red6', 2, 6, 'deactivated'); -- Parma
 
 /* JEM - sud e isole */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.851775, 14.268124, 13, 101, 'jhon30.herrera@gmail.com', '26:06:1C:EC:E7:32', 'Amber1', 3, 7, true); -- Napoli
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.115688, 13.361267, 14, 101, 'jhon30.herrera@gmail.com', '37:06:1C:EC:E7:33', 'Amber2', 3, 7, true ); -- Palermo
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(37.507877, 15.083030, 15, 101, 'jhon30.herrera@gmail.com', '58:06:1C:EC:E7:34', 'Amber3', 3, 7, true ); -- Catania
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(39.223841, 9.121661, 16, 101, 'jhon30.herrera@gmail.com', '6B:06:1C:EC:E7:35', 'Amber4', 3, 7, true );  -- Cagliari
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.639470, 17.694360, 17, 101, 'jhon30.herrera@gmail.com', '7C:06:1C:EC:E7:36', 'Amber5', 3, 7, true ); -- Lecce
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.193791, 15.554045, 18, 101, 'jhon30.herrera@gmail.com', '8D:06:1C:EC:E7:37', 'Amber6', 3, 7, true ); -- Messina
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(40.851775, 14.268124, 13, 101, 'jhon30.herrera@gmail.com', '26:06:1C:EC:E7:32', 'Amber1', 3, 7, 'activated'); -- Napoli
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(38.115688, 13.361267, 14, 101, 'jhon30.herrera@gmail.com', '37:06:1C:EC:E7:33', 'Amber2', 3, 7, 'activated'); -- Palermo
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(37.507877, 15.083030, 15, 101, 'jhon30.herrera@gmail.com', '58:06:1C:EC:E7:34', 'Amber3', 3, 7, 'activated'); -- Catania
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(39.223841, 9.121661, 16, 101, 'jhon30.herrera@gmail.com', '6B:06:1C:EC:E7:35', 'Amber4', 3, 7, 'activated');  -- Cagliari
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(40.639470, 17.694360, 17, 101, 'jhon30.herrera@gmail.com', '7C:06:1C:EC:E7:36', 'Amber5', 3, 7, 'activated'); -- Lecce
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(38.193791, 15.554045, 18, 101, 'jhon30.herrera@gmail.com', '8D:06:1C:EC:E7:37', 'Amber6', 3, 7, 'deactivated'); -- Messina
 
 insert into spec(id, measurement, unit_of_measurement, component)values(1, 'Temperature', '°C' ,'Sen5x')
 insert into spec(id, measurement, unit_of_measurement, component)values(2, 'Relative Humidity', '%RH' ,'Sen5x')

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -150,7 +150,7 @@
                                                           <td>
                                                                   <span th:if="${device.operator != null}" th:text="${device.operator}">Operator</span>
                                                           </td>
-                                                          <td th:text="${device.activated}"></td>
+                                                          <td th:text="${device.status}"></td>
                                                           <td>
                                                                   <!-- Edit (icona a matita) -->
                                                                   <a th:href="@{'/device/' + ${project.id} + '/' + ${device.macAddress}}"

--- a/src/test/java/it/sensorplatform/test/PacketServiceTests.java
+++ b/src/test/java/it/sensorplatform/test/PacketServiceTests.java
@@ -45,7 +45,7 @@ class PacketServiceTests {
 
         assertEquals(PacketService.Result.NEW_DEVICE, res);
         Device saved = deviceRepository.findByMacAddress("AA:BB:CC").orElseThrow();
-        assertFalse(saved.isActivated());
+        assertEquals("deactivated", saved.getStatus());
         assertEquals(project.getId(), saved.getProject().getId());
     }
 
@@ -59,7 +59,7 @@ class PacketServiceTests {
         device.setName("d1");
         device.setMacAddress("AA:DD:EE");
         device.setEmailOwner("");
-        device.setActivated(false);
+        device.setStatus("deactivated");
         device.setLatitude(0d);
         device.setLongitude(0d);
         device.setProject(project);
@@ -84,7 +84,7 @@ class PacketServiceTests {
         device.setName("d1");
         device.setMacAddress("AA:FF:00");
         device.setEmailOwner("");
-        device.setActivated(false);
+        device.setStatus("deactivated");
         device.setLatitude(0d);
         device.setLongitude(0d);
         device.setProject(project);
@@ -100,7 +100,7 @@ class PacketServiceTests {
         assertEquals(PacketService.Result.ACTIVATION, res);
 
         Device updated = deviceRepository.findByMacAddress("AA:FF:00").orElseThrow();
-        assertTrue(updated.isActivated());
+        assertEquals("activated", updated.getStatus());
         assertEquals(45.0, updated.getLatitude());
         assertEquals(7.0, updated.getLongitude());
     }


### PR DESCRIPTION
## Summary
- Replace boolean `activated` flag with `status` string on devices and DTOs
- Update controllers, services and templates to use `status`
- Migrate sample data and tests to `activated`/`deactivated` values

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9fd604588323875586b9b27cf6de