### PR TITLE
Add logging and error handling for device notifications

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -10,6 +10,9 @@ import it.sensorplatform.repository.ProjectRepository;
 import it.sensorplatform.repository.TypeOfDeviceRepository;
 import it.sensorplatform.service.SpecService;
 import it.sensorplatform.service.UnknownDeviceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -26,6 +29,7 @@ public class NotificationControllerRest {
     private final TypeOfDeviceRepository typeOfDeviceRepository;
     private final SpecService specService;
     private final ProjectRepository projectRepository;
+    private static final Logger logger = LoggerFactory.getLogger(NotificationControllerRest.class);
 
     public NotificationControllerRest(UnknownDeviceService unknownDeviceService,
                                       DeviceRepository deviceRepository,
@@ -70,13 +74,20 @@ public class NotificationControllerRest {
             tod.setSpecs(specs);
             typeOfDeviceRepository.save(tod);
         }
+        logger.info("Creating device with MAC {} and DevEUI {}", notif.getMacAddress(), notif.getDevEui());
         Device device = new Device();
         device.setMacAddress(notif.getMacAddress());
         device.setDevEui(notif.getDevEui());
         device.setProject(project);
         device.setTod(tod);
         device.setStatus("deactivated");
-        deviceRepository.save(device);
-        return ResponseEntity.ok().build();
+        try {
+            Device savedDevice = deviceRepository.save(device);
+            logger.info("Persisted device with id {} and status {}", savedDevice.getId(), savedDevice.getStatus());
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            logger.error("Error saving device with MAC {} and DevEUI {}", notif.getMacAddress(), notif.getDevEui(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Inject SLF4J logger into `NotificationControllerRest`
- Log unknown device identifiers before creating Device instances
- Log persisted device ID and status and handle save errors gracefully

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fac08f148323807be2015a9bad4c