### PR TITLE
Format MAC addresses in templates

### DIFF
--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -145,7 +145,7 @@
                                           <tbody>
                                                   <tr th:each="device : ${devices}">
                                                           <td th:text="${device.name}">Name</td>
-                                                          <td th:text="${device.macAddress}">Mac Address</td>
+                                                          <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">Mac Address</td>
                                                           <td th:text="${device.tod}">Mac Address</td>
                                                           <td>
                                                                   <span th:if="${device.operator != null}" th:text="${device.operator}">Operator</span>
@@ -209,9 +209,13 @@
 			attribution: '&copy; OpenStreetMap contributors'
 		}).addTo(map);
 
-		let markerByMac = new Map();
+                let markerByMac = new Map();
 
                 let allLatLngs = [];
+
+                function formatMac(mac) {
+                        return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+                }
 
                 initialDevices.forEach(function (d) {
                         const latlng = [d.latitude, d.longitude];
@@ -219,7 +223,7 @@
 
                         const marker = L.marker(latlng).addTo(map);
                         const popupContent = "Device: " + d.name + "<br>" +
-                                "MacAddress: " + d.macAddress + "<br>" +
+                                "MacAddress: " + formatMac(d.macAddress) + "<br>" +
                                 "Latitude: " + d.latitude + "<br>" +
                                 "Longitude: " + d.longitude;
 
@@ -256,7 +260,7 @@
                                                 ul.innerHTML = '';
                                                 validDevices.forEach(device => {
                                                         const li = document.createElement('li');
-                                                        li.textContent = `${device.name} (${device.macAddress})`;
+                                                        li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
                                                         ul.appendChild(li);
                                                 });
                                         });

--- a/src/main/resources/templates/admin/manageGroups.html
+++ b/src/main/resources/templates/admin/manageGroups.html
@@ -106,7 +106,7 @@
 		    <tbody>
 				<tr th:each="device : ${group.devices}">
 				    <td th:text="${device.name}">Device Name</td>
-				    <td th:text="${device.macAddress}">MAC</td>
+                                    <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">MAC</td>
 				    <td th:text="${device.tod != null ? device.tod.name : 'N/A'}">Type</td> <!-- Spostata sopra -->
 				    <td>
 				        <form th:action="@{'/group/' + ${project.id} + '/' + ${group.id} + '/removeDevice/' + ${device.macAddress}}" 
@@ -130,6 +130,9 @@
     </div>
 </div>
 <script>
