### PR TITLE
Support DevEUI identifiers across device flows

### DIFF
--- a/scripts/google_sheets.gs
+++ b/scripts/google_sheets.gs
@@ -147,7 +147,8 @@ function doGet(e) {
         payload: JSON.stringify({
           projectId: 101,
           typeOfDevice: 'Device4G',
-          macAddress: payload.macAddress, // o devEui
+          macAddress: payload.macAddress || null,
+          devEui: payload.devEui || null,
           payload: payload,
           spec: spec
         })

--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -147,40 +147,51 @@ public class DeviceController {
                 return "superadmin/deviceNotifications.html";
         }
 
-	@GetMapping("/superadmin/formUpdateDevice/{projectId}/{macAddress}")
+        @GetMapping("/superadmin/formUpdateDevice/{projectId}/{macAddress}")
         public String formUpdateDevice(@PathVariable("projectId") Long projectId,
-                        @PathVariable("macAddress") String macAddress, Model model) {
-                macAddress = MacAddressUtils.normalize(macAddress);
+                        @PathVariable("macAddress") String deviceKey, Model model) {
+                String normalizedKey = MacAddressUtils.normalize(deviceKey);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        return "error";
+                }
                 Project project = projectService.getProjectById(projectId);
-                Device device = deviceService.findByMacAddress(macAddress);
-		UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-		Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
-		model.addAttribute("user", credentials);
-		model.addAttribute("project", project);
-		model.addAttribute("device", device);
-		return "superadmin/formUpdateDevice.html";
-	}
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        return "error";
+                }
+                Device device = deviceOpt.get();
+                UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+                Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
+                model.addAttribute("user", credentials);
+                model.addAttribute("project", project);
+                model.addAttribute("device", device);
+                return "superadmin/formUpdateDevice.html";
+        }
 
         @PostMapping("/superadmin/updateDevice/{projectId}/{macAddress}")
         public String adminUpdateDevice(@PathVariable("projectId") Long projectId,
-                        @PathVariable("macAddress") String macAddress, @RequestParam String name,
+                        @PathVariable("macAddress") String deviceKey, @RequestParam String name,
                         @RequestParam(required = false) Double latitude, @RequestParam(required = false) Double longitude,
                         RedirectAttributes redirectAttributes) {
 
-		if (name == null || name.trim().isEmpty()) {
-			redirectAttributes.addFlashAttribute("error", "Device name is required.");
-			return "redirect:/superadmin/manageProjectDevices/" + projectId;
-		}
+                if (name == null || name.trim().isEmpty()) {
+                        redirectAttributes.addFlashAttribute("error", "Device name is required.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
 
-		// Recupera il dispositivo tramite MAC address
-                macAddress = MacAddressUtils.normalize(macAddress);
-                Device device = deviceService.findByMacAddress(macAddress);
+                String normalizedKey = MacAddressUtils.normalize(deviceKey);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
 
-		if (device == null) {
-			redirectAttributes.addFlashAttribute("error", "Device not found.");
-			return "redirect:/superadmin/manageProjectDevices/" + projectId;
-		}
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
 
+                Device device = deviceOpt.get();
                 // Aggiorna solo i campi modificabili
                 device.setName(name);
                 if (latitude != null && longitude != null) {
@@ -200,27 +211,42 @@ public class DeviceController {
                 return "redirect:/superadmin/manageProjectDevices/" + projectId;
         }
 
-	@PostMapping("/superadmin/deleteDevice/{projectId}/{macAddress}")
-        public String deleteDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String macAddress,
+        @PostMapping("/superadmin/deleteDevice/{projectId}/{macAddress}")
+        public String deleteDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String deviceKey,
                         RedirectAttributes redirectAttributes) {
-                macAddress = MacAddressUtils.normalize(macAddress);
-                Device device = deviceService.findByMacAddress(macAddress);
-		deviceService.delete(device);
-		redirectAttributes.addFlashAttribute("successMessage", "Dispositivo eliminato.");
-		return "redirect:/superadmin/manageProjectDevices/" + projectId;
-	}
+                String normalizedKey = MacAddressUtils.normalize(deviceKey);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        redirectAttributes.addFlashAttribute("errorMessage", "Device not found.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("errorMessage", "Device not found.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
+                deviceService.delete(deviceOpt.get());
+                redirectAttributes.addFlashAttribute("successMessage", "Dispositivo eliminato.");
+                return "redirect:/superadmin/manageProjectDevices/" + projectId;
+        }
 
-	@GetMapping("/device/{projectId}/{macAddress}")
-        public String aboutDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String macAddress,
+        @GetMapping("/device/{projectId}/{macAddress}")
+        public String aboutDevice(@PathVariable("projectId") Long projectId, @PathVariable("macAddress") String deviceKey,
                         Model model) {
-                macAddress = MacAddressUtils.normalize(macAddress);
+                String normalizedKey = MacAddressUtils.normalize(deviceKey);
                 Project project = projectService.getProjectById(projectId);
-                Device device = deviceService.findByMacAddress(macAddress);
-		UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-		Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
-		model.addAttribute("user", credentials);
-		model.addAttribute("project", project);
-		model.addAttribute("device", device);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        return "error";
+                }
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        return "error";
+                }
+                Device device = deviceOpt.get();
+                UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+                Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
+                model.addAttribute("user", credentials);
+                model.addAttribute("project", project);
+                model.addAttribute("device", device);
 		return "updateDevice";
 	}
 
@@ -229,21 +255,25 @@ public class DeviceController {
                         @RequestParam(required = false) Double latitude, @RequestParam(required = false) Double longitude,
                         RedirectAttributes redirectAttributes) {
 
-                macAddress = MacAddressUtils.normalize(macAddress);
+                String normalizedKey = MacAddressUtils.normalize(macAddress);
 
                 if (name == null || name.trim().isEmpty()) {
                         redirectAttributes.addFlashAttribute("error", "Device name is required.");
-                        return "redirect:/device/" + projectId + "/" + macAddress;
+                        return "redirect:/device/" + projectId + "/" + normalizedKey;
                 }
 
-                // Recupera il dispositivo tramite MAC address
-                Device device = deviceService.findByMacAddress(macAddress);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found.");
+                        return "redirect:/device/" + projectId + "/" + normalizedKey;
+                }
 
-		if (device == null) {
-			redirectAttributes.addFlashAttribute("error", "Device not found.");
-                        return "redirect:/device/" + projectId + "/" + macAddress;
-		}
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found.");
+                        return "redirect:/device/" + projectId + "/" + normalizedKey;
+                }
 
