### PR TITLE
Normalize MAC addresses before persistence

### DIFF
--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -22,6 +22,7 @@ import it.sensorplatform.service.DeviceService;
 import it.sensorplatform.service.GroupService;
 import it.sensorplatform.service.ProjectService;
 import it.sensorplatform.service.AdminService;
+import it.sensorplatform.util.MacAddressUtils;
 
 
 import static it.sensorplatform.model.Credentials.SUPERADMIN_ROLE;
@@ -177,30 +178,32 @@ private AdminService adminService;
 		return "redirect:/manageGroups/" + projectId;
 	}
 
-	@PostMapping("/group/{projectId}/{groupId}/removeDevice/{macAddress}")
-	public String removeDeviceFromGroup(@PathVariable Long projectId, @PathVariable Long groupId,
-			@PathVariable String macAddress, RedirectAttributes redirectAttributes) {
-		Group group = groupService.findGroupById(groupId);
-		Device device = deviceService.findByMacAddress(macAddress);
-		List<Device> devices = group.getDevices();
-		devices.remove(device);
-		group.setDevices(devices);
-		device.setGroup(null);
-		groupService.save(group);
-		deviceService.save(device);
-		redirectAttributes.addFlashAttribute("success", "Device removed successfully.");
-		return "redirect:/manageGroups/" + projectId;
-	}
+        @PostMapping("/group/{projectId}/{groupId}/removeDevice/{macAddress}")
+        public String removeDeviceFromGroup(@PathVariable Long projectId, @PathVariable Long groupId,
+                        @PathVariable String macAddress, RedirectAttributes redirectAttributes) {
+                macAddress = MacAddressUtils.normalize(macAddress);
+                Group group = groupService.findGroupById(groupId);
+                Device device = deviceService.findByMacAddress(macAddress);
+                List<Device> devices = group.getDevices();
+                devices.remove(device);
+                group.setDevices(devices);
+                device.setGroup(null);
+                groupService.save(group);
+                deviceService.save(device);
+                redirectAttributes.addFlashAttribute("success", "Device removed successfully.");
+                return "redirect:/manageGroups/" + projectId;
+        }
 
