### PR TITLE
Normalize MAC addresses before device operations

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -10,6 +10,7 @@ import it.sensorplatform.service.AdminService;
 import it.sensorplatform.service.CredentialsService;
 import it.sensorplatform.service.DeviceService;
 import it.sensorplatform.service.ProjectService;
+import it.sensorplatform.util.MacAddressUtils;
 import jakarta.validation.Valid;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,10 +78,11 @@ public class DeviceController {
         }
 
 	@GetMapping("/superadmin/formUpdateDevice/{projectId}/{macAddress}")
-	public String formUpdateDevice(@PathVariable("projectId") Long projectId,
-			@PathVariable("macAddress") String macAddress, Model model) {
-		Project project = projectService.getProjectById(projectId);
-		Device device = deviceService.findByMacAddress(macAddress);
+        public String formUpdateDevice(@PathVariable("projectId") Long projectId,
+                        @PathVariable("macAddress") String macAddress, Model model) {
+                macAddress = MacAddressUtils.normalize(macAddress);
+                Project project = projectService.getProjectById(projectId);
+                Device device = deviceService.findByMacAddress(macAddress);
 		UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
 		model.addAttribute("user", credentials);
@@ -101,7 +103,8 @@ public class DeviceController {
 		}
 
 		// Recupera il dispositivo tramite MAC address
-		Device device = deviceService.findByMacAddress(macAddress);
+                macAddress = MacAddressUtils.normalize(macAddress);
+                Device device = deviceService.findByMacAddress(macAddress);
 
 		if (device == null) {
 			redirectAttributes.addFlashAttribute("error", "Device not found.");
@@ -128,19 +131,21 @@ public class DeviceController {
         }
 
 	@PostMapping("/superadmin/deleteDevice/{projectId}/{macAddress}")
-	public String deleteDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String macAddress,
-			RedirectAttributes redirectAttributes) {
-		Device device = deviceService.findByMacAddress(macAddress);
+        public String deleteDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String macAddress,
+                        RedirectAttributes redirectAttributes) {
+                macAddress = MacAddressUtils.normalize(macAddress);
+                Device device = deviceService.findByMacAddress(macAddress);
 		deviceService.delete(device);
 		redirectAttributes.addFlashAttribute("successMessage", "Dispositivo eliminato.");
 		return "redirect:/superadmin/manageProjectDevices/" + projectId;
 	}
 
 	@GetMapping("/device/{projectId}/{macAddress}")
-	public String aboutDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String macAddress,
-			Model model) {
-		Project project = projectService.getProjectById(projectId);
-		Device device = deviceService.findByMacAddress(macAddress);
+        public String aboutDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String macAddress,
+                        Model model) {
+                macAddress = MacAddressUtils.normalize(macAddress);
+                Project project = projectService.getProjectById(projectId);
+                Device device = deviceService.findByMacAddress(macAddress);
 		UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
 		model.addAttribute("user", credentials);
@@ -154,17 +159,19 @@ public class DeviceController {
                         @RequestParam(required = false) Double latitude, @RequestParam(required = false) Double longitude,
                         RedirectAttributes redirectAttributes) {
 
-		if (name == null || name.trim().isEmpty()) {
-			redirectAttributes.addFlashAttribute("error", "Device name is required.");
-			return "redirect:/device/" + projectId + "/" + macAddress;
-		}
+                macAddress = MacAddressUtils.normalize(macAddress);
 
-		// Recupera il dispositivo tramite MAC address
-		Device device = deviceService.findByMacAddress(macAddress);
+                if (name == null || name.trim().isEmpty()) {
+                        redirectAttributes.addFlashAttribute("error", "Device name is required.");
+                        return "redirect:/device/" + projectId + "/" + macAddress;
+                }
+
+                // Recupera il dispositivo tramite MAC address
+                Device device = deviceService.findByMacAddress(macAddress);
 
 		if (device == null) {
 			redirectAttributes.addFlashAttribute("error", "Device not found.");
-			return "redirect:/device/" + projectId + "/" + macAddress;
+                        return "redirect:/device/" + projectId + "/" + macAddress;
 		}
 
                 // Aggiorna solo i campi modificabili
@@ -260,9 +267,10 @@ public class DeviceController {
 	}
 
 	@PostMapping("/admin/selectOperator/{macAddress}/{opId}/{projectId}")
-	public String assignOperatorToDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress, 
-										@PathVariable("opId") Long opId, RedirectAttributes ra) {
-		Device d = deviceService.findByMacAddress(macAddress);
+        public String assignOperatorToDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress,
+                                                                                @PathVariable("opId") Long opId, RedirectAttributes ra) {
+                macAddress = MacAddressUtils.normalize(macAddress);
+                Device d = deviceService.findByMacAddress(macAddress);
 		Credentials operator = credentialsService.findById(opId);
 		
 		d.setOperator(operator);
@@ -272,8 +280,9 @@ public class DeviceController {
 	}
 	
 	@PostMapping("/admin/removeOperator/{macAddress}/{projectId}")
-	public String removeOperatorfromDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress, 
-										 RedirectAttributes ra) {
+        public String removeOperatorfromDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress,
+                                                                                 RedirectAttributes ra) {
+                macAddress = MacAddressUtils.normalize(macAddress);
                 Device d = deviceService.findByMacAddress(macAddress);
 
                 d.setOperator(null);

--- a/src/main/java/it/sensorplatform/controller/rest/DeviceControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/DeviceControllerRest.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.model.MeasurementRecord;
 import it.sensorplatform.service.DeviceService;
+import it.sensorplatform.util.MacAddressUtils;
 
 @RestController
 @RequestMapping("/api/device")
@@ -27,10 +28,10 @@ public class DeviceControllerRest {
 
 
 	@PostMapping("/data")
-	public ResponseEntity<String> receivePayload(@RequestBody Map<String, Object> data) {
-	    String macAddress = (String) data.get("macAddress"); // Assicurati che sia presente nel pacchetto
+        public ResponseEntity<String> receivePayload(@RequestBody Map<String, Object> data) {
+            String macAddress = MacAddressUtils.normalize((String) data.get("macAddress"));
 
-		Device device = deviceService.findByMacAddress(macAddress);
+                Device device = deviceService.findByMacAddress(macAddress);
 
 	    try {
 	        ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -10,6 +10,7 @@ import it.sensorplatform.repository.ProjectRepository;
 import it.sensorplatform.repository.TypeOfDeviceRepository;
 import it.sensorplatform.service.SpecService;
 import it.sensorplatform.service.UnknownDeviceService;
+import it.sensorplatform.util.MacAddressUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -78,13 +79,14 @@ public class NotificationControllerRest {
             typeOfDeviceRepository.save(tod);
         }
 
-        String macAddress = notif.getMacAddress();
+        String macAddress = MacAddressUtils.normalize(notif.getMacAddress());
         if (macAddress == null || macAddress.isBlank()) {
-            macAddress = notif.getDevEui();
+            macAddress = MacAddressUtils.normalize(notif.getDevEui());
             logger.info("MAC address missing; using DevEUI {} as MAC address", macAddress);
         }
 
-        if (deviceRepository.existsByMacAddress(macAddress) || deviceRepository.existsByDevEui(notif.getDevEui())) {
+        String normalizedDevEui = MacAddressUtils.normalize(notif.getDevEui());
+        if (deviceRepository.existsByMacAddress(macAddress) || deviceRepository.existsByDevEui(normalizedDevEui)) {
             logger.warn("Device with MAC {} or DevEUI {} already exists", macAddress, notif.getDevEui());
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         }
@@ -92,7 +94,7 @@ public class NotificationControllerRest {
         logger.info("Creating device with MAC {} and DevEUI {}", macAddress, notif.getDevEui());
         Device device = new Device();
         device.setMacAddress(macAddress);
-        device.setDevEui(notif.getDevEui());
+        device.setDevEui(normalizedDevEui);
         device.setProject(project);
         device.setTod(tod);
         device.setStatus("deactivated");


### PR DESCRIPTION
## Summary
- Normalize MAC addresses when creating devices from notifications to ensure consistent lookup and storage
- Normalize MAC addresses received in REST payloads for device data
- Normalize path-based MAC addresses across device management endpoints

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c80c11e7f08323a89a7a5f6efe61be