### PR TITLE
Encode notification key in addDevice URL

### DIFF
--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -75,7 +75,7 @@
     setInterval(updateTimes, 1000);
 
     function addDevice(key) {
-        fetch(`/api/notifications/${projectId}/${key}/add`, {method:'POST'})
+        fetch(`/api/notifications/${projectId}/${encodeURIComponent(key)}/add`, {method:'POST'})
             .then(response => {
                 if (response.ok) {
                     window.location.href = `/superadmin/manageProjectDevices/${projectId}`;


### PR DESCRIPTION
## Summary
- encode device notification key when constructing add URL to ensure special characters are handled correctly

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for it.fourspark:ltrad:1.0)*
- `mvn -q spring-boot:run` *(fails: Non-resolvable parent POM for it.fourspark:ltrad:1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c805a0b4648323b4bf232fe1d62911