### PR TITLE
Add spec support for unknown devices and Sheets script

### DIFF
--- a/scripts/google_sheets.gs
+++ b/scripts/google_sheets.gs
@@ -1,0 +1,209 @@
+/**
+ * Normalizza un valore numerico passato come stringa.
+ * - converte virgola in punto
+ * - se vuoto o non numerico -> 0
+ * - divide per "divisor" (default 1)
+ */
+function normalize(value, divisor = 1) {
+  if (value === undefined || value === null) return 0;
+  value = value.toString().trim().replace(",", ".");
+  var n = parseFloat(value);
+  if (isNaN(n)) return 0;
+  return n / divisor;
+}
+
+/** Intestazioni colonne (0-based):
+ *  0 Data, 1 Ora, 2 MAC,
+ *  3 CO2, 4 PM1.0, 5 PM2.5, 6 PM4.0, 7 PM10,
+ *  8 SEN T, 9 SEN RH, 10 VOC, 11 NOx,
+ *  12 BME T, 13 BME RH, 14 BME P, 15 BME Gas,
+ *  16 Alt m, 17 BAT_V, 18 BAT_%,
+ *  19 Lat, 20 Lon,
+ *  21 ICM_T, 22 ICM_AccX, 23 ICM_AccY, 24 ICM_AccZ,
+ *  25 ICM_GyrX, 26 ICM_GyrY, 27 ICM_GyrZ
+ */
+var HEADERS = [
+  "Data",
+  "Ora [Europe/Rome]",
+  "MAC Address",
+  "SCD30 CO2 [ppm]",
+  "SEN55 PM1.0 [µg/m³]",
+  "SEN55 PM2.5 [µg/m³]",
+  "SEN55 PM4.0 [µg/m³]",
+  "SEN55 PM10.0 [µg/m³]",
+  "SEN55 Temp [°C]",
+  "SEN55 RH [%]",
+  "SEN55 VOC [index]",
+  "SEN55 NOx [index]",
+  "BME680 Temp [°C]",
+  "BME680 RH [%]",
+  "BME680 Pressione [Pa]",
+  "BME680 Gas [Ω]",
+  "BME680 Altitudine [m]",
+  "BAT_V [V]",
+  "BAT_% [%]",
+  "Latitudine",
+  "Longitudine",
+  "ICM Temp [°C]",
+  "ICM AccX [g]",
+  "ICM AccY [g]",
+  "ICM AccZ [g]",
+  "ICM GyrX [°/s]",
+  "ICM GyrY [°/s]",
+  "ICM GyrZ [°/s]"
+];
+
+/**
+ * Entry point: riceve parametri GET dal firmware, scrive su Google Sheets
+ * e inoltra i dati ad AetherSense.
+ */
+function doGet(e) {
+  try {
+    if (!e.parameter || Object.keys(e.parameter).length === 0) {
+      return ContentService.createTextOutput("Nessun parametro ricevuto");
+    }
+
+    var payload = e.parameter;
+
+    var ss = SpreadsheetApp.getActiveSpreadsheet();
+    var sheet = ss.getSheetByName("Foglio1") || ss.getSheets()[0];
+
+    setHeaders(sheet);
+    ensureColumns(sheet, HEADERS.length);
+
+    var row = new Array(HEADERS.length);
+    var now = new Date();
+
+    // Data / Ora (fallback locale Europe/Rome)
+    row[0] = e.parameter.currentDate || Utilities.formatDate(now, "Europe/Rome", "yyyy-MM-dd");
+    row[1] = e.parameter.currentTime || Utilities.formatDate(now, "Europe/Rome", "HH:mm:ss");
+
+    // MAC come terza colonna
+    row[2] = e.parameter.macAddress || "";
+
+    // SCD30
+    row[3] = normalize(e.parameter.co2_ppm, 1);        // ppm
+
+    // SEN55
+    row[4] = normalize(e.parameter.pm1p0, 1);          // µg/m³
+    row[5] = normalize(e.parameter.pm2p5, 1);
+    row[6] = normalize(e.parameter.pm4p0, 1);
+    row[7] = normalize(e.parameter.pm10p0, 1);
+    row[8] = normalize(e.parameter.senT, 1);           // °C
+    row[9] = normalize(e.parameter.senRH, 1);          // %
+    row[10] = normalize(e.parameter.vocIndex, 1);
+    row[11] = normalize(e.parameter.noxIndex, 1);
+
+    // BME680 (arrivano x100 dal firmware)
+    row[12] = normalize(e.parameter.bmeT_x100,   100); // °C
+    row[13] = normalize(e.parameter.bmeRH_x100,  100); // %
+    row[14] = normalize(e.parameter.bmeP_x100,   100); // Pa
+    row[15] = normalize(e.parameter.bmeGas_x100, 100); // Ω
+
+    // Altitudine (x100 -> m)
+    row[16] = normalize(e.parameter.alt_x100, 100);
+
+    // Batteria: V in x100, % già 0..100
+    row[17] = normalize(e.parameter.bat_v_x100, 100);  // V
+    row[18] = normalize(e.parameter.bat_pct, 1);       // %
+
+    // Lat/Lon (se arrivano in microgradi)
+    row[19] = normalize(e.parameter.latitude,  1);
+    row[20] = normalize(e.parameter.longitude, 1);
+
+    // ICM-20948 (tutti x100 dal firmware)
+    row[21] = normalize(e.parameter.icmTemp_x100,     100); // °C
+    row[22] = normalize(e.parameter.icmAccX_gx100,    100); // g
+    row[23] = normalize(e.parameter.icmAccY_gx100,    100); // g
+    row[24] = normalize(e.parameter.icmAccZ_gx100,    100); // g
+    row[25] = normalize(e.parameter.icmGyrX_dpsx100,  100); // °/s
+    row[26] = normalize(e.parameter.icmGyrY_dpsx100,  100); // °/s
+    row[27] = normalize(e.parameter.icmGyrZ_dpsx100,  100); // °/s
+
+    // Scrivi una riga
+    sheet.getRange(sheet.getLastRow() + 1, 1, 1, row.length).setValues([row]);
+
+    // Invio pacchetto a AetherSense
+    try {
+      // Costruisce la specifica delle misurazioni
+      var spec = HEADERS
+        .filter(function(h, i) {
+          return [0, 1, 2, 17, 18, 19, 20].indexOf(i) === -1;
+        })
+        .map(function(h) {
+          var match = h.match(/^([^ ]+)\s+([^\[]+)\s+\[([^\]]+)\]$/);
+          if (match) {
+            return match[1] + '-' +
+                   match[2].trim().replace(/\s+/g, '') + '-' +
+                   match[3].replace(/\s+/g, '');
+          }
+          return h.replace(/\s+/g, '-').replace(/\[|\]/g, '');
+        });
+
+      var response = UrlFetchApp.fetch('http://sensors.joinyourteam.it:8090/api/packets', {
+        method: 'post',
+        contentType: 'application/json',
+        muteHttpExceptions: true,
+        payload: JSON.stringify({
+          projectId: 101,
+          typeOfDevice: 'Device4G',
+          macAddress: payload.macAddress, // o devEui
+          payload: payload,
+          spec: spec
+        })
+      });
+
+      if (response.getResponseCode() === 200) {
+        Logger.log('Packet accepted: ' + response.getContentText());
+      } else {
+        Logger.log('Packet rejected: ' +
+                   response.getResponseCode() + ' ' +
+                   response.getContentText());
+      }
+    } catch (errApi) {
+      Logger.log('Errore chiamando AetherSense API: ' + errApi);
+    }
+
+    return ContentService.createTextOutput("Ok");
+  } catch (err) {
+    return ContentService.createTextOutput("Errore nello script: " + err);
+  }
+}
+
+/** Crea o aggiorna la riga intestazioni */
+function setHeaders(sheet) {
+  if (sheet.getLastRow() === 0) {
+    sheet.appendRow(HEADERS);
+    return;
+  }
+  ensureColumns(sheet, HEADERS.length);
+  var range = sheet.getRange(1, 1, 1, HEADERS.length);
+  var current = range.getValues()[0];
+  var needsUpdate = false;
+  for (var i = 0; i < HEADERS.length; i++) {
+    if (!current[i] || current[i].toString().trim() === "") {
+      needsUpdate = true;
+      break;
+    }
+  }
+  if (needsUpdate) range.setValues([HEADERS]);
+}
+
+/** Garantisce almeno N colonne disponibili */
+function ensureColumns(sheet, minColumns) {
+  var current = sheet.getMaxColumns();
+  if (current < minColumns) {
+    sheet.insertColumnsAfter(current, minColumns - current);
+  }
+}
+
+function testEndpoint() {
+  var url = 'http://sensors.joinyourteam.it:8090/api/packets';
+  try {
+    var res = UrlFetchApp.fetch(url, {method: 'get', muteHttpExceptions: true});
+    Logger.log(res.getResponseCode());
+    Logger.log(res.getContentText());
+  } catch (err) {
+    Logger.log('Fetch failed: ' + err);
+  }
+}

