### PR TITLE
Handle SSE unknown-device events

### DIFF
--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -80,11 +80,11 @@
     }
 
     const evtSource = new EventSource(`/api/notifications/stream/${projectId}`);
-    evtSource.onmessage = function(e) {
+    evtSource.addEventListener('unknown-device', e => {
         const data = JSON.parse(e.data);
         notifications.set(data.key, data);
         renderNotification(data);
-    };
+    });
 </script>
 <script>
     document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
## Summary
- Register client-side listener for `unknown-device` SSE events so notifications render correctly.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c713dd88408323b1bcd0f923511aef