### PR TITLE
Improve notification handling and frontend error feedback

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -12,6 +12,7 @@ import it.sensorplatform.service.SpecService;
 import it.sensorplatform.service.UnknownDeviceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -52,8 +53,10 @@ public class NotificationControllerRest {
     public ResponseEntity<Void> addDevice(@PathVariable Long projectId, @PathVariable String key) {
         UnknownDeviceNotification notif = unknownDeviceService.consume(projectId, key);
         if (notif == null) {
+            logger.warn("No notification found for project {} and key {}", projectId, key);
             return ResponseEntity.notFound().build();
         }
+        logger.info("Consumed notification for project {} key {}: mac {} devEui {}", projectId, key, notif.getMacAddress(), notif.getDevEui());
         Project project = projectRepository.findById(projectId).orElse(null);
         TypeOfDevice tod = typeOfDeviceRepository.findByName(notif.getTypeOfDevice()).orElse(null);
         if (tod == null) {
@@ -97,6 +100,9 @@ public class NotificationControllerRest {
             Device savedDevice = deviceRepository.save(device);
             logger.info("Persisted device with id {} and status {}", savedDevice.getId(), savedDevice.getStatus());
             return ResponseEntity.ok().build();
+        } catch (DataIntegrityViolationException e) {
+            logger.warn("Conflict saving device with MAC {} and DevEUI {}", macAddress, notif.getDevEui(), e);
+            return ResponseEntity.status(HttpStatus.CONFLICT).build();
         } catch (Exception e) {
             logger.error("Error saving device with MAC {} and DevEUI {}", macAddress, notif.getDevEui(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -76,7 +76,18 @@
 
     function addDevice(key) {
         fetch(`/api/notifications/${projectId}/${key}/add`, {method:'POST'})
-            .then(() => { window.location.href = `/superadmin/manageProjectDevices/${projectId}`; });
+            .then(response => {
+                if (response.ok) {
+                    window.location.href = `/superadmin/manageProjectDevices/${projectId}`;
+                } else if (response.status === 404) {
+                    alert('Notification not found');
+                } else if (response.status === 409) {
+                    alert('Device already exists');
+                } else {
+                    alert('Error adding device');
+                }
+            })
+            .catch(() => alert('Error connecting to server'));
     }
 
     const evtSource = new EventSource(`/api/notifications/stream/${projectId}`);


### PR DESCRIPTION
## Summary
- log project and device identifiers when consuming notifications and handle missing notifications
- guard against duplicate device inserts and report conflicts
- surface backend errors on device notification page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for it.fourspark:ltrad:1.0 ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7feb36a2c832398ad3806d981b52e