### PR TITLE
Use environment variables for database config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# AetherSense
+
+## Configurazione del database
+
+L'applicazione legge i dettagli di connessione al database dalle seguenti variabili d'ambiente:
+
+| Variabile | Descrizione |
+|-----------|-------------|
+| `DB_URL`  | URL JDBC del database, ad esempio `jdbc:postgresql://localhost:5432/nome_db` |
+| `DB_USER` | Nome utente del database |
+| `DB_PASS` | Password del database |
+
+### Impostazione delle variabili su una VPS
+
+Per configurare le variabili su una VPS basata su Linux:
+
+1. Accedere al server tramite SSH.
+2. Esportare le variabili nella shell corrente (sostituendo i valori di esempio con quelli reali):
+
+   ```bash
+   export DB_URL="jdbc:postgresql://<host>:5432/<database>"
+   export DB_USER="<utente>"
+   export DB_PASS="<password>"
+   ```
+
+3. Per renderle persistenti tra i riavvii, aggiungere le stesse righe al file `~/.bashrc` dell'utente oppure definirle in un file di servizio `systemd` utilizzando la direttiva `Environment=`.
+
+Una volta impostate le variabili, avviare l'applicazione con `./mvnw spring-boot:run` o tramite il sistema di gestione dei servizi preferito.
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,9 +9,9 @@ logging.level.org.hibernate.SQL=debug
 logging.level.org.hibernate.type.descriptor.sql=trace
 spring.jpa.hibernate.ddl-auto=create
 spring.datasource.driver-class-name=org.postgresql.Driver
-spring.datasource.url=jdbc:postgresql://localhost:5432/cocco
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASS}
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true
 #==================================
 # = Web server


### PR DESCRIPTION
## Summary
- Replace hard-coded datasource credentials with DB_URL, DB_USER and DB_PASS placeholders
- Add README explaining required environment variables and how to set them on a VPS

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c438dc2d3c83239acc903be462c9cd