### PR TITLE
Prevent group view crashes when devices have null names

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -1,5 +1,9 @@
 package it.sensorplatform.controller;
 
+import static it.sensorplatform.model.Credentials.FIRE_ADMIN_ROLE;
+import static it.sensorplatform.model.Credentials.LTRAD_ADMIN_ROLE;
+import static it.sensorplatform.model.Credentials.VOLCANO_ADMIN_ROLE;
+
 import it.sensorplatform.dto.DeviceDTO;
 import it.sensorplatform.model.Admin;
 import it.sensorplatform.model.Credentials;
@@ -30,6 +34,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -342,7 +349,7 @@ public class DeviceController {
 		return "redirect:/admin/group/"+projectId;
 	}
 	
-	@PostMapping("/admin/removeOperator/{macAddress}/{projectId}")
+        @PostMapping("/admin/removeOperator/{macAddress}/{projectId}")
         public String removeOperatorfromDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress,
                                                                                  RedirectAttributes ra) {
                 macAddress = MacAddressUtils.normalize(macAddress);
@@ -356,8 +363,63 @@ public class DeviceController {
                 ra.addFlashAttribute("successMessage", "Operator removed.");
                 return "redirect:/admin/group/"+projectId;
         }
-	
-	public void loadDeviceDTO(List<Device> devices, Model model) {
+
+        @GetMapping("/admin/device-dashboard/{projectId}/{macAddress}")
+        public String viewDeviceDashboard(@PathVariable("projectId") Long projectId,
+                                          @PathVariable("macAddress") String macAddress,
+                                          Model model) {
+                UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+                Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
+                model.addAttribute("user", credentials);
+
+                if (credentials.getAdmin() == null) {
+                        return "error";
+                }
+
+                Project project = projectService.getProjectById(projectId);
+                if (project == null || !Objects.equals(project.getId(), credentials.getProjectId())) {
+                        return "error";
+                }
+
+                if (!isAdminRoleForProject(credentials.getRole(), project.getName())) {
+                        return "error";
+                }
+
+                String normalizedMac = MacAddressUtils.normalize(macAddress);
+                Optional<Device> deviceOpt = deviceService.findOptionalByMacAddress(normalizedMac);
+                if (deviceOpt.isEmpty()) {
+                        return "error";
+                }
+
+                Device device = deviceOpt.get();
+                if (device.getProject() == null || !Objects.equals(device.getProject().getId(), projectId)) {
+                        return "error";
+                }
+
+                model.addAttribute("project", project);
+                model.addAttribute("device", device);
+                String projectKey = project.getName() != null ? project.getName().toLowerCase(Locale.ROOT) : "default";
+                model.addAttribute("projectKey", projectKey);
+                model.addAttribute("specs", device.getTod() != null && device.getTod().getSpecs() != null
+                                ? device.getTod().getSpecs() : List.of());
+
+                return "admin/deviceDashboard";
+        }
+
+        private boolean isAdminRoleForProject(String role, String projectName) {
+                if (role == null || projectName == null) {
+                        return false;
+                }
+                String normalizedProject = projectName.toUpperCase(Locale.ROOT);
+                return switch (normalizedProject) {
+                        case "LTRAD" -> LTRAD_ADMIN_ROLE.equals(role);
+                        case "FIRE" -> FIRE_ADMIN_ROLE.equals(role);
+                        case "VOLCANO" -> VOLCANO_ADMIN_ROLE.equals(role);
+                        default -> false;
+                };
+        }
+
+        public void loadDeviceDTO(List<Device> devices, Model model) {
                 List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getId(), d.getName(),
                                 d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(),
                                 d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))

--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -249,11 +249,16 @@ private AdminService adminService;
 	    devices.removeIf(d -> d.getLatitude() == null || d.getLongitude() == null);
 
 	    // search locale
-	    if (deviceInfo != null && !deviceInfo.isEmpty()) {
-	        String q = deviceInfo.toLowerCase();
-	        devices.removeIf(d -> !(d.getName().toLowerCase().startsWith(q)
-	                || d.getMacAddress().toLowerCase().startsWith(q)));
-	    }
+            if (deviceInfo != null && !deviceInfo.isEmpty()) {
+                String q = deviceInfo.toLowerCase();
+                devices.removeIf(d -> {
+                    String deviceName = d.getName();
+                    boolean nameMatches = deviceName != null && deviceName.toLowerCase().startsWith(q);
+                    String macAddress = d.getMacAddress();
+                    boolean macMatches = macAddress != null && macAddress.toLowerCase().startsWith(q);
+                    return !(nameMatches || macMatches);
+                });
+            }
 
 	    // DTO e model
 	    this.loadDeviceDTO(devices, model);
@@ -265,18 +270,35 @@ private AdminService adminService;
 	}
 	
 
