### PR TITLE
Add debug logs for packet handling flow

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/PacketControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/PacketControllerRest.java
@@ -19,11 +19,12 @@ public class PacketControllerRest {
         this.packetService = packetService;
     }
 
-@PostMapping
-public ResponseEntity<PacketService.Result> handle(@RequestBody PacketDTO packet) {
-    System.out.println("Received packet: " + packet);
-    PacketService.Result result = packetService.handlePacket(packet);
-    return ResponseEntity.ok(result);
+    @PostMapping
+    public ResponseEntity<PacketService.Result> handle(@RequestBody PacketDTO packet) {
+        System.out.println("PacketControllerRest.handle - received packet: " + packet);
+        PacketService.Result result = packetService.handlePacket(packet);
+        System.out.println("PacketControllerRest.handle - processing result: " + result);
+        return ResponseEntity.ok(result);
     }
 
 }

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -37,6 +37,7 @@ public class PacketService {
      * Process an incoming packet according to device/project state.
      */
     public Result handlePacket(PacketDTO packet) {
+        System.out.println("PacketService.handlePacket - processing packet: " + packet);
         if ((packet.getMacAddress() == null || packet.getMacAddress().isBlank()) &&
                 (packet.getDevEui() == null || packet.getDevEui().isBlank())) {
             throw new IllegalArgumentException("macAddress or devEui is required");
@@ -50,6 +51,7 @@ public class PacketService {
             existing = deviceRepository.findByDevEui(packet.getDevEui());
         }
         if (existing.isEmpty()) {
+            System.out.println("PacketService.handlePacket - device not found, notifying UnknownDeviceService");
             unknownDeviceService.notify(packet);
             return Result.NEW_DEVICE;
         }
@@ -57,6 +59,7 @@ public class PacketService {
         Device device = existing.get();
 
         if (packet.isActivation()) {
+            System.out.println("PacketService.handlePacket - activation packet for device: " + device.getId());
             // Case 3: activation packet -> update flags and location
             device.setStatus("activated");
             if (packet.getLatitude() != null) device.setLatitude(packet.getLatitude());
@@ -65,6 +68,7 @@ public class PacketService {
             return Result.ACTIVATION;
         }
 
+        System.out.println("PacketService.handlePacket - forwarding data to IngestService for device: " + device.getMacAddress());
         // Case 2: normal data packet -> forward metrics to ingest service
         Map<String, Object> payload = packet.getPayload();
         ingestService.process(device.getMacAddress(), device.getDevEui(), Instant.now(), payload);

--- a/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
+++ b/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
@@ -18,6 +18,7 @@ public class UnknownDeviceService {
     public void notify(PacketDTO packet) {
         String key = packet.getMacAddress() != null && !packet.getMacAddress().isBlank() ?
                 packet.getMacAddress() : packet.getDevEui();
+        System.out.println("UnknownDeviceService.notify - unknown device key: " + key + ", project: " + packet.getProjectId());
         UnknownDeviceNotification notification = new UnknownDeviceNotification(
                 key,
                 packet.getMacAddress(),
@@ -30,10 +31,13 @@ public class UnknownDeviceService {
         notifications.computeIfAbsent(packet.getProjectId(), k -> new ConcurrentHashMap<>())
                 .put(key, notification);
         List<SseEmitter> list = emitters.getOrDefault(packet.getProjectId(), List.of());
+        System.out.println("UnknownDeviceService.notify - sending notification to " + list.size() + " emitter(s)");
         for (SseEmitter emitter : list) {
             try {
+                System.out.println("UnknownDeviceService.notify - sending SSE event");
                 emitter.send(SseEmitter.event().name("unknown-device").data(notification));
             } catch (Exception e) {
+                System.out.println("UnknownDeviceService.notify - emitter failed, completing");
                 emitter.complete();
             }
         }


### PR DESCRIPTION
## Summary
- log when packet controller receives a packet and what result is produced
- log each step of packet processing, including unknown devices, activations, and data forwarding
- log notification dispatch details for unknown devices and SSE emitters

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ceff96b4832396b037b78098b9ff