### PR TITLE
Normalize MAC addresses on packet reception

### DIFF
--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -3,6 +3,7 @@ package it.sensorplatform.service;
 import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.util.MacAddressUtils;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -38,14 +39,15 @@ public class PacketService {
      */
     public Result handlePacket(PacketDTO packet) {
         System.out.println("PacketService.handlePacket - processing packet: " + packet);
-        if ((packet.getMacAddress() == null || packet.getMacAddress().isBlank()) &&
+        String mac = MacAddressUtils.normalize(packet.getMacAddress());
+        if ((mac == null || mac.isBlank()) &&
                 (packet.getDevEui() == null || packet.getDevEui().isBlank())) {
             throw new IllegalArgumentException("macAddress or devEui is required");
         }
 
         Optional<Device> existing = Optional.empty();
-        if (packet.getMacAddress() != null && !packet.getMacAddress().isBlank()) {
-            existing = deviceRepository.findByMacAddress(packet.getMacAddress());
+        if (mac != null && !mac.isBlank()) {
+            existing = deviceRepository.findByMacAddress(mac);
         }
         if (existing.isEmpty() && packet.getDevEui() != null && !packet.getDevEui().isBlank()) {
             existing = deviceRepository.findByDevEui(packet.getDevEui());

--- a/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
+++ b/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
@@ -2,6 +2,7 @@ package it.sensorplatform.service;
 
 import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.dto.UnknownDeviceNotification;
+import it.sensorplatform.util.MacAddressUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -16,12 +17,12 @@ public class UnknownDeviceService {
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
     public void notify(PacketDTO packet) {
-        String key = packet.getMacAddress() != null && !packet.getMacAddress().isBlank() ?
-                packet.getMacAddress() : packet.getDevEui();
+        String mac = MacAddressUtils.normalize(packet.getMacAddress());
+        String key = mac != null && !mac.isBlank() ? mac : packet.getDevEui();
         System.out.println("UnknownDeviceService.notify - unknown device key: " + key + ", project: " + packet.getProjectId());
         UnknownDeviceNotification notification = new UnknownDeviceNotification(
                 key,
-                packet.getMacAddress(),
+                mac,
                 packet.getDevEui(),
                 packet.getProjectId(),
                 packet.getTypeOfDevice(),


### PR DESCRIPTION
## Summary
- Normalize incoming packet MAC addresses before processing
- Use normalized MAC addresses as keys for unknown-device notifications

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for it.fourspark:ltrad:1.0: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c80b407cd88323acb0718b4d6e822f