### PR TITLE
Handle missing MAC address in notification

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -74,9 +74,21 @@ public class NotificationControllerRest {
             tod.setSpecs(specs);
             typeOfDeviceRepository.save(tod);
         }
-        logger.info("Creating device with MAC {} and DevEUI {}", notif.getMacAddress(), notif.getDevEui());
+
+        String macAddress = notif.getMacAddress();
+        if (macAddress == null || macAddress.isBlank()) {
+            macAddress = notif.getDevEui();
+            logger.info("MAC address missing; using DevEUI {} as MAC address", macAddress);
+        }
+
+        if (deviceRepository.existsByMacAddress(macAddress) || deviceRepository.existsByDevEui(notif.getDevEui())) {
+            logger.warn("Device with MAC {} or DevEUI {} already exists", macAddress, notif.getDevEui());
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
+        }
+
+        logger.info("Creating device with MAC {} and DevEUI {}", macAddress, notif.getDevEui());
         Device device = new Device();
-        device.setMacAddress(notif.getMacAddress());
+        device.setMacAddress(macAddress);
         device.setDevEui(notif.getDevEui());
         device.setProject(project);
         device.setTod(tod);
@@ -86,7 +98,7 @@ public class NotificationControllerRest {
             logger.info("Persisted device with id {} and status {}", savedDevice.getId(), savedDevice.getStatus());
             return ResponseEntity.ok().build();
         } catch (Exception e) {
-            logger.error("Error saving device with MAC {} and DevEUI {}", notif.getMacAddress(), notif.getDevEui(), e);
+            logger.error("Error saving device with MAC {} and DevEUI {}", macAddress, notif.getDevEui(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }

--- a/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
+++ b/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
@@ -1,0 +1,80 @@
+package it.sensorplatform.test;
+
+import it.sensorplatform.controller.rest.NotificationControllerRest;
+import it.sensorplatform.dto.UnknownDeviceNotification;
+import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Project;
+import it.sensorplatform.model.TypeOfDevice;
+import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.repository.ProjectRepository;
+import it.sensorplatform.repository.TypeOfDeviceRepository;
+import it.sensorplatform.service.SpecService;
+import it.sensorplatform.service.UnknownDeviceService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(OutputCaptureExtension.class)
+class NotificationControllerRestTests {
+
+    @Test
+    void addDeviceUsesDevEuiWhenMacMissing(CapturedOutput output) {
+        UnknownDeviceService unknownDeviceService = mock(UnknownDeviceService.class);
+        DeviceRepository deviceRepository = mock(DeviceRepository.class);
+        TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
+        SpecService specService = mock(SpecService.class);
+        ProjectRepository projectRepository = mock(ProjectRepository.class);
+
+        Long projectId = 1L;
+        String key = "key";
+        UnknownDeviceNotification notif = new UnknownDeviceNotification(
+                key,
+                null,
+                "DEV123",
+                projectId,
+                "type",
+                Map.of(),
+                Instant.now()
+        );
+
+        when(unknownDeviceService.consume(projectId, key)).thenReturn(notif);
+        when(typeOfDeviceRepository.findByName("type")).thenReturn(Optional.of(new TypeOfDevice()));
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(new Project()));
+        when(deviceRepository.existsByMacAddress("DEV123")).thenReturn(false);
+        when(deviceRepository.existsByDevEui("DEV123")).thenReturn(false);
+        when(deviceRepository.save(any(Device.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationControllerRest controller = new NotificationControllerRest(
+                unknownDeviceService,
+                deviceRepository,
+                typeOfDeviceRepository,
+                specService,
+                projectRepository
+        );
+
+        ResponseEntity<Void> response = controller.addDevice(projectId, key);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+
+        ArgumentCaptor<Device> deviceCaptor = ArgumentCaptor.forClass(Device.class);
+        verify(deviceRepository).save(deviceCaptor.capture());
+        Device savedDevice = deviceCaptor.getValue();
+        assertEquals("DEV123", savedDevice.getMacAddress());
+        assertEquals("DEV123", savedDevice.getDevEui());
+
+        assertTrue(output.getOut().contains("using DevEUI DEV123 as MAC address"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- Use DevEUI when MAC address is missing and ensure uniqueness before saving
- Add tests for fallback MAC addressing and logging

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7fb8c5ad08323b30835a2ef009055