### PR TITLE
Handle SSE unknown-device events

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/PacketControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/PacketControllerRest.java
@@ -19,11 +19,12 @@ public class PacketControllerRest {
         this.packetService = packetService;
     }
 
-@PostMapping
-public ResponseEntity<PacketService.Result> handle(@RequestBody PacketDTO packet) {
-    System.out.println("Received packet: " + packet);
-    PacketService.Result result = packetService.handlePacket(packet);
-    return ResponseEntity.ok(result);
+    @PostMapping
+    public ResponseEntity<PacketService.Result> handle(@RequestBody PacketDTO packet) {
+        System.out.println("Received packet: " + packet);
+        PacketService.Result result = packetService.handlePacket(packet);
+        System.out.println("Packet processed with result: " + result);
+        return ResponseEntity.ok(result);
     }
 
 }

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -37,6 +37,7 @@ public class PacketService {
      * Process an incoming packet according to device/project state.
      */
     public Result handlePacket(PacketDTO packet) {
+        System.out.println("PacketService.handlePacket called with: " + packet);
         if ((packet.getMacAddress() == null || packet.getMacAddress().isBlank()) &&
                 (packet.getDevEui() == null || packet.getDevEui().isBlank())) {
             throw new IllegalArgumentException("macAddress or devEui is required");
@@ -49,7 +50,9 @@ public class PacketService {
         if (existing.isEmpty() && packet.getDevEui() != null && !packet.getDevEui().isBlank()) {
             existing = deviceRepository.findByDevEui(packet.getDevEui());
         }
+        System.out.println("Existing device found: " + existing.isPresent());
         if (existing.isEmpty()) {
+            System.out.println("Unknown device, calling UnknownDeviceService.notify");
             unknownDeviceService.notify(packet);
             return Result.NEW_DEVICE;
         }
@@ -57,6 +60,7 @@ public class PacketService {
         Device device = existing.get();
 
         if (packet.isActivation()) {
+            System.out.println("Activation packet for device: " + device.getMacAddress());
             // Case 3: activation packet -> update flags and location
             device.setStatus("activated");
             if (packet.getLatitude() != null) device.setLatitude(packet.getLatitude());
@@ -65,6 +69,7 @@ public class PacketService {
             return Result.ACTIVATION;
         }
 
+        System.out.println("Data packet for device: " + device.getMacAddress());
         // Case 2: normal data packet -> forward metrics to ingest service
         Map<String, Object> payload = packet.getPayload();
         ingestService.process(device.getMacAddress(), device.getDevEui(), Instant.now(), payload);

--- a/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
+++ b/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
@@ -16,6 +16,7 @@ public class UnknownDeviceService {
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     public void notify(PacketDTO packet) {
+        System.out.println("UnknownDeviceService.notify for project " + packet.getProjectId());
         String key = packet.getMacAddress() != null && !packet.getMacAddress().isBlank() ?
                 packet.getMacAddress() : packet.getDevEui();
         UnknownDeviceNotification notification = new UnknownDeviceNotification(
@@ -29,21 +30,32 @@ public class UnknownDeviceService {
         );
         notifications.computeIfAbsent(packet.getProjectId(), k -> new ConcurrentHashMap<>())
                 .put(key, notification);
+        System.out.println("Stored notification with key " + key);
         List<SseEmitter> list = emitters.getOrDefault(packet.getProjectId(), List.of());
+        System.out.println("Sending notification to " + list.size() + " emitters");
         for (SseEmitter emitter : list) {
             try {
                 emitter.send(SseEmitter.event().name("unknown-device").data(notification));
+                System.out.println("Notification sent to emitter " + emitter);
             } catch (Exception e) {
+                System.out.println("Emitter send failed: " + e.getMessage());
                 emitter.complete();
             }
         }
     }
 
     public SseEmitter subscribe(Long projectId) {
+        System.out.println("UnknownDeviceService.subscribe for project " + projectId);
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
         emitters.computeIfAbsent(projectId, k -> new CopyOnWriteArrayList<>()).add(emitter);
-        emitter.onCompletion(() -> emitters.get(projectId).remove(emitter));
-        emitter.onTimeout(() -> emitters.get(projectId).remove(emitter));
+        emitter.onCompletion(() -> {
+            System.out.println("Emitter completed for project " + projectId);
+            emitters.get(projectId).remove(emitter);
+        });
+        emitter.onTimeout(() -> {
+            System.out.println("Emitter timed out for project " + projectId);
+            emitters.get(projectId).remove(emitter);
+        });
         return emitter;
     }
 

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -80,11 +80,11 @@
     }
 
     const evtSource = new EventSource(`/api/notifications/stream/${projectId}`);
-    evtSource.onmessage = function(e) {
+    evtSource.addEventListener('unknown-device', e => {
         const data = JSON.parse(e.data);
         notifications.set(data.key, data);
         renderNotification(data);
-    };
+    });
 </script>
 <script>
     document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
## Summary
- Register client-side listener for `unknown-device` SSE events so notifications render correctly.
- Add debug print statements in REST controller, packet service, and unknown device service to trace packet handling and notification generation.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c713dd88408323b1bcd0f923511aef