### PR TITLE
Allow devices without owner email

### DIFF
--- a/src/main/java/it/sensorplatform/model/Device.java
+++ b/src/main/java/it/sensorplatform/model/Device.java
@@ -37,7 +37,6 @@ public class Device {
 	@Column(unique = true, nullable = false)
 	private String macAddress;
 	
-        @NotBlank
         @Column(nullable = true)
         private String emailOwner;
 


### PR DESCRIPTION
## Summary
- remove validation constraint on `emailOwner` field in `Device`

## Testing
- `mvn test` *(fails: Network is unreachable when resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68c4202951888323b65375154f7e0951