### PR TITLE
Normalize MAC address formatting on maps

### DIFF
--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -214,7 +214,12 @@
                 let allLatLngs = [];
 
                 function formatMac(mac) {
-                        return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+                        if (!mac) {
+                                return '';
+                        }
+                        const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+                        const pairs = cleaned.match(/.{1,2}/g);
+                        return pairs ? pairs.join(':') : '';
                 }
 
                 initialDevices.forEach(function (d) {

--- a/src/main/resources/templates/admin/manageGroups.html
+++ b/src/main/resources/templates/admin/manageGroups.html
@@ -131,7 +131,12 @@
 </div>
 <script>
 function formatMac(mac) {
-    return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+    if (!mac) {
+        return '';
+    }
+    const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+    const pairs = cleaned.match(/.{1,2}/g);
+    return pairs ? pairs.join(':') : '';
 }
 document.querySelectorAll('.toggle-add-list').forEach(button => {
     button.addEventListener('click', async () => {

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -132,7 +132,12 @@
                 let allLatLngs = [];
 
                 function formatMac(mac) {
-                        return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+                        if (!mac) {
+                                return '';
+                        }
+                        const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+                        const pairs = cleaned.match(/.{1,2}/g);
+                        return pairs ? pairs.join(':') : '';
                 }
 
                 initialDevices.forEach(function (d) {

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -51,7 +51,12 @@
     const notifications = new Map();
 
     function formatMac(mac) {
-        return mac ? mac.replace(/(..)(?=..)/g, '$1:') : '';
+        if (!mac) {
+            return '';
+        }
+        const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+        const pairs = cleaned.match(/.{1,2}/g);
+        return pairs ? pairs.join(':') : '';
     }
 
     function renderNotification(n) {

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -112,7 +112,12 @@
         let allLatLngs = [];
 
         function formatMac(mac) {
-                return mac ? mac.replace(/.{2}(?!$)/g, '$&:') : '';
+                if (!mac) {
+                        return '';
+                }
+                const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+                const pairs = cleaned.match(/.{1,2}/g);
+                return pairs ? pairs.join(':') : '';
         }
 
         initialDevices.forEach(function (d) {


### PR DESCRIPTION
## Summary
- normalizes the client-side MAC formatting helper used in map popups and lists so that MACs are uppercased and regrouped without duplicating separators

## Testing
- mvn -q -DskipTests package *(fails: cannot reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c86a5c6fd883238d46b8618c2389a2