### PR TITLE
Normalize MAC addresses across services and controllers

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -52,12 +52,13 @@ public class NotificationControllerRest {
 
     @PostMapping("/{projectId}/{key}/add")
     public ResponseEntity<Void> addDevice(@PathVariable Long projectId, @PathVariable String key) {
-        UnknownDeviceNotification notif = unknownDeviceService.consume(projectId, key);
+        String normalizedKey = MacAddressUtils.normalize(key);
+        UnknownDeviceNotification notif = unknownDeviceService.consume(projectId, normalizedKey);
         if (notif == null) {
-            logger.warn("No notification found for project {} and key {}", projectId, key);
+            logger.warn("No notification found for project {} and key {}", projectId, normalizedKey);
             return ResponseEntity.notFound().build();
         }
-        logger.info("Consumed notification for project {} key {}: mac {} devEui {}", projectId, key, notif.getMacAddress(), notif.getDevEui());
+        logger.info("Consumed notification for project {} key {}: mac {} devEui {}", projectId, normalizedKey, notif.getMacAddress(), notif.getDevEui());
         Project project = projectRepository.findById(projectId).orElse(null);
         TypeOfDevice tod = typeOfDeviceRepository.findByName(notif.getTypeOfDevice()).orElse(null);
         if (tod == null) {

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -40,8 +40,9 @@ public class PacketService {
     public Result handlePacket(PacketDTO packet) {
         System.out.println("PacketService.handlePacket - processing packet: " + packet);
         String mac = MacAddressUtils.normalize(packet.getMacAddress());
+        String devEui = MacAddressUtils.normalize(packet.getDevEui());
         if ((mac == null || mac.isBlank()) &&
-                (packet.getDevEui() == null || packet.getDevEui().isBlank())) {
+                (devEui == null || devEui.isBlank())) {
             throw new IllegalArgumentException("macAddress or devEui is required");
         }
 
@@ -49,8 +50,8 @@ public class PacketService {
         if (mac != null && !mac.isBlank()) {
             existing = deviceRepository.findByMacAddress(mac);
         }
-        if (existing.isEmpty() && packet.getDevEui() != null && !packet.getDevEui().isBlank()) {
-            existing = deviceRepository.findByDevEui(packet.getDevEui());
+        if (existing.isEmpty() && devEui != null && !devEui.isBlank()) {
+            existing = deviceRepository.findByDevEui(devEui);
         }
         if (existing.isEmpty()) {
             System.out.println("PacketService.handlePacket - device not found, notifying UnknownDeviceService");

--- a/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
+++ b/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
@@ -18,12 +18,13 @@ public class UnknownDeviceService {
 
     public void notify(PacketDTO packet) {
         String mac = MacAddressUtils.normalize(packet.getMacAddress());
-        String key = mac != null && !mac.isBlank() ? mac : packet.getDevEui();
+        String devEui = MacAddressUtils.normalize(packet.getDevEui());
+        String key = mac != null && !mac.isBlank() ? mac : devEui;
         System.out.println("UnknownDeviceService.notify - unknown device key: " + key + ", project: " + packet.getProjectId());
         UnknownDeviceNotification notification = new UnknownDeviceNotification(
                 key,
                 mac,
-                packet.getDevEui(),
+                devEui,
                 packet.getProjectId(),
                 packet.getTypeOfDevice(),
                 packet.getPayload(),
@@ -65,6 +66,7 @@ public class UnknownDeviceService {
     }
 
     public UnknownDeviceNotification consume(Long projectId, String key) {
+        key = MacAddressUtils.normalize(key);
         Map<String, UnknownDeviceNotification> map = notifications.get(projectId);
         if (map == null) return null;
         return map.remove(key);

--- a/src/main/java/it/sensorplatform/util/MacAddressUtils.java
+++ b/src/main/java/it/sensorplatform/util/MacAddressUtils.java
@@ -11,7 +11,8 @@ public final class MacAddressUtils {
     }
 
     public static String format(String mac) {
-        return mac == null ? "" : mac.replaceAll("..(?!$)", "$0:");
+        String cleaned = normalize(mac);
+        return cleaned == null ? "" : cleaned.replaceAll("..(?!$)", "$0:");
     }
 }
 

--- a/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
+++ b/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
@@ -39,8 +39,9 @@ class NotificationControllerRestTests {
 
         Long projectId = 1L;
         String key = "key";
+        String normalizedKey = "KEY";
         UnknownDeviceNotification notif = new UnknownDeviceNotification(
-                key,
+                normalizedKey,
                 null,
                 "DEV123",
                 projectId,
@@ -49,7 +50,7 @@ class NotificationControllerRestTests {
                 Instant.now()
         );
 
-        when(unknownDeviceService.consume(projectId, key)).thenReturn(notif);
+        when(unknownDeviceService.consume(projectId, normalizedKey)).thenReturn(notif);
         when(typeOfDeviceRepository.findByName("type")).thenReturn(Optional.of(new TypeOfDevice()));
         when(projectRepository.findById(projectId)).thenReturn(Optional.of(new Project()));
         when(deviceRepository.existsByMacAddress("DEV123")).thenReturn(false);


### PR DESCRIPTION
## Summary
- Use shared formatting utility for MAC addresses
- Normalize MAC-based keys and DevEUI values in services and controllers
- Adjust tests for normalized keys

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c812cff2308323b80c2333fd935933