+                Device device = deviceOpt.get();
                 // Aggiorna solo i campi modificabili
                 device.setName(name);
                 if (latitude != null && longitude != null) {
@@ -260,7 +290,7 @@ public class DeviceController {
                 deviceService.save(device);
 
                 redirectAttributes.addFlashAttribute("success", "Device updated successfully.");
-                return "redirect:/device/" + projectId + "/" + macAddress;
+                return "redirect:/device/" + projectId + "/" + normalizedKey;
         }
 
 	@GetMapping("/admin/formRegisterOperator/{projectId}")
@@ -336,24 +366,42 @@ public class DeviceController {
 
 	}
 
-	@PostMapping("/admin/selectOperator/{macAddress}/{opId}/{projectId}")
+        @PostMapping("/admin/selectOperator/{macAddress}/{opId}/{projectId}")
         public String assignOperatorToDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress,
                                                                                 @PathVariable("opId") Long opId, RedirectAttributes ra) {
-                macAddress = MacAddressUtils.normalize(macAddress);
-                Device d = deviceService.findByMacAddress(macAddress);
-		Credentials operator = credentialsService.findById(opId);
-		
-		d.setOperator(operator);
-		deviceService.save(d);
-		
-		return "redirect:/admin/group/"+projectId;
-	}
-	
+                String normalizedKey = MacAddressUtils.normalize(macAddress);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        ra.addFlashAttribute("errorMessage", "Device not found.");
+                        return "redirect:/admin/group/"+projectId;
+                }
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        ra.addFlashAttribute("errorMessage", "Device not found.");
+                        return "redirect:/admin/group/"+projectId;
+                }
+                Device d = deviceOpt.get();
+                Credentials operator = credentialsService.findById(opId);
+
+                d.setOperator(operator);
+                deviceService.save(d);
+
+                return "redirect:/admin/group/"+projectId;
+        }
+
         @PostMapping("/admin/removeOperator/{macAddress}/{projectId}")
         public String removeOperatorfromDevice(@PathVariable ("projectId") Long projectId, @PathVariable ("macAddress") String macAddress,
                                                                                  RedirectAttributes ra) {
-                macAddress = MacAddressUtils.normalize(macAddress);
-                Device d = deviceService.findByMacAddress(macAddress);
+                String normalizedKey = MacAddressUtils.normalize(macAddress);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        ra.addFlashAttribute("errorMessage", "Device not found.");
+                        return "redirect:/admin/group/"+projectId;
+                }
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        ra.addFlashAttribute("errorMessage", "Device not found.");
+                        return "redirect:/admin/group/"+projectId;
+                }
+                Device d = deviceOpt.get();
 
                 d.setOperator(null);
                 d.setLatitude(null);