+function formatMac(mac) {
+    return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+}
 document.querySelectorAll('.toggle-add-list').forEach(button => {
     button.addEventListener('click', async () => {
         const groupId = button.getAttribute('data-group-id');
@@ -158,8 +161,8 @@ document.querySelectorAll('.toggle-add-list').forEach(button => {
 			    devices.forEach(device => {
 			        html += `
 			            <tr>
-			                <td>${device.name}</td>
-			                <td>${device.macAddress}</td>
+                                        <td>${device.name}</td>
+                                        <td>${formatMac(device.macAddress)}</td>
 			                <td>${device.tod || 'N/A'}</td>
 			                <td>
 			                    <form method="post" action="/group/${groupId}/add-device/${device.macAddress}">

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -106,7 +106,7 @@
 					<tbody>
 						<tr th:each="device : ${devices}">
 							<td th:text="${device.name}">Name</td>
-							<td th:text="${device.macAddress}">Mac</td>
+                                                        <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">Mac</td>
 							<td th:text="${device.tod}">Type</td>
 						</tr>
 					</tbody>
@@ -128,8 +128,12 @@
 			attribution: '&copy; OpenStreetMap contributors'
 		}).addTo(map);
 
-		let markerByMac = new Map();
-		let allLatLngs = [];
+                let markerByMac = new Map();
+                let allLatLngs = [];
+
+                function formatMac(mac) {
+                        return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+                }
 
                 initialDevices.forEach(function (d) {
                         if (d.latitude != null && d.longitude != null) {
@@ -137,7 +141,7 @@
                                 allLatLngs.push(latlng);
                                 const marker = L.marker(latlng).addTo(map);
                                 const popupContent = "Device: " + d.name + "<br>" +
-                                        "MacAddress: " + d.macAddress + "<br>" +
+                                        "MacAddress: " + formatMac(d.macAddress) + "<br>" +
                                         "Latitude: " + d.latitude + "<br>" +
                                         "Longitude: " + d.longitude;
                                 marker.bindPopup(popupContent);
@@ -167,7 +171,7 @@
 						ul.innerHTML = '';
 						devices.forEach(device => {
 							const li = document.createElement('li');
-							li.textContent = `${device.name} (${device.macAddress})`;
+                                                        li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
 							ul.appendChild(li);
 						});
 					});

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -50,15 +50,19 @@
     const container = document.getElementById('notification-list');
     const notifications = new Map();
 
+    function formatMac(mac) {
+        return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+    }
+
     function renderNotification(n) {
         let box = document.getElementById('notif-' + n.key);
         if (!box) {
             box = document.createElement('div');
             box.id = 'notif-' + n.key;
             box.className = 'notification-box';
-            box.innerHTML = `<p><strong>${n.macAddress ? n.macAddress : ''}${n.devEui ? '/' + n.devEui : ''}</strong></p>
+            box.innerHTML = `<p><strong>${n.macAddress ? formatMac(n.macAddress) : ''}${n.devEui ? '/' + n.devEui : ''}</strong></p>
                              <p class="time"></p>
-                             <button class="btn-add" onclick="addDevice('${n.key}')">Add</button>`;
+                              <button class="btn-add" onclick="addDevice('${n.key}')">Add</button>`;
             container.appendChild(box);
         }
         box.dataset.timestamp = Date.parse(n.timestamp);

--- a/src/main/resources/templates/superadmin/formUpdateDevice.html
+++ b/src/main/resources/templates/superadmin/formUpdateDevice.html
@@ -56,7 +56,7 @@
             <table>
                 <tr>
                     <th>MAC Address</th>
-                    <td th:text="${device.macAddress}"></td>
+                    <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}"></td>
                 </tr>
                 <tr>
                     <th>Owner Email</th>

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -84,7 +84,7 @@
 			<tbody>
 				<tr th:each="device : ${devices}">
 					<td th:text="${device.name}">Name</td>
-                                        <td th:text="${device.macAddress != null ? (device.devEui != null ? device.macAddress + '/' + device.devEui : device.macAddress) : device.devEui}">Mac Address</td>
+                                        <td th:text="${device.macAddress != null ? (device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress) + '/' + device.devEui : T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)) : device.devEui}">Mac Address</td>
                                         <td th:text="${device.emailOwner}">Email</td>
                                         <td th:text="${device.tod}">Type Of Device</td>
 				</tr>
@@ -107,9 +107,13 @@
 		attribution: '&copy; OpenStreetMap contributors'
 	}).addTo(map);
 
-	let markerByMac = new Map();
+        let markerByMac = new Map();
 
-	let allLatLngs = [];
+        let allLatLngs = [];
+
+        function formatMac(mac) {
+                return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+        }
 
         initialDevices.forEach(function (d) {
                 if (d.latitude != null && d.longitude != null) {
@@ -118,7 +122,7 @@
 
                         const marker = L.marker(latlng).addTo(map);
                         const popupContent = "Device: " + d.name + "<br>" +
-                                "MacAddress/DevEui: " + (d.macAddress ? d.macAddress : "") + (d.devEui ? '/' + d.devEui : "") + "<br>" +
+                                "MacAddress/DevEui: " + (d.macAddress ? formatMac(d.macAddress) : "") + (d.devEui ? '/' + d.devEui : "") + "<br>" +
                                 "Latitude: " + d.latitude + "<br>" +
                                 "Longitude: " + d.longitude;
 
@@ -154,7 +158,7 @@
 					ul.innerHTML = '';
 					devices.forEach(device => {
 						const li = document.createElement('li');
-						li.textContent = `${device.name} (${device.macAddress})`;
+                                                li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
 						ul.appendChild(li);
 					});
 				});

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -58,7 +58,7 @@
             <table>
                 <tr>
                     <th>MAC Address</th>
-                    <td th:text="${device.macAddress}"></td>
+                    <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}"></td>
                 </tr>
                 <tr>
                     <th>Owner Email</th>


### PR DESCRIPTION
## Summary
- Format device MAC addresses across admin, operator and superadmin templates using `MacAddressUtils.format`
- Add `formatMac` JavaScript helper to render colon-separated MACs in dynamic content

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c80d452ef08323988c158deee1df60