### PR TITLE
Allow unauthenticated POST to packets API

### DIFF
--- a/src/main/java/it/sensorplatform/authentication/AuthConfiguration.java
+++ b/src/main/java/it/sensorplatform/authentication/AuthConfiguration.java
@@ -72,12 +72,13 @@ public class AuthConfiguration {
 
 
 		http
-//		.csrf(csrf -> csrf
-//			    .ignoringRequestMatchers("/api/ingest/**")
-//			)
+		.csrf(csrf -> csrf
+				.ignoringRequestMatchers("/api/packets")
+			)
 		.authorizeHttpRequests(auth -> auth
 				.requestMatchers(HttpMethod.GET, "/", "/home", "/login", "/register", "/access", "/css/**", "/img/**", "/favicon.ico", "/videos/**", "/project/**").permitAll()
 				.requestMatchers(HttpMethod.POST, "/login", "/register").permitAll()
+				.requestMatchers(HttpMethod.POST, "/api/packets").permitAll()
 				
 				.requestMatchers(HttpMethod.GET, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)
 				.requestMatchers(HttpMethod.POST, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)


### PR DESCRIPTION
## Summary
- enable CSRF configuration and ignore the packets ingestion endpoint
- allow unauthenticated POST requests to `/api/packets`

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*
- `./mvnw -q spring-boot:run` *(fails: wget: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e0dd63008323a3ad1653b03f4ef8