### PR TITLE
Handle null emailOwner when sorting devices

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -289,15 +289,9 @@ public class DeviceController {
                 List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getName(), d.getMacAddress(),
                                 d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
                                 .collect(Collectors.toList());
-                Collections.sort(deviceDTOs, new Comparator<DeviceDTO>() {
-
-			@Override
-			public int compare(DeviceDTO d1, DeviceDTO d2) {
-
-				return d1.getEmailOwner().compareTo(d2.getEmailOwner());
-			}
-
-		});
+                Comparator<DeviceDTO> cmp = Comparator.comparing(DeviceDTO::getEmailOwner,
+                                Comparator.nullsFirst(String::compareTo));
+                Collections.sort(deviceDTOs, cmp);
 		model.addAttribute("devices", deviceDTOs);
 	}
 }

--- a/src/test/java/it/sensorplatform/test/DeviceControllerTests.java
+++ b/src/test/java/it/sensorplatform/test/DeviceControllerTests.java
@@ -1,0 +1,59 @@
+package it.sensorplatform.test;
+
+import it.sensorplatform.controller.DeviceController;
+import it.sensorplatform.dto.DeviceDTO;
+import it.sensorplatform.model.Device;
+import it.sensorplatform.model.TypeOfDevice;
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DeviceControllerTests {
+
+    @Test
+    void loadDeviceDTO_sortsByEmailOwnerNullsFirst() {
+        TypeOfDevice tod = new TypeOfDevice();
+        tod.setName("Type");
+
+        Device deviceWithNullEmail = new Device();
+        deviceWithNullEmail.setName("dev1");
+        deviceWithNullEmail.setMacAddress("00:11");
+        deviceWithNullEmail.setEmailOwner(null);
+        deviceWithNullEmail.setDevEui("devEui1");
+        deviceWithNullEmail.setTod(tod);
+
+        Device deviceB = new Device();
+        deviceB.setName("dev2");
+        deviceB.setMacAddress("00:22");
+        deviceB.setEmailOwner("b@example.com");
+        deviceB.setDevEui("devEui2");
+        deviceB.setTod(tod);
+
+        Device deviceA = new Device();
+        deviceA.setName("dev3");
+        deviceA.setMacAddress("00:33");
+        deviceA.setEmailOwner("a@example.com");
+        deviceA.setDevEui("devEui3");
+        deviceA.setTod(tod);
+
+        List<Device> devices = Arrays.asList(deviceB, deviceWithNullEmail, deviceA);
+
+        DeviceController controller = new DeviceController();
+        Model model = new ExtendedModelMap();
+        controller.loadDeviceDTO(devices, model);
+
+        @SuppressWarnings("unchecked")
+        List<DeviceDTO> result = (List<DeviceDTO>) model.getAttribute("devices");
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        assertNull(result.get(0).getEmailOwner());
+        assertEquals("a@example.com", result.get(1).getEmailOwner());
+        assertEquals("b@example.com", result.get(2).getEmailOwner());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure device list sorting is null-safe by comparing emailOwner with `Comparator.nullsFirst`
- add unit test verifying devices with `null` emailOwner sort before others

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f5ff07f4832380f0d2f36aa6af95