--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -21,7 +21,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -65,16 +64,18 @@ public class NotificationControllerRest {
             tod = new TypeOfDevice();
             tod.setName(notif.getTypeOfDevice());
             List<Spec> specs = new ArrayList<>();
-            for (Map.Entry<String, Object> entry : notif.getPayload().entrySet()) {
-                String[] parts = entry.getKey().split("[_:]");
-                Spec spec = new Spec();
-                spec.setMeasurement(parts[0]);
-                spec.setComponent(parts.length > 1 ? parts[1] : "");
-                spec.setUnitOfMeasurement("");
-                if (!specService.existsByFields(spec)) {
-                    specService.save(spec);
+            if (notif.getSpec() != null) {
+                for (String specEntry : notif.getSpec()) {
+                    String[] parts = specEntry.split("-");
+                    Spec spec = new Spec();
+                    spec.setComponent(parts.length > 0 ? parts[0] : "");
+                    spec.setMeasurement(parts.length > 1 ? parts[1] : "");
+                    spec.setUnitOfMeasurement(parts.length > 2 ? parts[2] : "");
+                    if (!specService.existsByFields(spec)) {
+                        specService.save(spec);
+                    }
+                    specs.add(spec);
                 }
-                specs.add(spec);
             }
             tod.setSpecs(specs);
             typeOfDeviceRepository.save(tod);

--- a/src/main/java/it/sensorplatform/dto/PacketDTO.java
+++ b/src/main/java/it/sensorplatform/dto/PacketDTO.java
@@ -1,5 +1,6 @@
 package it.sensorplatform.dto;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -16,6 +17,7 @@ public class PacketDTO {
     private Double latitude;
     private Double longitude;
     private Map<String, Object> payload;
+    private List<String> spec;
 
     public String getMacAddress() {
         return macAddress;
@@ -79,6 +81,14 @@ public class PacketDTO {
 
     public void setPayload(Map<String, Object> payload) {
         this.payload = payload;
+    }
+
+    public List<String> getSpec() {
+        return spec;
+    }
+
+    public void setSpec(List<String> spec) {
+        this.spec = spec;
     }
 }
 

--- a/src/main/java/it/sensorplatform/dto/UnknownDeviceNotification.java
+++ b/src/main/java/it/sensorplatform/dto/UnknownDeviceNotification.java
@@ -1,6 +1,7 @@
 package it.sensorplatform.dto;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 public class UnknownDeviceNotification {
@@ -10,15 +11,24 @@ public class UnknownDeviceNotification {
     private Long projectId;
     private String typeOfDevice;
     private Map<String, Object> payload;
+    private List<String> spec;
     private Instant timestamp;
 
-    public UnknownDeviceNotification(String key, String macAddress, String devEui, Long projectId, String typeOfDevice, Map<String, Object> payload, Instant timestamp) {
+    public UnknownDeviceNotification(String key,
+                                     String macAddress,
+                                     String devEui,
+                                     Long projectId,
+                                     String typeOfDevice,
+                                     Map<String, Object> payload,
+                                     List<String> spec,
+                                     Instant timestamp) {
         this.key = key;
         this.macAddress = macAddress;
         this.devEui = devEui;
         this.projectId = projectId;
         this.typeOfDevice = typeOfDevice;
         this.payload = payload;
+        this.spec = spec;
         this.timestamp = timestamp;
     }
 
@@ -28,5 +38,6 @@ public class UnknownDeviceNotification {
     public Long getProjectId() { return projectId; }
     public String getTypeOfDevice() { return typeOfDevice; }
     public Map<String, Object> getPayload() { return payload; }
+    public List<String> getSpec() { return spec; }
     public Instant getTimestamp() { return timestamp; }
 }

--- a/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
+++ b/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
@@ -29,6 +29,7 @@ public class UnknownDeviceService {
                 packet.getProjectId(),
                 packet.getTypeOfDevice(),
                 packet.getPayload(),
+                packet.getSpec(),
                 Instant.now()
         );
         notifications.computeIfAbsent(packet.getProjectId(), k -> new ConcurrentHashMap<>())

--- a/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
+++ b/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
@@ -20,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -48,6 +49,7 @@ class NotificationControllerRestTests {
                 projectId,
                 "type",
                 Map.of(),
+                List.of(),
                 Instant.now()
         );
 


### PR DESCRIPTION
## Summary
- carry device measurement specs in PacketDTO and unknown device notification
- build TypeOfDevice specs from notification spec list
- send spec metadata from Google Sheets script when posting packets

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c829eecf4c8323839118d45aa1ac8d