### PR TITLE
Refine dashboard to surface ranged specs and SEN55 indicators

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/DeviceTelemetryController.java
+++ b/src/main/java/it/sensorplatform/controller/rest/DeviceTelemetryController.java
@@ -56,14 +56,17 @@ public class DeviceTelemetryController {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        Device device = deviceOpt.get();
-        if (device.getTod() == null || device.getTod().getSpecs() == null) {
+        String normalizedMac = MacAddressUtils.normalize(macAddress);
+        if (normalizedMac == null) {
             return ResponseEntity.ok(Collections.emptyList());
         }
-
-        List<SpecDTO> specs = device.getTod().getSpecs().stream()
-                .filter(Objects::nonNull)
-                .map(SpecDTO::fromSpec)
+        List<IngestService.Sample> samples = ingestService.last(normalizedMac, 1);
+        if (samples.isEmpty()) {
+            return ResponseEntity.ok(Collections.emptyList());
+        }
+        IngestService.Sample sample = samples.get(samples.size() - 1);
+        List<SpecDTO> specs = sample.measurements().stream()
+                .map(SpecDTO::fromMeasurement)
                 .collect(Collectors.toList());
         return ResponseEntity.ok(specs);
     }

--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -1,5 +1,6 @@
 package it.sensorplatform.controller.rest;
 
+import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.dto.UnknownDeviceNotification;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.model.Project;
@@ -65,8 +66,11 @@ public class NotificationControllerRest {
             tod.setName(notif.getTypeOfDevice());
             List<Spec> specs = new ArrayList<>();
             if (notif.getSpec() != null) {
-                for (String specEntry : notif.getSpec()) {
-                    String[] parts = specEntry.split("-");
+                for (PacketDTO.SpecEntry specEntry : notif.getSpec()) {
+                    if (specEntry == null || specEntry.getLabel() == null) {
+                        continue;
+                    }
+                    String[] parts = specEntry.getLabel().split("-");
                     Spec spec = new Spec();
                     spec.setComponent(parts.length > 0 ? parts[0] : "");
                     spec.setMeasurement(parts.length > 1 ? parts[1] : "");

--- a/src/main/java/it/sensorplatform/dto/PacketDTO.java
+++ b/src/main/java/it/sensorplatform/dto/PacketDTO.java
@@ -17,7 +17,8 @@ public class PacketDTO {
     private Double latitude;
     private Double longitude;
     private Map<String, Object> payload;
-    private List<String> spec;
+    private List<SpecEntry> spec;
+    private List<String> indicator;
 
     public String getMacAddress() {
         return macAddress;
@@ -83,12 +84,50 @@ public class PacketDTO {
         this.payload = payload;
     }
 
-    public List<String> getSpec() {
+    public List<SpecEntry> getSpec() {
         return spec;
     }
 
-    public void setSpec(List<String> spec) {
+    public void setSpec(List<SpecEntry> spec) {
         this.spec = spec;
+    }
+
+    public List<String> getIndicator() {
+        return indicator;
+    }
+
+    public void setIndicator(List<String> indicator) {
+        this.indicator = indicator;
+    }
+
+    public static class SpecEntry {
+        private String label;
+        private Double min;
+        private Double max;
+
+        public String getLabel() {
+            return label;
+        }
+
+        public void setLabel(String label) {
+            this.label = label;
+        }
+
+        public Double getMin() {
+            return min;
+        }
+
+        public void setMin(Double min) {
+            this.min = min;
+        }
+
+        public Double getMax() {
+            return max;
+        }
+
+        public void setMax(Double max) {
+            this.max = max;
+        }
     }
 }
 

--- a/src/main/java/it/sensorplatform/dto/SpecDTO.java
+++ b/src/main/java/it/sensorplatform/dto/SpecDTO.java
@@ -1,14 +1,25 @@
 package it.sensorplatform.dto;
 
-import it.sensorplatform.model.Spec;
+import it.sensorplatform.service.IngestService;
 
-public record SpecDTO(String measurement, String unitOfMeasurement, String component) {
+public record SpecDTO(String key,
+                      String label,
+                      String displayName,
+                      String unit,
+                      Double min,
+                      Double max) {
 
-    public static SpecDTO fromSpec(Spec spec) {
-        if (spec == null) {
-            return new SpecDTO(null, null, null);
+    public static SpecDTO fromMeasurement(IngestService.MeasurementSample measurement) {
+        if (measurement == null) {
+            return new SpecDTO(null, null, null, null, null, null);
         }
-        return new SpecDTO(spec.getMeasurement(), spec.getUnitOfMeasurement(), spec.getComponent());
+        return new SpecDTO(
+                measurement.key(),
+                measurement.label(),
+                measurement.displayName(),
+                measurement.unit(),
+                measurement.min(),
+                measurement.max()
+        );
     }
 }
-

--- a/src/main/java/it/sensorplatform/dto/TelemetrySampleDTO.java
+++ b/src/main/java/it/sensorplatform/dto/TelemetrySampleDTO.java
@@ -1,17 +1,54 @@
 package it.sensorplatform.dto;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import it.sensorplatform.service.IngestService;
 
-public record TelemetrySampleDTO(Instant timestamp, Map<String, Object> metrics) {
+public record TelemetrySampleDTO(Instant timestamp,
+                                 List<MeasurementDTO> measurements,
+                                 List<IndicatorDTO> indicators,
+                                 Map<String, Object> info) {
 
     public static TelemetrySampleDTO fromSample(IngestService.Sample sample) {
         if (sample == null) {
             return null;
         }
-        return new TelemetrySampleDTO(sample.ts, sample.metrics);
+        List<MeasurementDTO> measurementDTOs = sample.measurements().stream()
+                .map(MeasurementDTO::fromMeasurement)
+                .collect(Collectors.toList());
+        List<IndicatorDTO> indicatorDTOs = sample.indicators().stream()
+                .map(IndicatorDTO::fromIndicator)
+                .collect(Collectors.toList());
+        return new TelemetrySampleDTO(sample.ts(), measurementDTOs, indicatorDTOs, sample.info());
+    }
+
+    public record MeasurementDTO(String key,
+                                 String label,
+                                 String displayName,
+                                 String unit,
+                                 Double min,
+                                 Double max,
+                                 Double value) {
+
+        private static MeasurementDTO fromMeasurement(IngestService.MeasurementSample measurement) {
+            return new MeasurementDTO(
+                    measurement.key(),
+                    measurement.label(),
+                    measurement.displayName(),
+                    measurement.unit(),
+                    measurement.min(),
+                    measurement.max(),
+                    measurement.value()
+            );
+        }
+    }
+
+    public record IndicatorDTO(String key, String label, Integer value) {
+        private static IndicatorDTO fromIndicator(IngestService.IndicatorSample indicator) {
+            return new IndicatorDTO(indicator.key(), indicator.label(), indicator.value());
+        }
     }
 }
-

--- a/src/main/java/it/sensorplatform/dto/UnknownDeviceNotification.java
+++ b/src/main/java/it/sensorplatform/dto/UnknownDeviceNotification.java
@@ -11,7 +11,8 @@ public class UnknownDeviceNotification {
     private Long projectId;
     private String typeOfDevice;
     private Map<String, Object> payload;
-    private List<String> spec;
+    private List<PacketDTO.SpecEntry> spec;
+    private List<String> indicator;
     private Instant timestamp;
 
     public UnknownDeviceNotification(String key,
@@ -20,7 +21,8 @@ public class UnknownDeviceNotification {
                                      Long projectId,
                                      String typeOfDevice,
                                      Map<String, Object> payload,
-                                     List<String> spec,
+                                     List<PacketDTO.SpecEntry> spec,
+                                     List<String> indicator,
                                      Instant timestamp) {
         this.key = key;
         this.macAddress = macAddress;
@@ -29,6 +31,7 @@ public class UnknownDeviceNotification {
         this.typeOfDevice = typeOfDevice;
         this.payload = payload;
         this.spec = spec;
+        this.indicator = indicator;
         this.timestamp = timestamp;
     }
 
@@ -38,6 +41,7 @@ public class UnknownDeviceNotification {
     public Long getProjectId() { return projectId; }
     public String getTypeOfDevice() { return typeOfDevice; }
     public Map<String, Object> getPayload() { return payload; }
-    public List<String> getSpec() { return spec; }
+    public List<PacketDTO.SpecEntry> getSpec() { return spec; }
+    public List<String> getIndicator() { return indicator; }
     public Instant getTimestamp() { return timestamp; }
 }

--- a/src/main/java/it/sensorplatform/service/IngestService.java
+++ b/src/main/java/it/sensorplatform/service/IngestService.java
@@ -3,7 +3,16 @@ package it.sensorplatform.service;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -16,23 +25,100 @@ import java.util.concurrent.ConcurrentHashMap;
 public class IngestService {
 
     /** Record di un singolo campione ricevuto */
-    public static class Sample {
-        public final String deviceId;
-        public final String devEui;
-        public final Instant ts;
-        public final Map<String, Object> metrics;
+    public static record Sample(String deviceId,
+                                String devEui,
+                                Instant ts,
+                                List<MeasurementSample> measurements,
+                                List<IndicatorSample> indicators,
+                                Map<String, Object> info) { }
 
-        public Sample(String deviceId, String devEui, Instant ts, Map<String, Object> metrics) {
-            this.deviceId = deviceId;
-            this.devEui = devEui;
-            this.ts = ts;
-            this.metrics = metrics != null ? Map.copyOf(metrics) : Map.of();
-        }
-    }
+    public static record MeasurementSample(String key,
+                                           String label,
+                                           String displayName,
+                                           String unit,
+                                           Double min,
+                                           Double max,
+                                           Double value) { }
+
+    public static record IndicatorSample(String key,
+                                         String label,
+                                         Integer value) { }
 
     /** Ultimi N campioni per device (buffer circolare) */
     private final Map<String, Deque<Sample>> store = new ConcurrentHashMap<>();
     private static final int MAX_SAMPLES_PER_DEVICE = 200;
+
+    private static final List<String> SPEC_KEYS = List.of(
+            "co2_ppm",
+            "pm1p0",
+            "pm2p5",
+            "pm4p0",
+            "pm10p0",
+            "vocIndex",
+            "noxIndex",
+            "bmeT",
+            "bmeRH",
+            "bmeP",
+            "bmeGas",
+            "icmTemp",
+            "icmAccX",
+            "icmAccY",
+            "icmAccZ",
+            "icmGyrX",
+            "icmGyrY",
+            "icmGyrZ"
+    );
+
+    private static final List<String> INDICATOR_KEYS = List.of(
+            "sen55_fan_err",
+            "sen55_speed_warn",
+            "sen55_laser_err",
+            "sen55_rht_err",
+            "sen55_gas_err",
+            "sen55_cleaning"
+    );
+
+    private static final Map<String, MeasurementMetadata> MEASUREMENT_METADATA = Map.ofEntries(
+            Map.entry("co2_ppm", new MeasurementMetadata("CO₂", "ppm")),
+            Map.entry("pm1p0", new MeasurementMetadata("PM1.0", "µg/m³")),
+            Map.entry("pm2p5", new MeasurementMetadata("PM2.5", "µg/m³")),
+            Map.entry("pm4p0", new MeasurementMetadata("PM4.0", "µg/m³")),
+            Map.entry("pm10p0", new MeasurementMetadata("PM10", "µg/m³")),
+            Map.entry("vocIndex", new MeasurementMetadata("VOC Index", "index")),
+            Map.entry("noxIndex", new MeasurementMetadata("NOx Index", "index")),
+            Map.entry("bmeT", new MeasurementMetadata("BME680 Temperature", "°C")),
+            Map.entry("bmeRH", new MeasurementMetadata("BME680 Humidity", "%")),
+            Map.entry("bmeP", new MeasurementMetadata("BME680 Pressure", "Pa")),
+            Map.entry("bmeGas", new MeasurementMetadata("BME680 Gas", "Ω")),
+            Map.entry("icmTemp", new MeasurementMetadata("ICM-20948 Temperature", "°C")),
+            Map.entry("icmAccX", new MeasurementMetadata("ICM-20948 AccX", "g")),
+            Map.entry("icmAccY", new MeasurementMetadata("ICM-20948 AccY", "g")),
+            Map.entry("icmAccZ", new MeasurementMetadata("ICM-20948 AccZ", "g")),
+            Map.entry("icmGyrX", new MeasurementMetadata("ICM-20948 GyrX", "°/s")),
+            Map.entry("icmGyrY", new MeasurementMetadata("ICM-20948 GyrY", "°/s")),
+            Map.entry("icmGyrZ", new MeasurementMetadata("ICM-20948 GyrZ", "°/s"))
+    );
+
+    private static final Map<String, String> INDICATOR_LABELS = Map.of(
+            "sen55_fan_err", "SEN55 Fan Error",
+            "sen55_speed_warn", "SEN55 Speed Warning",
+            "sen55_laser_err", "SEN55 Laser Error",
+            "sen55_rht_err", "SEN55 RHT Error",
+            "sen55_gas_err", "SEN55 Gas Error",
+            "sen55_cleaning", "SEN55 Cleaning"
+    );
+
+    private static final Set<String> INFO_KEYS = Set.of(
+            "currentDate",
+            "currentTime",
+            "macAddress",
+            "bat_V",
+            "bat_pct",
+            "latitude",
+            "longitude"
+    );
+
+    private record MeasurementMetadata(String displayName, String unit) { }
 
     /**
      * Normalizza e memorizza un pacchetto ricevuto.
@@ -41,7 +127,12 @@ public class IngestService {
      * @param ts       istante della misura (UTC)
      * @param metrics  mappa chiave=tipo misura, valore=numero (es. temp, hum, pm2p5)
      */
-    public void process(String deviceId, String devEui, Instant ts, Map<String, Object> metrics) {
+    public void process(String deviceId,
+                        String devEui,
+                        Instant ts,
+                        Map<String, Object> metrics,
+                        List<it.sensorplatform.dto.PacketDTO.SpecEntry> specEntries,
+                        List<String> indicatorLabels) {
         if (deviceId == null && devEui != null) {
             deviceId = devEui.toLowerCase(Locale.ROOT);
         }
@@ -50,8 +141,14 @@ public class IngestService {
         }
         if (ts == null) ts = Instant.now();
 
+        Map<String, Object> safeMetrics = metrics != null ? new HashMap<>(metrics) : new HashMap<>();
+
+        List<MeasurementSample> measurements = buildMeasurements(safeMetrics, specEntries);
+        List<IndicatorSample> indicators = buildIndicators(safeMetrics, indicatorLabels);
+        Map<String, Object> info = extractInfo(safeMetrics);
+
         Deque<Sample> queue = store.computeIfAbsent(deviceId, k -> new ArrayDeque<>());
-        queue.addLast(new Sample(deviceId, devEui, ts, metrics));
+        queue.addLast(new Sample(deviceId, devEui, ts, measurements, indicators, Map.copyOf(info)));
 
         // mantieni dimensione massima
         while (queue.size() > MAX_SAMPLES_PER_DEVICE) {
@@ -70,5 +167,95 @@ public class IngestService {
         if (n <= 0 || q.isEmpty()) return List.of();
         int skip = Math.max(0, q.size() - n);
         return q.stream().skip(skip).toList();
+    }
+
+    private List<MeasurementSample> buildMeasurements(Map<String, Object> metrics,
+                                                      List<it.sensorplatform.dto.PacketDTO.SpecEntry> specEntries) {
+        List<MeasurementSample> result = new ArrayList<>();
+        List<it.sensorplatform.dto.PacketDTO.SpecEntry> safeSpec = specEntries != null ? specEntries : List.of();
+        for (int i = 0; i < SPEC_KEYS.size(); i++) {
+            String key = SPEC_KEYS.get(i);
+            Object rawValue = metrics.get(key);
+            Double value = toDouble(rawValue);
+            Double min = null;
+            Double max = null;
+            String label = key;
+            if (i < safeSpec.size() && safeSpec.get(i) != null) {
+                var entry = safeSpec.get(i);
+                label = Optional.ofNullable(entry.getLabel()).orElse(key);
+                min = entry.getMin();
+                max = entry.getMax();
+            }
+            MeasurementMetadata metadata = MEASUREMENT_METADATA.get(key);
+            String displayName = metadata != null ? metadata.displayName() : label;
+            String unit = metadata != null ? metadata.unit() : null;
+            result.add(new MeasurementSample(key, label, displayName, unit, min, max, value));
+        }
+        return result;
+    }
+
+    private List<IndicatorSample> buildIndicators(Map<String, Object> metrics, List<String> indicatorLabels) {
+        List<IndicatorSample> result = new ArrayList<>();
+        List<String> safeLabels = indicatorLabels != null ? indicatorLabels : List.of();
+        for (int i = 0; i < INDICATOR_KEYS.size(); i++) {
+            String key = INDICATOR_KEYS.get(i);
+            Object rawValue = metrics.get(key);
+            Integer value = toInteger(rawValue);
+            String label = key;
+            if (i < safeLabels.size() && safeLabels.get(i) != null) {
+                label = safeLabels.get(i);
+            } else if (INDICATOR_LABELS.containsKey(key)) {
+                label = INDICATOR_LABELS.get(key);
+            }
+            result.add(new IndicatorSample(key, label, value));
+        }
+        return result;
+    }
+
+    private Map<String, Object> extractInfo(Map<String, Object> metrics) {
+        Map<String, Object> info = new LinkedHashMap<>();
+        if (metrics == null || metrics.isEmpty()) {
+            return info;
+        }
+        for (String key : INFO_KEYS) {
+            if (metrics.containsKey(key)) {
+                info.put(key, metrics.get(key));
+            }
+        }
+        return info;
+    }
+
+    private Double toDouble(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        if (value instanceof String s) {
+            try {
+                return Double.parseDouble(s);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Integer toInteger(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String s) {
+            try {
+                return Integer.parseInt(s);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -74,7 +74,14 @@ public class PacketService {
         System.out.println("PacketService.handlePacket - forwarding data to IngestService for device: " + device.getMacAddress());
         // Case 2: normal data packet -> forward metrics to ingest service
         Map<String, Object> payload = packet.getPayload();
-        ingestService.process(device.getMacAddress(), device.getDevEui(), Instant.now(), payload);
+        ingestService.process(
+                device.getMacAddress(),
+                device.getDevEui(),
+                Instant.now(),
+                payload,
+                packet.getSpec(),
+                packet.getIndicator()
+        );
         return Result.DATA;
     }
 }

--- a/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
+++ b/src/main/java/it/sensorplatform/service/UnknownDeviceService.java
@@ -30,6 +30,7 @@ public class UnknownDeviceService {
                 packet.getTypeOfDevice(),
                 packet.getPayload(),
                 packet.getSpec(),
+                packet.getIndicator(),
                 Instant.now()
         );
         notifications.computeIfAbsent(packet.getProjectId(), k -> new ConcurrentHashMap<>())

--- a/src/main/resources/static/css/deviceDashboard.css
+++ b/src/main/resources/static/css/deviceDashboard.css
@@ -252,8 +252,8 @@
         color: var(--accent-contrast);
 }
 
-.metric-unit {
-        font-size: 0.95rem;
+.metric-range {
+        font-size: 0.85rem;
         color: var(--muted-color);
 }
 
@@ -281,6 +281,36 @@
         border-radius: 0.6rem;
         color: var(--accent-contrast);
         padding: 0.35rem 0.75rem;
+}
+
+.info-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+        margin-top: 1rem;
+}
+
+.info-row {
+        background: rgba(255, 255, 255, 0.04);
+        border-radius: 0.75rem;
+        padding: 0.75rem 1rem;
+        display: grid;
+        row-gap: 0.35rem;
+}
+
+.info-row dt {
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--muted-color);
+        margin: 0;
+}
+
+.info-row dd {
+        margin: 0;
+        font-size: 1.05rem;
+        color: var(--accent-contrast);
+        font-weight: 500;
 }
 
 .status-panel {

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -88,10 +88,19 @@
                         </div>
                 </section>
 
+                <section class="panel info-panel">
+                        <div class="panel-header">
+                                <h3>Device information</h3>
+                                <span class="panel-subtitle">Metadata sent with the latest packet</span>
+                        </div>
+                        <dl id="info-grid" class="info-grid"></dl>
+                        <p id="info-empty" class="empty-state">No additional information available.</p>
+                </section>
+
                 <section class="panel status-panel">
                         <div class="panel-header">
                                 <h3>Status indicators</h3>
-                                <span class="panel-subtitle">Control bits and diagnostics</span>
+                                <span class="panel-subtitle">SEN55 diagnostic bits (0 = OK, 1 = Fault)</span>
                         </div>
                         <div id="status-flags" class="status-flags"></div>
                         <p id="status-empty" class="empty-state">No diagnostics were provided in the latest packet.</p>
@@ -111,7 +120,6 @@
                 const state = {
                         specDescriptors: [],
                         specCardsRendered: false,
-                        metricKeyBySpecId: new Map(),
                         chart: null,
                         historyLimit: 60,
                         lastSamples: [],
@@ -167,7 +175,7 @@
                                 throw new Error('Unable to load device specs.');
                         }
                         const specs = await response.json();
-                        state.specDescriptors = Array.isArray(specs) ? specs.map((spec, index) => buildDescriptorFromSpec(spec, index)) : [];
+                        state.specDescriptors = Array.isArray(specs) ? specs.map(buildDescriptorFromSpec) : [];
                 }
 
                 async function loadHistory() {
@@ -191,13 +199,14 @@
                                 metricsEmpty.hidden = false;
                                 chartEmpty.hidden = false;
                                 resetChart();
-                                updateStatusFlags({}, new Set());
+                                updateStatusFlags([]);
+                                updateInfoPanel(null);
                                 document.getElementById('last-update').textContent = '--';
                                 return;
                         }
 
                         if (!state.specDescriptors.length) {
-                                const fallback = buildDescriptorsFromMetrics(state.lastSamples[state.lastSamples.length - 1]);
+                                const fallback = buildDescriptorsFromSample(state.lastSamples[state.lastSamples.length - 1]);
                                 state.specDescriptors = fallback;
                         }
 
@@ -209,7 +218,6 @@
                                 metricsEmpty.hidden = true;
                         }
 
-                        resolveMetricKeys(state.lastSamples);
                         const latestSample = state.lastSamples[state.lastSamples.length - 1];
                         updateFromSample(latestSample);
                         buildOrUpdateChart(state.lastSamples);
@@ -230,7 +238,7 @@
                                 return;
                         }
                         const sample = await response.json();
-                        if (!sample || !sample.metrics) {
+                        if (!sample || !Array.isArray(sample.measurements)) {
                                 return;
                         }
                         if (state.latestTimestamp && state.latestTimestamp === sample.timestamp) {
@@ -240,7 +248,6 @@
                         if (state.lastSamples.length > state.historyLimit) {
                                 state.lastSamples.splice(0, state.lastSamples.length - state.historyLimit);
                         }
-                        resolveMetricKeys([sample]);
                         updateFromSample(sample);
                         buildOrUpdateChart(state.lastSamples);
                 }
@@ -251,14 +258,13 @@
                         state.specDescriptors.forEach(descriptor => {
                                 const card = document.createElement('div');
                                 card.className = 'metric-card';
-                                card.dataset.specId = descriptor.id;
+                                card.dataset.specKey = descriptor.key;
                                 card.innerHTML = `
                                         <div class="metric-header">
-                                                <span class="metric-name">${descriptor.measurement}</span>
-                                                ${descriptor.component ? `<span class="metric-component">${descriptor.component}</span>` : ''}
+                                                <span class="metric-name">${descriptor.displayName}</span>
                                         </div>
                                         <div class="metric-value" data-value>--</div>
-                                        <div class="metric-unit">${descriptor.unit ?? ''}</div>
+                                        <div class="metric-range" data-range>${formatRange(descriptor.min, descriptor.max, descriptor.unit)}</div>
                                 `;
                                 container.appendChild(card);
                         });
@@ -266,68 +272,55 @@
                 }
 
                 function updateFromSample(sample) {
-                        if (!sample || !sample.metrics) {
+                        if (!sample || !Array.isArray(sample.measurements)) {
                                 return;
                         }
-                        const matchedKeys = updateMetricCards(sample.metrics);
-                        updateStatusFlags(sample.metrics, matchedKeys);
+                        const measurementMap = mapMeasurements(sample.measurements);
+                        updateMetricCards(measurementMap);
+                        updateStatusFlags(sample.indicators);
+                        updateInfoPanel(sample.info);
                         updateTimestamp(sample.timestamp);
                 }
 
-                function updateMetricCards(metrics) {
-                        const matchedKeys = new Set();
+                function updateMetricCards(measurements) {
                         state.specDescriptors.forEach(descriptor => {
-                                const card = document.querySelector(`.metric-card[data-spec-id="${descriptor.id}"]`);
+                                const card = document.querySelector(`.metric-card[data-spec-key="${descriptor.key}"]`);
                                 if (!card) {
                                         return;
                                 }
-                                let metricKey = state.metricKeyBySpecId.get(descriptor.id);
-                                if (!metricKey) {
-                                        metricKey = findMetricKey(descriptor, metrics);
-                                        if (metricKey) {
-                                                state.metricKeyBySpecId.set(descriptor.id, metricKey);
-                                        }
-                                }
                                 const valueEl = card.querySelector('[data-value]');
-                                if (!metricKey || !(metricKey in metrics)) {
+                                const rangeEl = card.querySelector('[data-range]');
+                                const measurement = measurements.get(descriptor.key);
+                                if (!measurement) {
                                         valueEl.textContent = '--';
+                                        rangeEl.textContent = formatRange(descriptor.min, descriptor.max, descriptor.unit);
                                         return;
                                 }
-                                matchedKeys.add(metricKey);
-                                const rawValue = metrics[metricKey];
-                                valueEl.textContent = formatValue(rawValue);
+                                valueEl.textContent = formatValue(measurement.value);
+                                rangeEl.textContent = formatRange(measurement.min, measurement.max, measurement.unit || descriptor.unit);
                         });
-                        return matchedKeys;
                 }
 
-                function updateStatusFlags(metrics, matchedKeys) {
+                function updateStatusFlags(indicators) {
                         const container = document.getElementById('status-flags');
                         const emptyState = document.getElementById('status-empty');
                         container.innerHTML = '';
 
-                        if (!metrics) {
-                                emptyState.hidden = false;
-                                return;
-                        }
-
-                        const entries = Object.entries(metrics).filter(([key]) => !matchedKeys.has(key));
-
-                        if (!entries.length) {
+                        if (!Array.isArray(indicators) || !indicators.length) {
                                 emptyState.hidden = false;
                                 return;
                         }
 
                         emptyState.hidden = true;
-                        entries.forEach(([key, value]) => {
+                        indicators.forEach(indicator => {
                                 const flag = document.createElement('div');
                                 flag.className = 'status-flag';
-                                const numeric = toNumber(value);
-                                const isBinary = typeof value === 'boolean' || numeric === 0 || numeric === 1;
-                                const isOn = typeof value === 'boolean' ? value : numeric === 1;
-                                const valueClass = isBinary ? (isOn ? 'flag-on' : 'flag-off') : 'flag-generic';
-                                const normalizedValue = formatStatus(value);
+                                const numeric = toNumber(indicator.value);
+                                const isOn = numeric === 1;
+                                const valueClass = numeric === null ? 'flag-generic' : (isOn ? 'flag-on' : 'flag-off');
+                                const normalizedValue = numeric === null ? '--' : (isOn ? 'Issue' : 'OK');
                                 flag.innerHTML = `
-                                        <span class="flag-key">${prettifyKey(key)}</span>
+                                        <span class="flag-key">${indicator.label ?? prettifyKey(indicator.key)}</span>
                                         <span class="flag-value ${valueClass}">${normalizedValue}</span>
                                 `;
                                 container.appendChild(flag);
@@ -387,18 +380,21 @@
                 function buildDatasets(samples) {
                         const theme = (PROJECT_KEY && palettes[PROJECT_KEY]) ? PROJECT_KEY : 'default';
                         const palette = palettes[theme];
-                        const descriptors = state.specDescriptors.filter(descriptor => state.metricKeyBySpecId.get(descriptor.id));
+                        const descriptors = state.specDescriptors;
+                        const measurementMaps = samples.map(sample => mapMeasurements(sample.measurements));
                         let colorIndex = 0;
                         return descriptors.map(descriptor => {
-                                const metricKey = state.metricKeyBySpecId.get(descriptor.id);
-                                const values = samples.map(sample => toNumber(sample.metrics?.[metricKey]));
+                                const values = measurementMaps.map(measurements => {
+                                        const measurement = measurements.get(descriptor.key);
+                                        return measurement ? toNumber(measurement.value) : null;
+                                });
                                 if (values.every(value => value === null)) {
                                         return null;
                                 }
                                 const color = palette[colorIndex % palette.length];
                                 colorIndex += 1;
                                 return {
-                                        label: descriptor.unit ? `${descriptor.measurement} (${descriptor.unit})` : descriptor.measurement,
+                                        label: descriptor.unit ? `${descriptor.displayName} (${descriptor.unit})` : descriptor.displayName,
                                         data: values,
                                         borderColor: color,
                                         backgroundColor: color + '33',
@@ -408,110 +404,63 @@
                         }).filter(Boolean);
                 }
 
-                function resolveMetricKeys(samples) {
-                        samples.forEach(sample => {
-                                if (!sample || !sample.metrics) {
-                                        return;
-                                }
-                                state.specDescriptors.forEach(descriptor => {
-                                        if (state.metricKeyBySpecId.get(descriptor.id)) {
-                                                return;
-                                        }
-                                        const key = findMetricKey(descriptor, sample.metrics);
-                                        if (key) {
-                                                state.metricKeyBySpecId.set(descriptor.id, key);
-                                        }
-                                });
-                        });
-                }
-
-                function findMetricKey(descriptor, metrics) {
-                        if (!metrics) {
-                                return null;
-                        }
-                        const entries = Object.entries(metrics);
-                        for (const [key, value] of entries) {
-                                const normalizedKey = normalizeKey(key);
-                                if (!normalizedKey) {
-                                        continue;
-                                }
-                                const numericValue = toNumber(value);
-                                if (numericValue === null) {
-                                        continue;
-                                }
-                                if (descriptor.normalizedKeys.some(candidate =>
-                                        candidate && (normalizedKey === candidate || normalizedKey.includes(candidate) || candidate.includes(normalizedKey)))) {
-                                        return key;
-                                }
-                        }
-                        return null;
-                }
-
-                function buildDescriptorFromSpec(spec, index) {
-                        const measurement = spec?.measurement ?? `Metric ${index + 1}`;
-                        const unit = spec?.unitOfMeasurement ?? '';
-                        const component = spec?.component ?? '';
+                function buildDescriptorFromSpec(spec) {
+                        const displayName = spec.displayName || prettifyKey(spec.label || spec.key);
                         return {
-                                id: `spec-${index}-${normalizeKey(measurement + component)}`,
-                                measurement,
-                                unit,
-                                component,
-                                normalizedKeys: buildCandidateKeys(measurement)
+                                key: spec.key,
+                                label: spec.label,
+                                displayName,
+                                unit: spec.unit,
+                                min: spec.min,
+                                max: spec.max
                         };
                 }
 
-                function buildDescriptorsFromMetrics(sample) {
-                        if (!sample || !sample.metrics) {
+                function buildDescriptorsFromSample(sample) {
+                        if (!sample || !Array.isArray(sample.measurements)) {
                                 return [];
                         }
-                        return Object.entries(sample.metrics)
-                                .filter(([key, value]) => toNumber(value) !== null)
-                                .map(([key]) => ({
-                                        id: `auto-${normalizeKey(key)}`,
-                                        measurement: prettifyKey(key),
-                                        unit: '',
-                                        component: '',
-                                        normalizedKeys: [normalizeKey(key)]
-                                }));
+                        return sample.measurements.map(measurement => ({
+                                key: measurement.key,
+                                label: measurement.label,
+                                displayName: measurement.displayName || prettifyKey(measurement.label || measurement.key),
+                                unit: measurement.unit,
+                                min: measurement.min,
+                                max: measurement.max
+                        }));
                 }
 
-                function buildCandidateKeys(measurement) {
-                        const candidates = new Set();
-                        const base = measurement ? measurement.toString() : '';
-                        const normalized = normalizeKey(base);
-                        if (normalized) {
-                                candidates.add(normalized);
+                function mapMeasurements(measurements) {
+                        const map = new Map();
+                        if (!Array.isArray(measurements)) {
+                                return map;
                         }
-                        const noSpaces = normalizeKey(base.replace(/\s+/g, ''));
-                        if (noSpaces) {
-                                candidates.add(noSpaces);
-                        }
-                        const decimalAlt = normalizeKey(base.replace(/\./g, ''));
-                        if (decimalAlt) {
-                                candidates.add(decimalAlt);
-                        }
-                        const decimalP = normalizeKey(base.replace(/\./g, 'p'));
-                        if (decimalP) {
-                                candidates.add(decimalP);
-                        }
-                        const percentLess = normalizeKey(base.replace(/%/g, ''));
-                        if (percentLess) {
-                                candidates.add(percentLess);
-                        }
-                        base.split(/\s+/).forEach(part => {
-                                const normalizedPart = normalizeKey(part);
-                                if (normalizedPart) {
-                                        candidates.add(normalizedPart);
+                        measurements.forEach(measurement => {
+                                if (measurement && measurement.key) {
+                                        map.set(measurement.key, measurement);
                                 }
                         });
-                        return Array.from(candidates);
+                        return map;
                 }
 
-                function normalizeKey(value) {
-                        if (!value && value !== 0) {
-                                return '';
+                function updateInfoPanel(info) {
+                        const container = document.getElementById('info-grid');
+                        const emptyState = document.getElementById('info-empty');
+                        container.innerHTML = '';
+                        if (!info || Object.keys(info).length === 0) {
+                                emptyState.hidden = false;
+                                return;
                         }
-                        return value.toString().toLowerCase().replace(/[^a-z0-9]/g, '');
+                        emptyState.hidden = true;
+                        Object.entries(info).forEach(([key, value]) => {
+                                const row = document.createElement('div');
+                                row.className = 'info-row';
+                                row.innerHTML = `
+                                        <dt>${prettifyKey(key)}</dt>
+                                        <dd>${formatValue(value)}</dd>
+                                `;
+                                container.appendChild(row);
+                        });
                 }
 
                 function prettifyKey(key) {
@@ -542,24 +491,14 @@
                         return Math.abs(numeric) >= 100 ? numeric.toFixed(0) : numeric.toFixed(2).replace(/\.00$/, '');
                 }
 
-                function formatStatus(value) {
-                        if (typeof value === 'boolean') {
-                                return value ? 'ON' : 'OFF';
+                function formatRange(min, max, unit) {
+                        if (min === null && max === null) {
+                                return unit ? `Range: -- ${unit}` : 'Range: --';
                         }
-                        if (value === null || value === undefined) {
-                                return '--';
-                        }
-                        const numeric = toNumber(value);
-                        if (numeric === 1) {
-                                return 'ON';
-                        }
-                        if (numeric === 0) {
-                                return 'OFF';
-                        }
-                        if (numeric !== null) {
-                                return formatValue(numeric);
-                        }
-                        return String(value);
+                        const formattedMin = min === null ? '--' : formatValue(min);
+                        const formattedMax = max === null ? '--' : formatValue(max);
+                        const suffix = unit ? ` ${unit}` : '';
+                        return `Range: ${formattedMin} – ${formattedMax}${suffix}`;
                 }
 
                 function updateTimestamp(timestamp) {


### PR DESCRIPTION
## Summary
- extend packet handling to capture spec ranges, SEN55 indicator labels, and general info in telemetry samples
- expose the new measurement structures through the telemetry API and update unknown-device notifications accordingly
- refresh the device dashboard UI to show measurement ranges, SEN55 diagnostics, and a metadata panel for non-spec fields

## Testing
- `./mvnw -q test` *(fails: Unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c95714b3cc8323b2355f9e1c52ae29