-	@PostMapping("/group/{groupId}/add-device/{macAddress}")
-	public String addDeviceToGroup(@PathVariable Long groupId, @PathVariable("macAddress") String macAddress,
-			Principal principal, RedirectAttributes redirectAttributes) {
-		Group group = groupService.findGroupById(groupId);
-		if (group == null) {
-			redirectAttributes.addFlashAttribute("error", "Group not found");
-			return "error";
-		}
-		Device device = deviceService.findByMacAddress(macAddress);
+        @PostMapping("/group/{groupId}/add-device/{macAddress}")
+        public String addDeviceToGroup(@PathVariable Long groupId, @PathVariable("macAddress") String macAddress,
+                        Principal principal, RedirectAttributes redirectAttributes) {
+                macAddress = MacAddressUtils.normalize(macAddress);
+                Group group = groupService.findGroupById(groupId);
+                if (group == null) {
+                        redirectAttributes.addFlashAttribute("error", "Group not found");
+                        return "error";
+                }
+                Device device = deviceService.findByMacAddress(macAddress);
 		if (device == null) {
 			redirectAttributes.addFlashAttribute("error", "Device not found");
 		} else {

--- a/src/main/java/it/sensorplatform/model/Device.java
+++ b/src/main/java/it/sensorplatform/model/Device.java
@@ -12,7 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-
+import it.sensorplatform.util.MacAddressUtils;
 @Entity
 public class Device {
 	@Id
@@ -120,9 +120,9 @@ public class Device {
 	}
 
 
-	public void setMacAddress(String macAddress) {
-		this.macAddress = macAddress;
-	}
+        public void setMacAddress(String macAddress) {
+                this.macAddress = MacAddressUtils.normalize(macAddress);
+        }
 	
 	
 	public List<MeasurementRecord> getRecords() {

--- a/src/main/java/it/sensorplatform/service/DeviceService.java
+++ b/src/main/java/it/sensorplatform/service/DeviceService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import it.sensorplatform.model.Credentials;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.util.MacAddressUtils;
 
 @Service
 public class DeviceService {
@@ -29,32 +30,38 @@ public class DeviceService {
 		this.deviceRepository.deleteById(deviceId);
 	}
 
-	public void saveDevice(Device existing) {
-		this.deviceRepository.save(existing);
-	}
+        public void saveDevice(Device existing) {
+                if (existing != null) {
+                        existing.setMacAddress(MacAddressUtils.normalize(existing.getMacAddress()));
+                        this.deviceRepository.save(existing);
+                }
+        }
 
 	public Device findById(Long deviceId) {
 		return this.deviceRepository.findById(deviceId).get();
 	}
 
-	public Device findByMacAddress(String macAddress) {
-		return this.deviceRepository.findByMacAddress(macAddress).get();
-	}
+        public Device findByMacAddress(String macAddress) {
+                return this.deviceRepository.findByMacAddress(MacAddressUtils.normalize(macAddress)).get();
+        }
 
-	public void save(Device device) {
-		this.deviceRepository.save(device);
-	}
+        public void save(Device device) {
+                if (device != null) {
+                        device.setMacAddress(MacAddressUtils.normalize(device.getMacAddress()));
+                        this.deviceRepository.save(device);
+                }
+        }
 
-	public boolean existsByMacAddress(String macAddress) {
-		return this.deviceRepository.existsByMacAddress(macAddress);
-	}
+        public boolean existsByMacAddress(String macAddress) {
+                return this.deviceRepository.existsByMacAddress(MacAddressUtils.normalize(macAddress));
+        }
 
 	public Set<Device> findByNameStartingWithIgnoreCase(String deviceInfo) {
         return this.deviceRepository.findByNameStartingWithIgnoreCase(deviceInfo);
     }
 
     public Set<Device> findByMacAddressStartingWithIgnoreCase(String deviceInfo) {
-        return this.deviceRepository.findByMacAddressStartingWithIgnoreCase(deviceInfo);
+        return this.deviceRepository.findByMacAddressStartingWithIgnoreCase(MacAddressUtils.normalize(deviceInfo));
     }
 
     public Set<Device> findByEmailOwnerStartingWithIgnoreCase(String deviceQuery) {

--- a/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
+++ b/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
@@ -10,6 +10,7 @@ import it.sensorplatform.repository.ProjectRepository;
 import it.sensorplatform.repository.TypeOfDeviceRepository;
 import it.sensorplatform.service.SpecService;
 import it.sensorplatform.service.UnknownDeviceService;
+import it.sensorplatform.util.MacAddressUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -53,7 +54,7 @@ class NotificationControllerRestTests {
         when(unknownDeviceService.consume(projectId, normalizedKey)).thenReturn(notif);
         when(typeOfDeviceRepository.findByName("type")).thenReturn(Optional.of(new TypeOfDevice()));
         when(projectRepository.findById(projectId)).thenReturn(Optional.of(new Project()));
-        when(deviceRepository.existsByMacAddress("DEV123")).thenReturn(false);
+        when(deviceRepository.existsByMacAddress(MacAddressUtils.normalize("DEV123"))).thenReturn(false);
         when(deviceRepository.existsByDevEui("DEV123")).thenReturn(false);
         when(deviceRepository.save(any(Device.class))).thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/it/sensorplatform/test/PacketServiceTests.java
+++ b/src/test/java/it/sensorplatform/test/PacketServiceTests.java
@@ -7,6 +7,7 @@ import it.sensorplatform.repository.DeviceRepository;
 import it.sensorplatform.repository.ProjectRepository;
 import it.sensorplatform.service.IngestService;
 import it.sensorplatform.service.PacketService;
+import it.sensorplatform.util.MacAddressUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -44,7 +45,7 @@ class PacketServiceTests {
         PacketService.Result res = packetService.handlePacket(dto);
 
         assertEquals(PacketService.Result.NEW_DEVICE, res);
-        Device saved = deviceRepository.findByMacAddress("AA:BB:CC").orElseThrow();
+        Device saved = deviceRepository.findByMacAddress(MacAddressUtils.normalize("AA:BB:CC")).orElseThrow();
         assertEquals("deactivated", saved.getStatus());
         assertEquals(project.getId(), saved.getProject().getId());
     }
@@ -71,7 +72,7 @@ class PacketServiceTests {
 
         PacketService.Result res = packetService.handlePacket(dto);
         assertEquals(PacketService.Result.DATA, res);
-        assertEquals(1, ingestService.last("AA:DD:EE", 1).size());
+        assertEquals(1, ingestService.last(MacAddressUtils.normalize("AA:DD:EE"), 1).size());
     }
 
     @Test
@@ -99,7 +100,7 @@ class PacketServiceTests {
         PacketService.Result res = packetService.handlePacket(dto);
         assertEquals(PacketService.Result.ACTIVATION, res);
 
-        Device updated = deviceRepository.findByMacAddress("AA:FF:00").orElseThrow();
+        Device updated = deviceRepository.findByMacAddress(MacAddressUtils.normalize("AA:FF:00")).orElseThrow();
         assertEquals("activated", updated.getStatus());
         assertEquals(45.0, updated.getLatitude());
         assertEquals(7.0, updated.getLongitude());


### PR DESCRIPTION
## Summary
- Normalize and uppercase MAC addresses via `MacAddressUtils` whenever devices are created or saved
- Ensure lookups and uniqueness checks use normalized MAC strings
- Update tests to expect normalized MAC addresses

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.4)*

------
https://chatgpt.com/codex/tasks/task_e_68c816d390b883238d72b824ce704b58