-	public void loadDeviceDTO(Set<Device> devices, Model model) {
-		List<Device> orderedDevices = new ArrayList<>(devices);
-		Collections.sort(orderedDevices, new Comparator<Device>() {
-			@Override
-			public int compare(Device d1, Device d2) {
-				return d1.getName().compareTo(d2.getName());
-			}
-		});
+        public void loadDeviceDTO(Set<Device> devices, Model model) {
+                List<Device> orderedDevices = new ArrayList<>(devices);
+                Collections.sort(orderedDevices, new Comparator<Device>() {
+                        @Override
+                        public int compare(Device d1, Device d2) {
+                                String label1 = getDeviceSortLabel(d1);
+                                String label2 = getDeviceSortLabel(d2);
+                                return label1.compareToIgnoreCase(label2);
+                        }
+                });
                 List<DeviceDTO> deviceDTOs = orderedDevices.stream().map(d -> new DeviceDTO(d.getId(), d.getName(),
                                 d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
                                 .collect(Collectors.toList());
                 model.addAttribute("devices", deviceDTOs);
+        }
+
+        private String getDeviceSortLabel(Device device) {
+                if (device == null) {
+                        return "";
+                }
+                String name = device.getName();
+                if (name != null && !name.isBlank()) {
+                        return name;
+                }
+                String macAddress = device.getMacAddress();
+                if (macAddress != null) {
+                        return macAddress;
+                }
+                return "";
         }
 
 }

--- a/src/main/java/it/sensorplatform/controller/rest/DeviceTelemetryController.java
+++ b/src/main/java/it/sensorplatform/controller/rest/DeviceTelemetryController.java
@@ -1,0 +1,148 @@
+package it.sensorplatform.controller.rest;
+
+import static it.sensorplatform.model.Credentials.FIRE_ADMIN_ROLE;
+import static it.sensorplatform.model.Credentials.LTRAD_ADMIN_ROLE;
+import static it.sensorplatform.model.Credentials.VOLCANO_ADMIN_ROLE;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import it.sensorplatform.dto.SpecDTO;
+import it.sensorplatform.dto.TelemetrySampleDTO;
+import it.sensorplatform.model.Credentials;
+import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Project;
+import it.sensorplatform.service.CredentialsService;
+import it.sensorplatform.service.DeviceService;
+import it.sensorplatform.service.IngestService;
+import it.sensorplatform.util.MacAddressUtils;
+
+@RestController
+@RequestMapping("/api/admin/devices")
+public class DeviceTelemetryController {
+
+    private static final int MAX_HISTORY = 200;
+
+    private final DeviceService deviceService;
+    private final CredentialsService credentialsService;
+    private final IngestService ingestService;
+
+    public DeviceTelemetryController(DeviceService deviceService,
+                                     CredentialsService credentialsService,
+                                     IngestService ingestService) {
+        this.deviceService = deviceService;
+        this.credentialsService = credentialsService;
+        this.ingestService = ingestService;
+    }
+
+    @GetMapping("/{macAddress}/specs")
+    public ResponseEntity<List<SpecDTO>> getDeviceSpecs(@PathVariable("macAddress") String macAddress) {
+        Optional<Device> deviceOpt = resolveAuthorizedDevice(macAddress);
+        if (deviceOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        Device device = deviceOpt.get();
+        if (device.getTod() == null || device.getTod().getSpecs() == null) {
+            return ResponseEntity.ok(Collections.emptyList());
+        }
+
+        List<SpecDTO> specs = device.getTod().getSpecs().stream()
+                .filter(Objects::nonNull)
+                .map(SpecDTO::fromSpec)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(specs);
+    }
+
+    @GetMapping("/{macAddress}/telemetry/latest")
+    public ResponseEntity<TelemetrySampleDTO> getLatestSample(@PathVariable("macAddress") String macAddress) {
+        Optional<Device> deviceOpt = resolveAuthorizedDevice(macAddress);
+        if (deviceOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        String normalizedMac = MacAddressUtils.normalize(macAddress);
+        List<IngestService.Sample> samples = ingestService.last(normalizedMac, 1);
+        if (samples.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        TelemetrySampleDTO dto = TelemetrySampleDTO.fromSample(samples.get(samples.size() - 1));
+        return ResponseEntity.ok(dto);
+    }
+
+    @GetMapping("/{macAddress}/telemetry/history")
+    public ResponseEntity<List<TelemetrySampleDTO>> getHistory(@PathVariable("macAddress") String macAddress,
+                                                               @RequestParam(value = "limit", defaultValue = "50") int limit) {
+        Optional<Device> deviceOpt = resolveAuthorizedDevice(macAddress);
+        if (deviceOpt.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+
+        String normalizedMac = MacAddressUtils.normalize(macAddress);
+        int safeLimit = Math.max(1, Math.min(limit, MAX_HISTORY));
+        List<TelemetrySampleDTO> history = ingestService.last(normalizedMac, safeLimit).stream()
+                .map(TelemetrySampleDTO::fromSample)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(history);
+    }
+
+    private Optional<Device> resolveAuthorizedDevice(String macAddress) {
+        Credentials credentials = currentCredentials();
+        if (credentials == null || credentials.getAdmin() == null) {
+            return Optional.empty();
+        }
+
+        String normalizedMac = MacAddressUtils.normalize(macAddress);
+        if (normalizedMac == null || normalizedMac.isBlank()) {
+            return Optional.empty();
+        }
+
+        Optional<Device> deviceOpt = deviceService.findOptionalByMacAddress(normalizedMac);
+        if (deviceOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Device device = deviceOpt.get();
+        if (!isAuthorized(credentials, device)) {
+            return Optional.empty();
+        }
+        return Optional.of(device);
+    }
+
+    private Credentials currentCredentials() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof UserDetails userDetails)) {
+            return null;
+        }
+        return credentialsService.getCredentials(userDetails.getUsername());
+    }
+
+    private boolean isAuthorized(Credentials credentials, Device device) {
+        Project project = device.getProject();
+        if (project == null || project.getId() == null) {
+            return false;
+        }
+        if (!Objects.equals(project.getId(), credentials.getProjectId())) {
+            return false;
+        }
+        String role = credentials.getRole();
+        return LTRAD_ADMIN_ROLE.equals(role)
+                || FIRE_ADMIN_ROLE.equals(role)
+                || VOLCANO_ADMIN_ROLE.equals(role);
+    }
+}
+

--- a/src/main/java/it/sensorplatform/dto/SpecDTO.java
+++ b/src/main/java/it/sensorplatform/dto/SpecDTO.java
@@ -1,0 +1,14 @@
+package it.sensorplatform.dto;
+
+import it.sensorplatform.model.Spec;
+
+public record SpecDTO(String measurement, String unitOfMeasurement, String component) {
+
+    public static SpecDTO fromSpec(Spec spec) {
+        if (spec == null) {
+            return new SpecDTO(null, null, null);
+        }
+        return new SpecDTO(spec.getMeasurement(), spec.getUnitOfMeasurement(), spec.getComponent());
+    }
+}
+

--- a/src/main/java/it/sensorplatform/dto/TelemetrySampleDTO.java
+++ b/src/main/java/it/sensorplatform/dto/TelemetrySampleDTO.java
@@ -1,0 +1,17 @@
+package it.sensorplatform.dto;
+
+import java.time.Instant;
+import java.util.Map;
+
+import it.sensorplatform.service.IngestService;
+
+public record TelemetrySampleDTO(Instant timestamp, Map<String, Object> metrics) {
+
+    public static TelemetrySampleDTO fromSample(IngestService.Sample sample) {
+        if (sample == null) {
+            return null;
+        }
+        return new TelemetrySampleDTO(sample.ts, sample.metrics);
+    }
+}
+

--- a/src/main/java/it/sensorplatform/service/DeviceService.java
+++ b/src/main/java/it/sensorplatform/service/DeviceService.java
@@ -1,6 +1,7 @@
 package it.sensorplatform.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,8 +42,12 @@ public class DeviceService {
 		return this.deviceRepository.findById(deviceId).get();
 	}
 
-        public Device findByMacAddress(String macAddress) {
+    public Device findByMacAddress(String macAddress) {
                 return this.deviceRepository.findByMacAddress(MacAddressUtils.normalize(macAddress)).get();
+        }
+
+        public Optional<Device> findOptionalByMacAddress(String macAddress) {
+                return this.deviceRepository.findByMacAddress(MacAddressUtils.normalize(macAddress));
         }
 
         public void save(Device device) {

--- a/src/main/resources/static/css/deviceDashboard.css
+++ b/src/main/resources/static/css/deviceDashboard.css
@@ -1,370 +1,504 @@
 :root {
-        color-scheme: dark;
+    color-scheme: dark;
 }
 
 .dashboard-body {
-        margin: 0;
-        min-height: 100vh;
-        font-family: 'Roboto', sans-serif;
-        background: var(--page-background, #0f172a);
-        color: var(--text-color, #ffffff);
-        --accent-color: #2d6cdf;
-        --accent-contrast: #ffffff;
-        --accent-soft: rgba(45, 108, 223, 0.25);
-        --navbar-border: rgba(255, 255, 255, 0.25);
-        --panel-background: rgba(11, 26, 47, 0.92);
-        --panel-border: rgba(255, 255, 255, 0.12);
-        --card-background: rgba(11, 26, 47, 0.65);
-        --card-border: rgba(255, 255, 255, 0.12);
-        --status-background: rgba(11, 26, 47, 0.65);
-        --status-border: rgba(255, 255, 255, 0.12);
-        --muted-color: rgba(255, 255, 255, 0.72);
-        --chart-grid: rgba(255, 255, 255, 0.2);
+    margin: 0;
+    min-height: 100dvh;
+    font-family: 'Roboto', sans-serif;
+    background: var(--page-background, #0f172a);
+    color: var(--text-color, #ffffff);
+    display: flex;
+    flex-direction: column;
+    --accent-color: #2d6cdf;
+    --accent-contrast: #ffffff;
+    --accent-soft: rgba(45, 108, 223, 0.25);
+    --navbar-border: rgba(255, 255, 255, 0.18);
+    --panel-background: rgba(11, 26, 47, 0.92);
+    --panel-border: rgba(255, 255, 255, 0.12);
+    --card-background: rgba(11, 26, 47, 0.65);
+    --card-border: rgba(255, 255, 255, 0.15);
+    --status-background: rgba(11, 26, 47, 0.7);
+    --status-border: rgba(255, 255, 255, 0.18);
+    --muted-color: rgba(255, 255, 255, 0.72);
+    --chart-grid: rgba(255, 255, 255, 0.18);
+    --shadow-soft: 0 18px 45px rgba(4, 10, 24, 0.45);
 }
 
 .dashboard-body.theme-ltrad {
-        --accent-color: #007bff;
-        --accent-soft: rgba(0, 123, 255, 0.3);
-        --navbar-border: rgb(142, 196, 255);
-        --page-background: #778DA9;
-        --panel-border: rgba(142, 196, 255, 0.35);
-        --card-border: rgba(142, 196, 255, 0.35);
-        --status-border: rgba(142, 196, 255, 0.35);
+    --accent-color: #007bff;
+    --accent-soft: rgba(0, 123, 255, 0.28);
+    --navbar-border: rgba(142, 196, 255, 0.5);
+    --page-background: #14213d;
+    --panel-border: rgba(142, 196, 255, 0.3);
+    --card-border: rgba(142, 196, 255, 0.28);
+    --status-border: rgba(142, 196, 255, 0.28);
 }
 
 .dashboard-body.theme-fire {
-        --accent-color: #cc0000;
-        --accent-soft: rgba(204, 0, 0, 0.3);
-        --navbar-border: rgb(255, 142, 142);
-        --page-background: #778DA9;
-        --panel-border: rgba(255, 142, 142, 0.35);
-        --card-border: rgba(255, 142, 142, 0.35);
-        --status-border: rgba(255, 142, 142, 0.35);
+    --accent-color: #cc0000;
+    --accent-soft: rgba(204, 0, 0, 0.28);
+    --navbar-border: rgba(255, 142, 142, 0.45);
+    --page-background: #2a1420;
+    --panel-border: rgba(255, 142, 142, 0.28);
+    --card-border: rgba(255, 142, 142, 0.28);
+    --status-border: rgba(255, 142, 142, 0.28);
 }
 
 .dashboard-body.theme-volcano {
-        --accent-color: #e67e00;
-        --accent-soft: rgba(230, 126, 0, 0.3);
-        --navbar-border: #ffc266;
-        --page-background: #778DA9;
-        --panel-border: rgba(255, 194, 102, 0.35);
-        --card-border: rgba(255, 194, 102, 0.35);
-        --status-border: rgba(255, 194, 102, 0.35);
-}
-
-.dashboard-body.theme-default {
-        --accent-color: #2d6cdf;
-        --accent-soft: rgba(45, 108, 223, 0.25);
-        --navbar-border: rgba(255, 255, 255, 0.25);
-        --page-background: #778DA9;
+    --accent-color: #e67e00;
+    --accent-soft: rgba(230, 126, 0, 0.28);
+    --navbar-border: rgba(255, 194, 102, 0.45);
+    --page-background: #301d11;
+    --panel-border: rgba(255, 194, 102, 0.28);
+    --card-border: rgba(255, 194, 102, 0.28);
+    --status-border: rgba(255, 194, 102, 0.28);
 }
 
 .navbar {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 0.75rem 1.5rem;
-        background: var(--accent-color);
-        color: var(--accent-contrast);
-        position: sticky;
-        top: 0;
-        z-index: 10;
-        border-bottom: 2px solid var(--navbar-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.85rem 1.75rem;
+    background: var(--accent-color);
+    color: var(--accent-contrast);
+    border-bottom: 2px solid var(--navbar-border);
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.2);
 }
 
 .nav-left h1 {
-        margin: 0;
-        font-size: 1.5rem;
+    margin: 0;
+    font-size: 1.5rem;
+    letter-spacing: 0.03em;
 }
 
 .nav-title-link {
-        color: var(--accent-contrast);
-        text-decoration: none;
+    color: inherit;
+    text-decoration: none;
 }
 
 .nav-right {
-        display: flex;
-        align-items: center;
-        gap: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
 }
 
 .home-button {
-        color: var(--accent-contrast);
-        display: flex;
-        align-items: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: inherit;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    transition: background-color 150ms ease, transform 150ms ease;
+}
+
+.home-button:hover,
+.home-button:focus {
+    background: rgba(255, 255, 255, 0.18);
+    transform: translateY(-1px);
 }
 
 .icon-home {
-        fill: currentColor;
-        width: 24px;
-        height: 24px;
+    width: 22px;
+    height: 22px;
+    fill: currentColor;
 }
 
 .dropdown {
-        position: relative;
-        display: inline-block;
+    position: relative;
+    display: inline-flex;
 }
 
 .dropdown-toggle {
-        background: none;
-        border: none;
-        color: var(--accent-contrast);
-        font-size: 1rem;
-        cursor: pointer;
-        display: flex;
-        align-items: center;
-        gap: 0.35rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+}
+
+.dropdown-icon {
+    width: 16px;
+    height: 16px;
+    fill: currentColor;
 }
 
 .dropdown-menu {
-        display: none;
-        position: absolute;
-        right: 0;
-        top: 2.4rem;
-        background: var(--panel-background);
-        border: 1px solid var(--accent-soft);
-        border-radius: 0.5rem;
-        padding: 0.75rem;
-        min-width: 140px;
-        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+    position: absolute;
+    top: calc(100% + 0.65rem);
+    right: 0;
+    min-width: 160px;
+    padding: 0.75rem;
+    background: var(--panel-background);
+    border: 1px solid var(--accent-soft);
+    border-radius: 0.65rem;
+    box-shadow: var(--shadow-soft);
+    display: none;
+    z-index: 40;
 }
 
 .dropdown-menu.show {
-        display: block;
+    display: block;
 }
 
 .dropdown-logout {
-        background: none;
-        border: none;
-        color: var(--accent-contrast);
-        font-size: 0.95rem;
-        width: 100%;
-        text-align: left;
-        cursor: pointer;
-        padding: 0.4rem 0;
+    display: block;
+    width: 100%;
+    padding: 0.45rem 0.5rem;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+    border-radius: 0.45rem;
+    transition: background-color 120ms ease;
 }
 
-.dropdown-logout:hover {
-        color: var(--muted-color);
-}
-
-.dashboard-main {
-        padding: 2rem clamp(1rem, 4vw, 3rem);
-        display: flex;
-        flex-direction: column;
-        gap: 2rem;
-}
-
-.device-header {
-        display: flex;
-        justify-content: space-between;
-        gap: 1.5rem;
-        flex-wrap: wrap;
-        align-items: flex-end;
-}
-
-.device-header h2 {
-        margin: 0 0 0.5rem;
-        font-size: clamp(1.6rem, 3vw, 2.3rem);
-}
-
-.device-meta {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 1.5rem;
-        margin: 0;
-        color: var(--muted-color);
-}
-
-.device-meta span strong,
-.device-location span strong {
-        color: var(--accent-contrast);
-}
-
-.device-location {
-        display: flex;
-        gap: 1.25rem;
-        color: var(--muted-color);
-}
-
-.widgets-section {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: 1.5rem;
-}
-
-.panel {
-        background: var(--panel-background);
-        border-radius: 1rem;
-        padding: 1.5rem;
-        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
-        backdrop-filter: blur(10px);
-        border: 1px solid var(--panel-border);
-}
-
-.panel-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        gap: 1rem;
-        margin-bottom: 1.25rem;
-}
-
-.panel-header h3 {
-        margin: 0;
-        font-size: 1.2rem;
-}
-
-.panel-subtitle {
-        font-size: 0.9rem;
-        color: var(--muted-color);
-}
-
-.metrics-grid {
-        display: grid;
-        gap: 1rem;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-}
-
-.metric-card {
-        background: var(--card-background);
-        border-radius: 0.9rem;
-        padding: 1rem 1.2rem;
-        border: 1px solid var(--card-border);
-        display: flex;
-        flex-direction: column;
-        gap: 0.5rem;
-        min-height: 130px;
-}
-
-.metric-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: baseline;
-        gap: 0.5rem;
-        color: var(--muted-color);
-        font-size: 0.9rem;
-}
-
-.metric-value {
-        font-size: clamp(1.6rem, 4vw, 2.4rem);
-        font-weight: 600;
-        color: var(--accent-contrast);
-}
-
-.metric-unit {
-        font-size: 0.95rem;
-        color: var(--muted-color);
-}
-
-.chart-panel {
-        position: relative;
-        min-height: 320px;
-}
-
-.chart-panel canvas {
-        width: 100% !important;
-        height: 100% !important;
-}
-
-.history-controls {
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
-        color: var(--muted-color);
-        font-size: 0.9rem;
-}
-
-.history-controls select {
-        background: rgba(255, 255, 255, 0.08);
-        border: 1px solid var(--accent-soft);
-        border-radius: 0.6rem;
-        color: var(--accent-contrast);
-        padding: 0.35rem 0.75rem;
-}
-
-.status-panel {
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-}
-
-.status-flags {
-        display: grid;
-        gap: 0.75rem;
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-}
-
-.status-flag {
-        display: flex;
-        align-items: center;
-        gap: 0.75rem;
-        flex-wrap: wrap;
-        background: var(--status-background);
-        border-radius: 0.8rem;
-        padding: 0.75rem 1rem;
-        border: 1px solid var(--status-border);
-        color: var(--muted-color);
-        font-size: 0.9rem;
-}
-
-.status-flag .flag-key {
-        flex: 1 1 120px;
-        min-width: 0;
-}
-
-.flag-value {
-        font-weight: 600;
-        padding: 0.25rem 0.6rem;
-        border-radius: 0.6rem;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        margin-left: auto;
-        max-width: 100%;
-        overflow-wrap: anywhere;
-}
-
-.flag-on {
-        background: rgba(102, 187, 106, 0.2);
-        color: #9ef5ad;
-}
-
-.flag-off {
-        background: rgba(239, 83, 80, 0.25);
-        color: #ffb3b0;
-}
-
-.flag-generic {
-        background: rgba(255, 255, 255, 0.12);
-        color: var(--accent-contrast);
-}
-
-.empty-state {
-        margin: 1rem 0 0;
-        color: var(--muted-color);
-        font-size: 0.95rem;
-        text-align: center;
+.dropdown-logout:hover,
+.dropdown-logout:focus {
+    background: rgba(255, 255, 255, 0.08);
 }
 
 .error-banner {
-        background: rgba(239, 83, 80, 0.15);
-        border-left: 4px solid #ef5350;
-        color: #ffb4b1;
-        margin: 1.5rem clamp(1rem, 4vw, 3rem) 0;
-        padding: 0.75rem 1rem;
-        border-radius: 0.6rem;
+    margin: 1.5rem auto 0;
+    padding: 0.85rem 1.25rem;
+    border-radius: 0.75rem;
+    background: rgba(204, 0, 0, 0.12);
+    color: #ffb4b4;
+    border: 1px solid rgba(204, 0, 0, 0.35);
+    width: min(960px, calc(100% - 2rem));
+    font-weight: 500;
+    box-shadow: var(--shadow-soft);
+}
+
+.dashboard-main {
+    flex: 1;
+    width: min(1100px, calc(100% - 2rem));
+    margin: 2.5rem auto 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.device-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 2rem;
+    align-items: flex-start;
+    background: var(--panel-background);
+    border: 1px solid var(--panel-border);
+    border-radius: 1.25rem;
+    padding: clamp(1.25rem, 2vw, 1.75rem);
+    box-shadow: var(--shadow-soft);
+}
+
+.device-header h2 {
+    margin: 0 0 0.5rem;
+    font-size: clamp(1.6rem, 3vw, 2rem);
+}
+
+.device-meta,
+.device-location {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+    color: var(--muted-color);
+    font-size: 0.95rem;
+}
+
+.device-meta span,
+.device-location span {
+    display: inline-flex;
+    gap: 0.25rem;
+    align-items: baseline;
+}
+
+.device-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.25rem 0.65rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--accent-contrast);
+}
+
+.status-chip .chip-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--muted-color);
+}
+
+.status-chip .chip-value {
+    font-weight: 700;
+}
+
+.status-chip[data-state='OFFLINE'],
+.status-chip[data-state='DISCONNECTED'] {
+    background: rgba(231, 76, 60, 0.22);
+    border-color: rgba(231, 76, 60, 0.35);
+    color: #ffb4b4;
+}
+
+.status-chip[data-state='ONLINE'],
+.status-chip[data-state='ACTIVE'],
+.status-chip[data-state='CONNECTED'] {
+    background: rgba(46, 204, 113, 0.22);
+    border-color: rgba(46, 204, 113, 0.35);
+    color: #68f7a2;
+}
+
+.widgets-section {
+    display: grid;
+    grid-template-columns: 1.15fr 0.85fr;
+    gap: 2rem;
+}
+
+.panel {
+    background: var(--panel-background);
+    border: 1px solid var(--panel-border);
+    border-radius: 1.25rem;
+    padding: 1.5rem;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.panel-header h3 {
+    margin: 0;
+    font-size: 1.25rem;
+}
+
+.panel-subtitle {
+    color: var(--muted-color);
+    font-size: 0.95rem;
+}
+
+.history-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--muted-color);
+    font-size: 0.9rem;
+}
+
+.history-controls select {
+    border-radius: 0.5rem;
+    border: 1px solid var(--accent-soft);
+    background: rgba(255, 255, 255, 0.05);
+    color: inherit;
+    padding: 0.35rem 0.65rem;
+}
+
+.metrics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+}
+
+.metric-card {
+    background: var(--card-background);
+    border: 1px solid var(--card-border);
+    border-radius: 1rem;
+    padding: 1.1rem 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    min-height: 150px;
+    position: relative;
+    overflow: hidden;
+}
+
+.metric-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    pointer-events: none;
+}
+
+.metric-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.5rem;
+    color: var(--muted-color);
+    font-size: 0.95rem;
+}
+
+.metric-name {
+    font-weight: 600;
+}
+
+.metric-component {
+    font-size: 0.85rem;
+    background: rgba(255, 255, 255, 0.08);
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+}
+
+.metric-value {
+    font-size: clamp(1.6rem, 4vw, 2.5rem);
+    font-weight: 600;
+    color: var(--accent-color);
+    line-height: 1.1;
+}
+
+.metric-unit {
+    color: var(--muted-color);
+    font-size: 0.95rem;
+}
+
+.chart-panel {
+    min-height: 360px;
+}
+
+.chart-panel canvas {
+    width: 100%;
+    min-height: 260px;
+}
+
+#metrics-chart {
+    flex: 1;
+}
+
+.empty-state {
+    margin: 0;
+    color: var(--muted-color);
+    text-align: center;
+    font-size: 0.95rem;
+}
+
+.status-panel {
+    gap: 1rem;
+}
+
+.status-flags {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 0.75rem;
+}
+
+.status-flag {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.75rem;
+    background: var(--status-background);
+    border: 1px solid var(--status-border);
+    font-size: 0.95rem;
+    gap: 0.75rem;
+}
+
+.flag-key {
+    color: var(--muted-color);
+}
+
+.flag-value {
+    padding: 0.25rem 0.6rem;
+    border-radius: 999px;
+    font-weight: 600;
+    min-width: 4ch;
+    text-align: center;
+}
+
+.flag-on {
+    background: rgba(46, 204, 113, 0.18);
+    color: #68f7a2;
+}
+
+.flag-off {
+    background: rgba(231, 76, 60, 0.18);
+    color: #ffb4b4;
+}
+
+.flag-generic {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--accent-contrast);
+}
+
+@media (max-width: 1024px) {
+    .widgets-section {
+        grid-template-columns: 1fr;
+    }
+
+    .chart-panel {
+        min-height: 320px;
+    }
 }
 
 @media (max-width: 768px) {
-        .navbar {
-                flex-direction: column;
-                align-items: flex-start;
-                gap: 0.75rem;
-        }
+    .navbar {
+        flex-wrap: wrap;
+        gap: 1rem;
+        justify-content: center;
+        text-align: center;
+    }
 
-        .device-header {
-                align-items: flex-start;
-        }
+    .nav-left h1 {
+        font-size: 1.35rem;
+    }
+
+    .nav-right {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .dashboard-main {
+        width: calc(100% - 1.5rem);
+        margin: 2rem auto;
+    }
+
+    .device-header {
+        flex-direction: column;
+    }
+
+    .device-header h2 {
+        font-size: 1.5rem;
+    }
 }
 
+@media (max-width: 520px) {
+    .metric-card {
+        min-height: 135px;
+    }
+
+    .metric-header,
+    .metric-unit,
+    .device-meta,
+    .device-location,
+    .history-controls {
+        font-size: 0.85rem;
+    }
+}

--- a/src/main/resources/static/css/deviceDashboard.css
+++ b/src/main/resources/static/css/deviceDashboard.css
@@ -1,0 +1,370 @@
+:root {
+        color-scheme: dark;
+}
+
+.dashboard-body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Roboto', sans-serif;
+        background: var(--page-background, #0f172a);
+        color: var(--text-color, #ffffff);
+        --accent-color: #2d6cdf;
+        --accent-contrast: #ffffff;
+        --accent-soft: rgba(45, 108, 223, 0.25);
+        --navbar-border: rgba(255, 255, 255, 0.25);
+        --panel-background: rgba(11, 26, 47, 0.92);
+        --panel-border: rgba(255, 255, 255, 0.12);
+        --card-background: rgba(11, 26, 47, 0.65);
+        --card-border: rgba(255, 255, 255, 0.12);
+        --status-background: rgba(11, 26, 47, 0.65);
+        --status-border: rgba(255, 255, 255, 0.12);
+        --muted-color: rgba(255, 255, 255, 0.72);
+        --chart-grid: rgba(255, 255, 255, 0.2);
+}
+
+.dashboard-body.theme-ltrad {
+        --accent-color: #007bff;
+        --accent-soft: rgba(0, 123, 255, 0.3);
+        --navbar-border: rgb(142, 196, 255);
+        --page-background: #778DA9;
+        --panel-border: rgba(142, 196, 255, 0.35);
+        --card-border: rgba(142, 196, 255, 0.35);
+        --status-border: rgba(142, 196, 255, 0.35);
+}
+
+.dashboard-body.theme-fire {
+        --accent-color: #cc0000;
+        --accent-soft: rgba(204, 0, 0, 0.3);
+        --navbar-border: rgb(255, 142, 142);
+        --page-background: #778DA9;
+        --panel-border: rgba(255, 142, 142, 0.35);
+        --card-border: rgba(255, 142, 142, 0.35);
+        --status-border: rgba(255, 142, 142, 0.35);
+}
+
+.dashboard-body.theme-volcano {
+        --accent-color: #e67e00;
+        --accent-soft: rgba(230, 126, 0, 0.3);
+        --navbar-border: #ffc266;
+        --page-background: #778DA9;
+        --panel-border: rgba(255, 194, 102, 0.35);
+        --card-border: rgba(255, 194, 102, 0.35);
+        --status-border: rgba(255, 194, 102, 0.35);
+}
+
+.dashboard-body.theme-default {
+        --accent-color: #2d6cdf;
+        --accent-soft: rgba(45, 108, 223, 0.25);
+        --navbar-border: rgba(255, 255, 255, 0.25);
+        --page-background: #778DA9;
+}
+
+.navbar {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 1.5rem;
+        background: var(--accent-color);
+        color: var(--accent-contrast);
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        border-bottom: 2px solid var(--navbar-border);
+}
+
+.nav-left h1 {
+        margin: 0;
+        font-size: 1.5rem;
+}
+
+.nav-title-link {
+        color: var(--accent-contrast);
+        text-decoration: none;
+}
+
+.nav-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+}
+
+.home-button {
+        color: var(--accent-contrast);
+        display: flex;
+        align-items: center;
+}
+
+.icon-home {
+        fill: currentColor;
+        width: 24px;
+        height: 24px;
+}
+
+.dropdown {
+        position: relative;
+        display: inline-block;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: var(--accent-contrast);
+        font-size: 1rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 2.4rem;
+        background: var(--panel-background);
+        border: 1px solid var(--accent-soft);
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+        min-width: 140px;
+        box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-logout {
+        background: none;
+        border: none;
+        color: var(--accent-contrast);
+        font-size: 0.95rem;
+        width: 100%;
+        text-align: left;
+        cursor: pointer;
+        padding: 0.4rem 0;
+}
+
+.dropdown-logout:hover {
+        color: var(--muted-color);
+}
+
+.dashboard-main {
+        padding: 2rem clamp(1rem, 4vw, 3rem);
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+}
+
+.device-header {
+        display: flex;
+        justify-content: space-between;
+        gap: 1.5rem;
+        flex-wrap: wrap;
+        align-items: flex-end;
+}
+
+.device-header h2 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(1.6rem, 3vw, 2.3rem);
+}
+
+.device-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        margin: 0;
+        color: var(--muted-color);
+}
+
+.device-meta span strong,
+.device-location span strong {
+        color: var(--accent-contrast);
+}
+
+.device-location {
+        display: flex;
+        gap: 1.25rem;
+        color: var(--muted-color);
+}
+
+.widgets-section {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1.5rem;
+}
+
+.panel {
+        background: var(--panel-background);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.25);
+        backdrop-filter: blur(10px);
+        border: 1px solid var(--panel-border);
+}
+
+.panel-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 1rem;
+        margin-bottom: 1.25rem;
+}
+
+.panel-header h3 {
+        margin: 0;
+        font-size: 1.2rem;
+}
+
+.panel-subtitle {
+        font-size: 0.9rem;
+        color: var(--muted-color);
+}
+
+.metrics-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.metric-card {
+        background: var(--card-background);
+        border-radius: 0.9rem;
+        padding: 1rem 1.2rem;
+        border: 1px solid var(--card-border);
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        min-height: 130px;
+}
+
+.metric-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 0.5rem;
+        color: var(--muted-color);
+        font-size: 0.9rem;
+}
+
+.metric-value {
+        font-size: clamp(1.6rem, 4vw, 2.4rem);
+        font-weight: 600;
+        color: var(--accent-contrast);
+}
+
+.metric-unit {
+        font-size: 0.95rem;
+        color: var(--muted-color);
+}
+
+.chart-panel {
+        position: relative;
+        min-height: 320px;
+}
+
+.chart-panel canvas {
+        width: 100% !important;
+        height: 100% !important;
+}
+
+.history-controls {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        color: var(--muted-color);
+        font-size: 0.9rem;
+}
+
+.history-controls select {
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid var(--accent-soft);
+        border-radius: 0.6rem;
+        color: var(--accent-contrast);
+        padding: 0.35rem 0.75rem;
+}
+
+.status-panel {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+
+.status-flags {
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.status-flag {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+        background: var(--status-background);
+        border-radius: 0.8rem;
+        padding: 0.75rem 1rem;
+        border: 1px solid var(--status-border);
+        color: var(--muted-color);
+        font-size: 0.9rem;
+}
+
+.status-flag .flag-key {
+        flex: 1 1 120px;
+        min-width: 0;
+}
+
+.flag-value {
+        font-weight: 600;
+        padding: 0.25rem 0.6rem;
+        border-radius: 0.6rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: auto;
+        max-width: 100%;
+        overflow-wrap: anywhere;
+}
+
+.flag-on {
+        background: rgba(102, 187, 106, 0.2);
+        color: #9ef5ad;
+}
+
+.flag-off {
+        background: rgba(239, 83, 80, 0.25);
+        color: #ffb3b0;
+}
+
+.flag-generic {
+        background: rgba(255, 255, 255, 0.12);
+        color: var(--accent-contrast);
+}
+
+.empty-state {
+        margin: 1rem 0 0;
+        color: var(--muted-color);
+        font-size: 0.95rem;
+        text-align: center;
+}
+
+.error-banner {
+        background: rgba(239, 83, 80, 0.15);
+        border-left: 4px solid #ef5350;
+        color: #ffb4b1;
+        margin: 1.5rem clamp(1rem, 4vw, 3rem) 0;
+        padding: 0.75rem 1rem;
+        border-radius: 0.6rem;
+}
+
+@media (max-width: 768px) {
+        .navbar {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 0.75rem;
+        }
+
+        .device-header {
+                align-items: flex-start;
+        }
+}
+

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org"
+<html lang="en" xmlns:th="http://www.thymeleaf.org"
       xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
 
 <head>
-        <title>Device dashboard</title>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="color-scheme" content="dark light" />
+        <title th:text="|${device.name} · Device dashboard|">Device dashboard</title>
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
         <link rel="stylesheet" th:href="@{/css/deviceDashboard.css}" />
         <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"
@@ -14,7 +15,7 @@
 </head>
 
 <body th:class="'dashboard-body theme-' + ${projectKey}" th:attr="data-theme=${projectKey}">
-        <header class="navbar">
+        <header class="navbar" role="banner">
                 <div class="nav-left">
                         <h1>
                                 <a th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link" th:text="${project.name}">Project</a>
@@ -43,17 +44,22 @@
                 </div>
         </header>
 
-        <div id="dashboard-error" class="error-banner" hidden></div>
+        <div id="dashboard-error" class="error-banner" role="alert" hidden></div>
 
         <main class="dashboard-main">
                 <section class="device-header">
-                        <div>
+                        <div class="device-summary">
                                 <h2 th:text="${device.name}">Device name</h2>
                                 <p class="device-meta">
                                         <span>MAC: <strong th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">--</strong></span>
                                         <span th:if="${device.tod != null}">Type: <strong th:text="${device.tod.name}">Type</strong></span>
-                                        <span>Status: <strong th:text="${device.status}">--</strong></span>
                                 </p>
+                                <div class="device-tags" th:if="${device.status != null}">
+                                        <span class="status-chip" th:attr="data-state=${device.status}">
+                                                <span class="chip-label">Status</span>
+                                                <span class="chip-value" th:text="${device.status}">--</span>
+                                        </span>
+                                </div>
                         </div>
                         <div class="device-location" th:if="${device.latitude != null && device.longitude != null}">
                                 <span>Lat: <strong th:text="${#numbers.formatDecimal(device.latitude, 1, 6)}">0</strong></span>
@@ -83,7 +89,7 @@
                                                 </select>
                                         </div>
                                 </div>
-                                <canvas id="metrics-chart" aria-label="Telemetria" role="img"></canvas>
+                                <canvas id="metrics-chart" aria-label="Telemetry chart" role="img"></canvas>
                                 <p id="chart-empty" class="empty-state">No telemetry received yet.</p>
                         </div>
                 </section>

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -1,0 +1,612 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6">
+
+<head>
+        <title>Device dashboard</title>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet" />
+        <link rel="stylesheet" th:href="@{/css/deviceDashboard.css}" />
+        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"
+                integrity="sha384-+vBx/6CMEpcIbVKxH/TSGBBWp4kqBmDp2snmqP0oM2fw1kYfSbcFFZsB5uB7wA1S"
+                crossorigin="anonymous"></script>
+</head>
+
+<body th:class="'dashboard-body theme-' + ${projectKey}" th:attr="data-theme=${projectKey}">
+        <header class="navbar">
+                <div class="nav-left">
+                        <h1>
+                                <a th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link" th:text="${project.name}">Project</a>
+                        </h1>
+                </div>
+                <div class="nav-right">
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"
+                                                fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
+                        <a href="/" class="home-button" title="Homepage">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
+                                        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+                                </svg>
+                        </a>
+                </div>
+        </header>
+
+        <div id="dashboard-error" class="error-banner" hidden></div>
+
+        <main class="dashboard-main">
+                <section class="device-header">
+                        <div>
+                                <h2 th:text="${device.name}">Device name</h2>
+                                <p class="device-meta">
+                                        <span>MAC: <strong th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">--</strong></span>
+                                        <span th:if="${device.tod != null}">Type: <strong th:text="${device.tod.name}">Type</strong></span>
+                                        <span>Status: <strong th:text="${device.status}">--</strong></span>
+                                </p>
+                        </div>
+                        <div class="device-location" th:if="${device.latitude != null && device.longitude != null}">
+                                <span>Lat: <strong th:text="${#numbers.formatDecimal(device.latitude, 1, 6)}">0</strong></span>
+                                <span>Lng: <strong th:text="${#numbers.formatDecimal(device.longitude, 1, 6)}">0</strong></span>
+                        </div>
+                </section>
+
+                <section class="widgets-section">
+                        <div class="panel metrics-panel">
+                                <div class="panel-header">
+                                        <h3>Latest measurements</h3>
+                                        <span class="panel-subtitle">Last update: <span id="last-update">--</span></span>
+                                </div>
+                                <div id="metrics-grid" class="metrics-grid"></div>
+                                <p id="metrics-empty" class="empty-state">No measurement specs available for this device.</p>
+                        </div>
+
+                        <div class="panel chart-panel">
+                                <div class="panel-header">
+                                        <h3>Trend</h3>
+                                        <div class="history-controls">
+                                                <label for="history-window">Window</label>
+                                                <select id="history-window">
+                                                        <option value="30">30 samples</option>
+                                                        <option value="60" selected>60 samples</option>
+                                                        <option value="120">120 samples</option>
+                                                </select>
+                                        </div>
+                                </div>
+                                <canvas id="metrics-chart" aria-label="Telemetria" role="img"></canvas>
+                                <p id="chart-empty" class="empty-state">No telemetry received yet.</p>
+                        </div>
+                </section>
+
+                <section class="panel status-panel">
+                        <div class="panel-header">
+                                <h3>Status indicators</h3>
+                                <span class="panel-subtitle">Control bits and diagnostics</span>
+                        </div>
+                        <div id="status-flags" class="status-flags"></div>
+                        <p id="status-empty" class="empty-state">No diagnostics were provided in the latest packet.</p>
+                </section>
+        </main>
+
+        <script th:inline="javascript">
+                /*<![CDATA[*/
+                const DEVICE_MAC = /*[[${device.macAddress}]]*/ '';
+                const PROJECT_ID = /*[[${project.id}]]*/ 0;
+                const DEVICE_NAME = /*[[${device.name}]]*/ '';
+                const PROJECT_KEY = /*[[${projectKey}]]*/ 'default';
+                /*]]>*/
+        </script>
+
+        <script>
+                const state = {
+                        specDescriptors: [],
+                        specCardsRendered: false,
+                        metricKeyBySpecId: new Map(),
+                        chart: null,
+                        historyLimit: 60,
+                        lastSamples: [],
+                        latestTimestamp: null
+                };
+
+                const palettes = {
+                        'ltrad': ['#007bff', '#8ec5ff', '#d6e8ff'],
+                        'fire': ['#cc0000', '#ff6666', '#ffd6d6'],
+                        'volcano': ['#e67e00', '#ff9f1c', '#ffd670'],
+                        'default': ['#2d6cdf', '#4c9f70', '#dd6b20']
+                };
+
+                function readCssVariable(name, fallback) {
+                        const raw = getComputedStyle(document.body).getPropertyValue(name);
+                        if (raw && raw.trim().length) {
+                                return raw.trim();
+                        }
+                        return fallback;
+                }
+
+                document.addEventListener('DOMContentLoaded', () => {
+                        setupDropdown();
+                        initializeDashboard().catch(error => showError(error.message));
+                        const historySelect = document.getElementById('history-window');
+                        historySelect.addEventListener('change', async (event) => {
+                                state.historyLimit = parseInt(event.target.value, 10);
+                                await loadHistory();
+                        });
+                        setInterval(refreshLatestSample, 15000);
+                });
+
+                function setupDropdown() {
+                        const toggle = document.getElementById('userDropdown');
+                        const menu = document.getElementById('userDropdownMenu');
+                        if (!toggle || !menu) {
+                                return;
+                        }
+                        toggle.addEventListener('click', function (e) {
+                                e.stopPropagation();
+                                menu.classList.toggle('show');
+                        });
+                        document.addEventListener('click', function (e) {
+                                if (!toggle.contains(e.target)) {
+                                        menu.classList.remove('show');
+                                }
+                        });
+                }
+
+                async function initializeDashboard() {
+                        await loadSpecs();
+                        await loadHistory();
+                }
+
+                async function loadSpecs() {
+                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_MAC)}/specs`);
+                        if (response.status === 403) {
+                                throw new Error('Non sei autorizzato a visualizzare questo dispositivo.');
+                        }
+                        if (!response.ok) {
+                                throw new Error('Unable to load device specs.');
+                        }
+                        const specs = await response.json();
+                        state.specDescriptors = Array.isArray(specs) ? specs.map((spec, index) => buildDescriptorFromSpec(spec, index)) : [];
+                }
+
+                async function loadHistory() {
+                        clearError();
+                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_MAC)}/telemetry/history?limit=${state.historyLimit}`);
+                        if (response.status === 403) {
+                                throw new Error('Non sei autorizzato a visualizzare questo dispositivo.');
+                        }
+                        if (!response.ok) {
+                                throw new Error('Unable to load telemetry history.');
+                        }
+                        const samples = await response.json();
+                        state.lastSamples = Array.isArray(samples) ? samples : [];
+
+                        const metricsGrid = document.getElementById('metrics-grid');
+                        const metricsEmpty = document.getElementById('metrics-empty');
+                        const chartEmpty = document.getElementById('chart-empty');
+
+                        if (!state.lastSamples.length) {
+                                metricsGrid.innerHTML = '';
+                                metricsEmpty.hidden = false;
+                                chartEmpty.hidden = false;
+                                resetChart();
+                                updateStatusFlags({}, new Set());
+                                document.getElementById('last-update').textContent = '--';
+                                return;
+                        }
+
+                        if (!state.specDescriptors.length) {
+                                const fallback = buildDescriptorsFromMetrics(state.lastSamples[state.lastSamples.length - 1]);
+                                state.specDescriptors = fallback;
+                        }
+
+                        if (!state.specDescriptors.length) {
+                                metricsGrid.innerHTML = '';
+                                metricsEmpty.hidden = false;
+                        } else if (!state.specCardsRendered) {
+                                renderMetricCards();
+                                metricsEmpty.hidden = true;
+                        }
+
+                        resolveMetricKeys(state.lastSamples);
+                        const latestSample = state.lastSamples[state.lastSamples.length - 1];
+                        updateFromSample(latestSample);
+                        buildOrUpdateChart(state.lastSamples);
+                        chartEmpty.hidden = state.chart !== null;
+                }
+
+                async function refreshLatestSample() {
+                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_MAC)}/telemetry/latest`);
+                        if (response.status === 403) {
+                                showError('Non sei autorizzato a visualizzare questo dispositivo.');
+                                return;
+                        }
+                        if (response.status === 204) {
+                                return;
+                        }
+                        if (!response.ok) {
+                                showError('Unable to refresh the latest sample.');
+                                return;
+                        }
+                        const sample = await response.json();
+                        if (!sample || !sample.metrics) {
+                                return;
+                        }
+                        if (state.latestTimestamp && state.latestTimestamp === sample.timestamp) {
+                                return;
+                        }
+                        state.lastSamples.push(sample);
+                        if (state.lastSamples.length > state.historyLimit) {
+                                state.lastSamples.splice(0, state.lastSamples.length - state.historyLimit);
+                        }
+                        resolveMetricKeys([sample]);
+                        updateFromSample(sample);
+                        buildOrUpdateChart(state.lastSamples);
+                }
+
+                function renderMetricCards() {
+                        const container = document.getElementById('metrics-grid');
+                        container.innerHTML = '';
+                        state.specDescriptors.forEach(descriptor => {
+                                const card = document.createElement('div');
+                                card.className = 'metric-card';
+                                card.dataset.specId = descriptor.id;
+                                card.innerHTML = `
+                                        <div class="metric-header">
+                                                <span class="metric-name">${descriptor.measurement}</span>
+                                                ${descriptor.component ? `<span class="metric-component">${descriptor.component}</span>` : ''}
+                                        </div>
+                                        <div class="metric-value" data-value>--</div>
+                                        <div class="metric-unit">${descriptor.unit ?? ''}</div>
+                                `;
+                                container.appendChild(card);
+                        });
+                        state.specCardsRendered = true;
+                }
+
+                function updateFromSample(sample) {
+                        if (!sample || !sample.metrics) {
+                                return;
+                        }
+                        const matchedKeys = updateMetricCards(sample.metrics);
+                        updateStatusFlags(sample.metrics, matchedKeys);
+                        updateTimestamp(sample.timestamp);
+                }
+
+                function updateMetricCards(metrics) {
+                        const matchedKeys = new Set();
+                        state.specDescriptors.forEach(descriptor => {
+                                const card = document.querySelector(`.metric-card[data-spec-id="${descriptor.id}"]`);
+                                if (!card) {
+                                        return;
+                                }
+                                let metricKey = state.metricKeyBySpecId.get(descriptor.id);
+                                if (!metricKey) {
+                                        metricKey = findMetricKey(descriptor, metrics);
+                                        if (metricKey) {
+                                                state.metricKeyBySpecId.set(descriptor.id, metricKey);
+                                        }
+                                }
+                                const valueEl = card.querySelector('[data-value]');
+                                if (!metricKey || !(metricKey in metrics)) {
+                                        valueEl.textContent = '--';
+                                        return;
+                                }
+                                matchedKeys.add(metricKey);
+                                const rawValue = metrics[metricKey];
+                                valueEl.textContent = formatValue(rawValue);
+                        });
+                        return matchedKeys;
+                }
+
+                function updateStatusFlags(metrics, matchedKeys) {
+                        const container = document.getElementById('status-flags');
+                        const emptyState = document.getElementById('status-empty');
+                        container.innerHTML = '';
+
+                        if (!metrics) {
+                                emptyState.hidden = false;
+                                return;
+                        }
+
+                        const entries = Object.entries(metrics).filter(([key]) => !matchedKeys.has(key));
+
+                        if (!entries.length) {
+                                emptyState.hidden = false;
+                                return;
+                        }
+
+                        emptyState.hidden = true;
+                        entries.forEach(([key, value]) => {
+                                const flag = document.createElement('div');
+                                flag.className = 'status-flag';
+                                const numeric = toNumber(value);
+                                const isBinary = typeof value === 'boolean' || numeric === 0 || numeric === 1;
+                                const isOn = typeof value === 'boolean' ? value : numeric === 1;
+                                const valueClass = isBinary ? (isOn ? 'flag-on' : 'flag-off') : 'flag-generic';
+                                const normalizedValue = formatStatus(value);
+                                flag.innerHTML = `
+                                        <span class="flag-key">${prettifyKey(key)}</span>
+                                        <span class="flag-value ${valueClass}">${normalizedValue}</span>
+                                `;
+                                container.appendChild(flag);
+                        });
+                }
+
+                function buildOrUpdateChart(samples) {
+                        if (!samples.length) {
+                                resetChart();
+                                return;
+                        }
+                        const labels = samples.map(sample => formatTimestamp(sample.timestamp, true));
+                        const datasets = buildDatasets(samples);
+                        const axisColor = readCssVariable('--muted-color', '#dde1f2');
+                        const gridColor = readCssVariable('--chart-grid', 'rgba(255, 255, 255, 0.1)');
+                        const legendColor = readCssVariable('--accent-contrast', '#ffffff');
+                        if (!datasets.length) {
+                                resetChart();
+                                return;
+                        }
+                        if (!state.chart) {
+                                const ctx = document.getElementById('metrics-chart').getContext('2d');
+                                state.chart = new Chart(ctx, {
+                                        type: 'line',
+                                        data: { labels, datasets },
+                                        options: {
+                                                responsive: true,
+                                                maintainAspectRatio: false,
+                                                interaction: { mode: 'index', intersect: false },
+                                                plugins: {
+                                                        legend: { labels: { color: legendColor } },
+                                                        tooltip: {
+                                                                callbacks: {
+                                                                        label: (context) => `${context.dataset.label}: ${formatValue(context.parsed.y)}`
+                                                                }
+                                                        }
+                                                },
+                                                scales: {
+                                                        x: { ticks: { color: axisColor }, grid: { color: gridColor } },
+                                                        y: { ticks: { color: axisColor }, grid: { color: gridColor } }
+                                                }
+                                        }
+                                });
+                        } else {
+                                state.chart.data.labels = labels;
+                                state.chart.data.datasets = datasets;
+                                state.chart.options.plugins.legend.labels.color = legendColor;
+                                state.chart.options.scales.x.ticks.color = axisColor;
+                                state.chart.options.scales.x.grid.color = gridColor;
+                                state.chart.options.scales.y.ticks.color = axisColor;
+                                state.chart.options.scales.y.grid.color = gridColor;
+                                state.chart.update('none');
+                        }
+                        document.getElementById('chart-empty').hidden = true;
+                }
+
+                function resetChart() {
+                        if (state.chart) {
+                                state.chart.destroy();
+                                state.chart = null;
+                        }
+                        document.getElementById('chart-empty').hidden = false;
+                }
+
+                function buildDatasets(samples) {
+                        const theme = (PROJECT_KEY && palettes[PROJECT_KEY]) ? PROJECT_KEY : 'default';
+                        const palette = palettes[theme];
+                        const descriptors = state.specDescriptors.filter(descriptor => state.metricKeyBySpecId.get(descriptor.id));
+                        let colorIndex = 0;
+                        return descriptors.map(descriptor => {
+                                const metricKey = state.metricKeyBySpecId.get(descriptor.id);
+                                const values = samples.map(sample => toNumber(sample.metrics?.[metricKey]));
+                                if (values.every(value => value === null)) {
+                                        return null;
+                                }
+                                const color = palette[colorIndex % palette.length];
+                                colorIndex += 1;
+                                return {
+                                        label: descriptor.unit ? `${descriptor.measurement} (${descriptor.unit})` : descriptor.measurement,
+                                        data: values,
+                                        borderColor: color,
+                                        backgroundColor: color + '33',
+                                        spanGaps: true,
+                                        tension: 0.3
+                                };
+                        }).filter(Boolean);
+                }
+
+                function resolveMetricKeys(samples) {
+                        samples.forEach(sample => {
+                                if (!sample || !sample.metrics) {
+                                        return;
+                                }
+                                state.specDescriptors.forEach(descriptor => {
+                                        if (state.metricKeyBySpecId.get(descriptor.id)) {
+                                                return;
+                                        }
+                                        const key = findMetricKey(descriptor, sample.metrics);
+                                        if (key) {
+                                                state.metricKeyBySpecId.set(descriptor.id, key);
+                                        }
+                                });
+                        });
+                }
+
+                function findMetricKey(descriptor, metrics) {
+                        if (!metrics) {
+                                return null;
+                        }
+                        const entries = Object.entries(metrics);
+                        for (const [key, value] of entries) {
+                                const normalizedKey = normalizeKey(key);
+                                if (!normalizedKey) {
+                                        continue;
+                                }
+                                const numericValue = toNumber(value);
+                                if (numericValue === null) {
+                                        continue;
+                                }
+                                if (descriptor.normalizedKeys.some(candidate =>
+                                        candidate && (normalizedKey === candidate || normalizedKey.includes(candidate) || candidate.includes(normalizedKey)))) {
+                                        return key;
+                                }
+                        }
+                        return null;
+                }
+
+                function buildDescriptorFromSpec(spec, index) {
+                        const measurement = spec?.measurement ?? `Metric ${index + 1}`;
+                        const unit = spec?.unitOfMeasurement ?? '';
+                        const component = spec?.component ?? '';
+                        return {
+                                id: `spec-${index}-${normalizeKey(measurement + component)}`,
+                                measurement,
+                                unit,
+                                component,
+                                normalizedKeys: buildCandidateKeys(measurement)
+                        };
+                }
+
+                function buildDescriptorsFromMetrics(sample) {
+                        if (!sample || !sample.metrics) {
+                                return [];
+                        }
+                        return Object.entries(sample.metrics)
+                                .filter(([key, value]) => toNumber(value) !== null)
+                                .map(([key]) => ({
+                                        id: `auto-${normalizeKey(key)}`,
+                                        measurement: prettifyKey(key),
+                                        unit: '',
+                                        component: '',
+                                        normalizedKeys: [normalizeKey(key)]
+                                }));
+                }
+
+                function buildCandidateKeys(measurement) {
+                        const candidates = new Set();
+                        const base = measurement ? measurement.toString() : '';
+                        const normalized = normalizeKey(base);
+                        if (normalized) {
+                                candidates.add(normalized);
+                        }
+                        const noSpaces = normalizeKey(base.replace(/\s+/g, ''));
+                        if (noSpaces) {
+                                candidates.add(noSpaces);
+                        }
+                        const decimalAlt = normalizeKey(base.replace(/\./g, ''));
+                        if (decimalAlt) {
+                                candidates.add(decimalAlt);
+                        }
+                        const decimalP = normalizeKey(base.replace(/\./g, 'p'));
+                        if (decimalP) {
+                                candidates.add(decimalP);
+                        }
+                        const percentLess = normalizeKey(base.replace(/%/g, ''));
+                        if (percentLess) {
+                                candidates.add(percentLess);
+                        }
+                        base.split(/\s+/).forEach(part => {
+                                const normalizedPart = normalizeKey(part);
+                                if (normalizedPart) {
+                                        candidates.add(normalizedPart);
+                                }
+                        });
+                        return Array.from(candidates);
+                }
+
+                function normalizeKey(value) {
+                        if (!value && value !== 0) {
+                                return '';
+                        }
+                        return value.toString().toLowerCase().replace(/[^a-z0-9]/g, '');
+                }
+
+                function prettifyKey(key) {
+                        if (!key) {
+                                return '';
+                        }
+                        return key
+                                .replace(/_/g, ' ')
+                                .replace(/([a-z])([A-Z])/g, '$1 $2')
+                                .replace(/\s+/g, ' ')
+                                .trim()
+                                .replace(/^./, c => c.toUpperCase());
+                }
+
+                function toNumber(value) {
+                        if (typeof value === 'number' && Number.isFinite(value)) {
+                                return value;
+                        }
+                        const parsed = Number(value);
+                        return Number.isFinite(parsed) ? parsed : null;
+                }
+
+                function formatValue(value) {
+                        const numeric = toNumber(value);
+                        if (numeric === null) {
+                                return value === null || value === undefined ? '--' : String(value);
+                        }
+                        return Math.abs(numeric) >= 100 ? numeric.toFixed(0) : numeric.toFixed(2).replace(/\.00$/, '');
+                }
+
+                function formatStatus(value) {
+                        if (typeof value === 'boolean') {
+                                return value ? 'ON' : 'OFF';
+                        }
+                        if (value === null || value === undefined) {
+                                return '--';
+                        }
+                        const numeric = toNumber(value);
+                        if (numeric === 1) {
+                                return 'ON';
+                        }
+                        if (numeric === 0) {
+                                return 'OFF';
+                        }
+                        if (numeric !== null) {
+                                return formatValue(numeric);
+                        }
+                        return String(value);
+                }
+
+                function updateTimestamp(timestamp) {
+                        state.latestTimestamp = timestamp;
+                        document.getElementById('last-update').textContent = formatTimestamp(timestamp, false);
+                }
+
+                function formatTimestamp(timestamp, short) {
+                        if (!timestamp) {
+                                return '--';
+                        }
+                        const date = new Date(timestamp);
+                        if (Number.isNaN(date.getTime())) {
+                                return '--';
+                        }
+                        const options = short ? { hour: '2-digit', minute: '2-digit', second: '2-digit' } : { dateStyle: 'short', timeStyle: 'medium' };
+                        return new Intl.DateTimeFormat(undefined, options).format(date);
+                }
+
+                function showError(message) {
+                        const banner = document.getElementById('dashboard-error');
+                        banner.textContent = message;
+                        banner.hidden = false;
+                }
+
+                function clearError() {
+                        const banner = document.getElementById('dashboard-error');
+                        banner.hidden = true;
+                }
+        </script>
+</body>
+
+</html>
+

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -200,6 +200,7 @@
 
 	<script th:inline="javascript">
 		/*<![CDATA[*/
+                const PROJECT_ID = /*[[${project.id}]]*/ 0;
                 let initialDevices = [[${devices}]];
                 initialDevices = initialDevices.filter(d => d.latitude != null && d.longitude != null);
                 /*]]>*/
@@ -235,6 +236,10 @@
                         marker.bindPopup(popupContent);
                         marker.on("mouseover", function () {this.openPopup();});
                         marker.on("mouseout", function () {this.closePopup();});
+                        marker.on("click", function () {
+                                const destination = `/admin/device-dashboard/${PROJECT_ID}/${encodeURIComponent(d.macAddress)}`;
+                                window.location.href = destination;
+                        });
 
                         markerByMac.set(d.macAddress, marker);
                 });
@@ -305,8 +310,7 @@
 
 	<script th:inline="javascript">
 		/*<![CDATA[*/
-		document.addEventListener('DOMContentLoaded', function () {
-			const PROJECT_ID = /*[[${project.id}]]*/ 0;
+                document.addEventListener('DOMContentLoaded', function () {
 
                         const LIST_OP_URL = `/api/projects/${PROJECT_ID}/operators`;
                         const ASSIGN_OP_URL = ({mac, opId}) =>


### PR DESCRIPTION
## Summary
- guard the group and operator device filtering logic against null device names and mac addresses
- sort device DTOs using a safe label that falls back to the mac address when the name is missing
- align the new device dashboard with the project-specific colour palettes and keep long status values (like MAC addresses) inside their badges

## Testing
- ./mvnw -q test *(fails: unable to download Maven binaries because of network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c92068a4bc83238b1aa09f43e86224