@@ -386,7 +434,7 @@ public class DeviceController {
                 }
 
                 String normalizedMac = MacAddressUtils.normalize(macAddress);
-                Optional<Device> deviceOpt = deviceService.findOptionalByMacAddress(normalizedMac);
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedMac);
                 if (deviceOpt.isEmpty()) {
                         return "error";
                 }

--- a/src/main/java/it/sensorplatform/controller/rest/DeviceTelemetryController.java
+++ b/src/main/java/it/sensorplatform/controller/rest/DeviceTelemetryController.java
@@ -6,6 +6,7 @@ import static it.sensorplatform.model.Credentials.VOLCANO_ADMIN_ROLE;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -50,17 +51,17 @@ public class DeviceTelemetryController {
     }
 
     @GetMapping("/{macAddress}/specs")
-    public ResponseEntity<List<SpecDTO>> getDeviceSpecs(@PathVariable("macAddress") String macAddress) {
-        Optional<Device> deviceOpt = resolveAuthorizedDevice(macAddress);
+    public ResponseEntity<List<SpecDTO>> getDeviceSpecs(@PathVariable("macAddress") String deviceKey) {
+        Optional<Device> deviceOpt = resolveAuthorizedDevice(deviceKey);
         if (deviceOpt.isEmpty()) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        String normalizedMac = MacAddressUtils.normalize(macAddress);
-        if (normalizedMac == null) {
+        String telemetryKey = telemetryIdentifier(deviceOpt.get());
+        if (telemetryKey == null) {
             return ResponseEntity.ok(Collections.emptyList());
         }
-        List<IngestService.Sample> samples = ingestService.last(normalizedMac, 1);
+        List<IngestService.Sample> samples = ingestService.last(telemetryKey, 1);
         if (samples.isEmpty()) {
             return ResponseEntity.ok(Collections.emptyList());
         }
@@ -72,14 +73,17 @@ public class DeviceTelemetryController {
     }
 
     @GetMapping("/{macAddress}/telemetry/latest")
-    public ResponseEntity<TelemetrySampleDTO> getLatestSample(@PathVariable("macAddress") String macAddress) {
-        Optional<Device> deviceOpt = resolveAuthorizedDevice(macAddress);
+    public ResponseEntity<TelemetrySampleDTO> getLatestSample(@PathVariable("macAddress") String deviceKey) {
+        Optional<Device> deviceOpt = resolveAuthorizedDevice(deviceKey);
         if (deviceOpt.isEmpty()) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        String normalizedMac = MacAddressUtils.normalize(macAddress);
-        List<IngestService.Sample> samples = ingestService.last(normalizedMac, 1);
+        String telemetryKey = telemetryIdentifier(deviceOpt.get());
+        if (telemetryKey == null) {
+            return ResponseEntity.noContent().build();
+        }
+        List<IngestService.Sample> samples = ingestService.last(telemetryKey, 1);
         if (samples.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
@@ -88,33 +92,31 @@ public class DeviceTelemetryController {
     }
 
     @GetMapping("/{macAddress}/telemetry/history")
-    public ResponseEntity<List<TelemetrySampleDTO>> getHistory(@PathVariable("macAddress") String macAddress,
+    public ResponseEntity<List<TelemetrySampleDTO>> getHistory(@PathVariable("macAddress") String deviceKey,
                                                                @RequestParam(value = "limit", defaultValue = "50") int limit) {
-        Optional<Device> deviceOpt = resolveAuthorizedDevice(macAddress);
+        Optional<Device> deviceOpt = resolveAuthorizedDevice(deviceKey);
         if (deviceOpt.isEmpty()) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         }
 
-        String normalizedMac = MacAddressUtils.normalize(macAddress);
+        String telemetryKey = telemetryIdentifier(deviceOpt.get());
+        if (telemetryKey == null) {
+            return ResponseEntity.ok(Collections.emptyList());
+        }
         int safeLimit = Math.max(1, Math.min(limit, MAX_HISTORY));
-        List<TelemetrySampleDTO> history = ingestService.last(normalizedMac, safeLimit).stream()
+        List<TelemetrySampleDTO> history = ingestService.last(telemetryKey, safeLimit).stream()
                 .map(TelemetrySampleDTO::fromSample)
                 .collect(Collectors.toList());
         return ResponseEntity.ok(history);
     }
 
-    private Optional<Device> resolveAuthorizedDevice(String macAddress) {
+    private Optional<Device> resolveAuthorizedDevice(String deviceKey) {
         Credentials credentials = currentCredentials();
         if (credentials == null || credentials.getAdmin() == null) {
             return Optional.empty();
         }
 
-        String normalizedMac = MacAddressUtils.normalize(macAddress);
-        if (normalizedMac == null || normalizedMac.isBlank()) {
-            return Optional.empty();
-        }
-
-        Optional<Device> deviceOpt = deviceService.findOptionalByMacAddress(normalizedMac);
+        Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(deviceKey);
         if (deviceOpt.isEmpty()) {
             return Optional.empty();
         }
@@ -124,6 +126,18 @@ public class DeviceTelemetryController {
             return Optional.empty();
         }
         return Optional.of(device);
+    }
+
+    private String telemetryIdentifier(Device device) {
+        String mac = MacAddressUtils.normalize(device.getMacAddress());
+        if (mac != null && !mac.isBlank()) {
+            return mac;
+        }
+        String devEui = device.getDevEui();
+        if (devEui == null || devEui.isBlank()) {
+            return null;
+        }
+        return devEui.toLowerCase(Locale.ROOT);
     }
 
     private Credentials currentCredentials() {

--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -86,19 +86,21 @@ public class NotificationControllerRest {
         }
 
         String macAddress = MacAddressUtils.normalize(notif.getMacAddress());
-        if (macAddress == null || macAddress.isBlank()) {
-            macAddress = MacAddressUtils.normalize(notif.getDevEui());
-            logger.info("MAC address missing; using DevEUI {} as MAC address", macAddress);
-        }
-
         String normalizedDevEui = MacAddressUtils.normalize(notif.getDevEui());
-        if (deviceRepository.existsByMacAddress(macAddress)
-                || (normalizedDevEui != null && deviceRepository.existsByDevEui(normalizedDevEui))) {
-            logger.warn("Device with MAC {} or DevEUI {} already exists", macAddress, notif.getDevEui());
+
+        boolean macConflict = macAddress != null && !macAddress.isBlank() && deviceRepository.existsByMacAddress(macAddress);
+        boolean devEuiConflict = normalizedDevEui != null && !normalizedDevEui.isBlank()
+                && deviceRepository.existsByDevEui(normalizedDevEui);
+        if (macConflict || devEuiConflict) {
+            logger.warn("Device with MAC {} or DevEUI {} already exists", macAddress, normalizedDevEui);
             return ResponseEntity.status(HttpStatus.CONFLICT).build();
         }
 
-        logger.info("Creating device with MAC {} and DevEUI {}", macAddress, notif.getDevEui());
+        if (macAddress == null || macAddress.isBlank()) {
+            logger.info("MAC address missing; persisting device with DevEUI {} only", normalizedDevEui);
+        }
+
+        logger.info("Creating device with MAC {} and DevEUI {}", macAddress, normalizedDevEui);
         Device device = new Device();
         device.setMacAddress(macAddress);
         device.setDevEui(normalizedDevEui);

--- a/src/main/java/it/sensorplatform/service/DeviceService.java
+++ b/src/main/java/it/sensorplatform/service/DeviceService.java
@@ -50,6 +50,27 @@ public class DeviceService {
                 return this.deviceRepository.findByMacAddress(MacAddressUtils.normalize(macAddress));
         }
 
+        public Optional<Device> findOptionalByDevEui(String devEui) {
+                return this.deviceRepository.findByDevEui(MacAddressUtils.normalize(devEui));
+        }
+
+        public Optional<Device> findOptionalByDeviceKey(String deviceKey) {
+                String normalizedKey = MacAddressUtils.normalize(deviceKey);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        return Optional.empty();
+                }
+                Optional<Device> byMac = this.deviceRepository.findByMacAddress(normalizedKey);
+                if (byMac.isPresent()) {
+                        return byMac;
+                }
+                return this.deviceRepository.findByDevEui(normalizedKey);
+        }
+
+        public Device findByDeviceKey(String deviceKey) {
+                return findOptionalByDeviceKey(deviceKey)
+                                .orElseThrow(() -> new IllegalArgumentException("Device not found for key: " + deviceKey));
+        }
+
         public void save(Device device) {
                 if (device != null) {
                         device.setMacAddress(MacAddressUtils.normalize(device.getMacAddress()));

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -48,7 +48,8 @@
                         <div>
                                 <h2 th:text="${device.name}">Device name</h2>
                                 <p class="device-meta">
-                                        <span>MAC: <strong th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">--</strong></span>
+                                        <span th:if="${device.macAddress != null}">MAC: <strong th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">--</strong></span>
+                                        <span th:if="${device.macAddress == null}">DevEUI: <strong th:text="${device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui) : '--'}">--</strong></span>
                                         <span th:if="${device.tod != null}">Type: <strong th:text="${device.tod.name}">Type</strong></span>
                                         <span>Status: <strong th:text="${device.status}">--</strong></span>
                                 </p>
@@ -107,7 +108,7 @@
 
         <script th:inline="javascript">
                 /*<![CDATA[*/
-                const DEVICE_MAC = /*[[${device.macAddress}]]*/ '';
+                const DEVICE_KEY = /*[[${device.macAddress != null ? device.macAddress : (device.devEui != null ? device.devEui : '')}]]*/ '';
                 const PROJECT_ID = /*[[${project.id}]]*/ 0;
                 const DEVICE_NAME = /*[[${device.name}]]*/ '';
                 const PROJECT_KEY = /*[[${projectKey}]]*/ 'default';
@@ -165,7 +166,7 @@
                 }
 
                 async function loadSpecs() {
-                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_MAC)}/specs`);
+                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_KEY)}/specs`);
                         if (response.status === 403) {
                                 throw new Error('Non sei autorizzato a visualizzare questo dispositivo.');
                         }
@@ -178,7 +179,7 @@
 
                 async function loadHistory() {
                         clearError();
-                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_MAC)}/telemetry/history?limit=${state.historyLimit}`);
+                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_KEY)}/telemetry/history?limit=${state.historyLimit}`);
                         if (response.status === 403) {
                                 throw new Error('Non sei autorizzato a visualizzare questo dispositivo.');
                         }
@@ -223,7 +224,7 @@
                 }
 
                 async function refreshLatestSample() {
-                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_MAC)}/telemetry/latest`);
+                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(DEVICE_KEY)}/telemetry/latest`);
                         if (response.status === 403) {
                                 showError('Non sei autorizzato a visualizzare questo dispositivo.');
                                 return;


### PR DESCRIPTION
## Summary
- persist DevEUI independently from the MAC address when registering notifications
- allow device lookups by DevEUI in admin controllers and reuse the telemetry identifier stored by ingest
- surface DevEUI in the dashboard UI when the MAC is unavailable and send it correctly from the Google Sheets bridge

## Testing
- `./mvnw test` *(fails: unable to download Maven wrapper dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c992df27ac8327981faa2eb7947323