### PR TITLE
Replay existing unknown device notifications to new SSE subscribers

### DIFF
--- a/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
+++ b/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
@@ -42,6 +42,18 @@ public class UnknownDeviceService {
     public SseEmitter subscribe(Long projectId) {
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
         emitters.computeIfAbsent(projectId, k -> new CopyOnWriteArrayList<>()).add(emitter);
+
+        Map<String, UnknownDeviceNotification> map = notifications.get(projectId);
+        if (map != null && !map.isEmpty()) {
+            for (UnknownDeviceNotification notification : map.values()) {
+                try {
+                    emitter.send(SseEmitter.event().name("unknown-device").data(notification));
+                } catch (Exception e) {
+                    emitter.complete();
+                }
+            }
+        }
+
         emitter.onCompletion(() -> emitters.get(projectId).remove(emitter));
         emitter.onTimeout(() -> emitters.get(projectId).remove(emitter));
         return emitter;


### PR DESCRIPTION
## Summary
- Deliver stored unknown device notifications to new SSE subscriptions.
- Ensure newly subscribed clients immediately receive any prior unknown device events.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c72baa34e48323ab352b3eefd86704