### PR TITLE
feat: support dynamic telemetry specs

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -67,14 +67,30 @@ public class NotificationControllerRest {
             List<Spec> specs = new ArrayList<>();
             if (notif.getSpec() != null) {
                 for (PacketDTO.SpecEntry specEntry : notif.getSpec()) {
-                    if (specEntry == null || specEntry.getLabel() == null) {
+                    if (specEntry == null) {
                         continue;
                     }
-                    String[] parts = specEntry.getLabel().split("-");
+                    String label = specEntry.getLabel();
+                    String key = sanitize(specEntry.getKey());
+                    if (label == null && key == null) {
+                        continue;
+                    }
                     Spec spec = new Spec();
-                    spec.setComponent(parts.length > 0 ? parts[0] : "");
-                    spec.setMeasurement(parts.length > 1 ? parts[1] : "");
-                    spec.setUnitOfMeasurement(parts.length > 2 ? parts[2] : "");
+                    if (label != null) {
+                        String[] parts = label.split("-");
+                        spec.setComponent(parts.length > 0 ? parts[0] : "");
+                        String measurementPart = parts.length > 1 ? parts[1] : "";
+                        spec.setMeasurement(key != null ? key : measurementPart);
+                        spec.setUnitOfMeasurement(parts.length > 2 ? parts[2] : "");
+                    } else {
+                        spec.setMeasurement(key != null ? key : "");
+                    }
+                    if (spec.getComponent() == null) {
+                        spec.setComponent("");
+                    }
+                    if (spec.getUnitOfMeasurement() == null) {
+                        spec.setUnitOfMeasurement("");
+                    }
                     if (!specService.existsByFields(spec)) {
                         specService.save(spec);
                     }
@@ -118,5 +134,13 @@ public class NotificationControllerRest {
             logger.error("Error saving device with MAC {} and DevEUI {}", macAddress, notif.getDevEui(), e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    private String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 }

--- a/src/main/java/it/sensorplatform/dto/PacketDTO.java
+++ b/src/main/java/it/sensorplatform/dto/PacketDTO.java
@@ -101,9 +101,18 @@ public class PacketDTO {
     }
 
     public static class SpecEntry {
+        private String key;
         private String label;
         private Double min;
         private Double max;
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
 
         public String getLabel() {
             return label;

--- a/src/main/java/it/sensorplatform/service/IngestService.java
+++ b/src/main/java/it/sensorplatform/service/IngestService.java
@@ -1,5 +1,8 @@
 package it.sensorplatform.service;
 
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Spec;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -8,10 +11,10 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -47,36 +50,6 @@ public class IngestService {
     /** Ultimi N campioni per device (buffer circolare) */
     private final Map<String, Deque<Sample>> store = new ConcurrentHashMap<>();
     private static final int MAX_SAMPLES_PER_DEVICE = 200;
-
-    private static final List<String> SPEC_KEYS = List.of(
-            "co2_ppm",
-            "pm1p0",
-            "pm2p5",
-            "pm4p0",
-            "pm10p0",
-            "vocIndex",
-            "noxIndex",
-            "bmeT",
-            "bmeRH",
-            "bmeP",
-            "bmeGas",
-            "icmTemp",
-            "icmAccX",
-            "icmAccY",
-            "icmAccZ",
-            "icmGyrX",
-            "icmGyrY",
-            "icmGyrZ"
-    );
-
-    private static final List<String> INDICATOR_KEYS = List.of(
-            "sen55_fan_err",
-            "sen55_speed_warn",
-            "sen55_laser_err",
-            "sen55_rht_err",
-            "sen55_gas_err",
-            "sen55_cleaning"
-    );
 
     private static final Map<String, MeasurementMetadata> MEASUREMENT_METADATA = Map.ofEntries(
             Map.entry("co2_ppm", new MeasurementMetadata("CO₂", "ppm")),
@@ -120,6 +93,8 @@ public class IngestService {
 
     private record MeasurementMetadata(String displayName, String unit) { }
 
+    private record IndicatorDescriptor(String key, String label) { }
+
     /**
      * Normalizza e memorizza un pacchetto ricevuto.
      * @param deviceId nome del device (se null, prova a usare devEui)
@@ -127,12 +102,35 @@ public class IngestService {
      * @param ts       istante della misura (UTC)
      * @param metrics  mappa chiave=tipo misura, valore=numero (es. temp, hum, pm2p5)
      */
+    public void process(Device device,
+                        Instant ts,
+                        Map<String, Object> metrics,
+                        List<PacketDTO.SpecEntry> specEntries,
+                        List<String> indicatorLabels) {
+        String deviceId = device != null ? device.getMacAddress() : null;
+        String devEui = device != null ? device.getDevEui() : null;
+        List<Spec> savedSpecs = device != null && device.getTod() != null && device.getTod().getSpecs() != null
+                ? device.getTod().getSpecs()
+                : List.of();
+        process(deviceId, devEui, ts, metrics, specEntries, indicatorLabels, savedSpecs);
+    }
+
     public void process(String deviceId,
                         String devEui,
                         Instant ts,
                         Map<String, Object> metrics,
-                        List<it.sensorplatform.dto.PacketDTO.SpecEntry> specEntries,
+                        List<PacketDTO.SpecEntry> specEntries,
                         List<String> indicatorLabels) {
+        process(deviceId, devEui, ts, metrics, specEntries, indicatorLabels, List.of());
+    }
+
+    private void process(String deviceId,
+                         String devEui,
+                         Instant ts,
+                         Map<String, Object> metrics,
+                         List<PacketDTO.SpecEntry> specEntries,
+                         List<String> indicatorLabels,
+                         List<Spec> savedSpecs) {
         if (deviceId == null && devEui != null) {
             deviceId = devEui.toLowerCase(Locale.ROOT);
         }
@@ -141,22 +139,32 @@ public class IngestService {
         }
         if (ts == null) ts = Instant.now();
 
-        Map<String, Object> safeMetrics = metrics != null ? new HashMap<>(metrics) : new HashMap<>();
+        Map<String, Object> safeMetrics = metrics != null ? new LinkedHashMap<>(metrics) : new LinkedHashMap<>();
+        List<PacketDTO.SpecEntry> safeSpecEntries = specEntries != null ? specEntries : List.of();
+        List<Spec> safeSavedSpecs = savedSpecs != null ? savedSpecs : List.of();
 
-        List<MeasurementSample> measurements = buildMeasurements(safeMetrics, specEntries);
-        List<IndicatorSample> indicators = buildIndicators(safeMetrics, indicatorLabels);
+        List<IndicatorDescriptor> indicatorDescriptors = parseIndicatorDescriptors(indicatorLabels);
+        Set<String> indicatorKeyHints = new LinkedHashSet<>();
+        for (IndicatorDescriptor descriptor : indicatorDescriptors) {
+            if (descriptor != null && descriptor.key() != null) {
+                indicatorKeyHints.add(descriptor.key());
+            }
+        }
+
+        List<MeasurementSample> measurements = buildMeasurements(safeMetrics, safeSpecEntries, safeSavedSpecs, indicatorKeyHints);
+        Set<String> measurementKeys = new LinkedHashSet<>();
+        for (MeasurementSample measurement : measurements) {
+            measurementKeys.add(measurement.key());
+        }
+        List<IndicatorSample> indicators = buildIndicators(safeMetrics, indicatorDescriptors, measurementKeys);
         Map<String, Object> info = extractInfo(safeMetrics);
 
         Deque<Sample> queue = store.computeIfAbsent(deviceId, k -> new ArrayDeque<>());
         queue.addLast(new Sample(deviceId, devEui, ts, measurements, indicators, Map.copyOf(info)));
 
-        // mantieni dimensione massima
         while (queue.size() > MAX_SAMPLES_PER_DEVICE) {
             queue.removeFirst();
         }
-
-        // TODO (Fase 2): persistere su DB
-        // persistToDb(deviceId, devEui, ts, metrics);
     }
 
     /**
@@ -170,46 +178,362 @@ public class IngestService {
     }
 
     private List<MeasurementSample> buildMeasurements(Map<String, Object> metrics,
-                                                      List<it.sensorplatform.dto.PacketDTO.SpecEntry> specEntries) {
+                                                      List<PacketDTO.SpecEntry> specEntries,
+                                                      List<Spec> savedSpecs,
+                                                      Set<String> indicatorKeyHints) {
         List<MeasurementSample> result = new ArrayList<>();
-        List<it.sensorplatform.dto.PacketDTO.SpecEntry> safeSpec = specEntries != null ? specEntries : List.of();
-        for (int i = 0; i < SPEC_KEYS.size(); i++) {
-            String key = SPEC_KEYS.get(i);
+        List<PacketDTO.SpecEntry> safeSpecEntries = specEntries != null ? specEntries : List.of();
+        List<Spec> safeSavedSpecs = savedSpecs != null ? savedSpecs : List.of();
+
+        Map<String, PacketDTO.SpecEntry> specByKey = indexSpecEntries(safeSpecEntries);
+        Map<String, Spec> savedSpecByKey = indexSavedSpecs(safeSavedSpecs);
+        List<String> measurementKeys = resolveMeasurementKeys(metrics, safeSpecEntries, safeSavedSpecs, indicatorKeyHints);
+
+        for (int i = 0; i < measurementKeys.size(); i++) {
+            String key = measurementKeys.get(i);
             Object rawValue = metrics.get(key);
             Double value = toDouble(rawValue);
-            Double min = null;
-            Double max = null;
-            String label = key;
-            if (i < safeSpec.size() && safeSpec.get(i) != null) {
-                var entry = safeSpec.get(i);
-                label = Optional.ofNullable(entry.getLabel()).orElse(key);
-                min = entry.getMin();
-                max = entry.getMax();
+
+            PacketDTO.SpecEntry specEntry = specByKey.get(key);
+            if (specEntry == null && i < safeSpecEntries.size()) {
+                specEntry = safeSpecEntries.get(i);
             }
+            Spec savedSpec = savedSpecByKey.get(key);
+
+            Double min = specEntry != null ? specEntry.getMin() : null;
+            Double max = specEntry != null ? specEntry.getMax() : null;
+            String label = resolveMeasurementLabel(key, specEntry, savedSpec);
             MeasurementMetadata metadata = MEASUREMENT_METADATA.get(key);
-            String displayName = metadata != null ? metadata.displayName() : label;
-            String unit = metadata != null ? metadata.unit() : null;
+            String displayName = resolveMeasurementDisplayName(key, label, metadata, savedSpec);
+            String unit = resolveMeasurementUnit(metadata, savedSpec);
+
             result.add(new MeasurementSample(key, label, displayName, unit, min, max, value));
         }
         return result;
     }
 
-    private List<IndicatorSample> buildIndicators(Map<String, Object> metrics, List<String> indicatorLabels) {
+    private List<IndicatorSample> buildIndicators(Map<String, Object> metrics,
+                                                  List<IndicatorDescriptor> indicatorDescriptors,
+                                                  Set<String> measurementKeys) {
         List<IndicatorSample> result = new ArrayList<>();
-        List<String> safeLabels = indicatorLabels != null ? indicatorLabels : List.of();
-        for (int i = 0; i < INDICATOR_KEYS.size(); i++) {
-            String key = INDICATOR_KEYS.get(i);
+        List<IndicatorDescriptor> safeDescriptors = indicatorDescriptors != null ? indicatorDescriptors : List.of();
+        List<String> indicatorKeys = resolveIndicatorKeys(metrics, safeDescriptors, measurementKeys);
+        for (int i = 0; i < indicatorKeys.size(); i++) {
+            String key = indicatorKeys.get(i);
             Object rawValue = metrics.get(key);
             Integer value = toInteger(rawValue);
-            String label = key;
-            if (i < safeLabels.size() && safeLabels.get(i) != null) {
-                label = safeLabels.get(i);
-            } else if (INDICATOR_LABELS.containsKey(key)) {
-                label = INDICATOR_LABELS.get(key);
-            }
+            String label = resolveIndicatorLabel(key, safeDescriptors, i);
             result.add(new IndicatorSample(key, label, value));
         }
         return result;
+    }
+
+    private Map<String, PacketDTO.SpecEntry> indexSpecEntries(List<PacketDTO.SpecEntry> specEntries) {
+        Map<String, PacketDTO.SpecEntry> map = new HashMap<>();
+        if (specEntries == null) {
+            return map;
+        }
+        for (PacketDTO.SpecEntry entry : specEntries) {
+            if (entry == null) {
+                continue;
+            }
+            String key = sanitize(entry.getKey());
+            if (key != null && !map.containsKey(key)) {
+                map.put(key, entry);
+            }
+        }
+        return map;
+    }
+
+    private Map<String, Spec> indexSavedSpecs(List<Spec> specs) {
+        Map<String, Spec> map = new HashMap<>();
+        if (specs == null) {
+            return map;
+        }
+        for (Spec spec : specs) {
+            if (spec == null) {
+                continue;
+            }
+            String key = sanitize(spec.getMeasurement());
+            if (key != null && !map.containsKey(key)) {
+                map.put(key, spec);
+            }
+        }
+        return map;
+    }
+
+    private List<String> resolveMeasurementKeys(Map<String, Object> metrics,
+                                                List<PacketDTO.SpecEntry> specEntries,
+                                                List<Spec> savedSpecs,
+                                                Set<String> indicatorKeyHints) {
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
+        if (savedSpecs != null) {
+            for (Spec spec : savedSpecs) {
+                if (spec == null) {
+                    continue;
+                }
+                String key = sanitize(spec.getMeasurement());
+                if (key != null) {
+                    keys.add(key);
+                }
+            }
+        }
+        if (specEntries != null) {
+            for (PacketDTO.SpecEntry entry : specEntries) {
+                if (entry == null) {
+                    continue;
+                }
+                String key = sanitize(entry.getKey());
+                if (key != null) {
+                    keys.add(key);
+                }
+            }
+        }
+        if (metrics != null) {
+            for (String rawKey : metrics.keySet()) {
+                String key = sanitize(rawKey);
+                if (key == null) {
+                    continue;
+                }
+                if (INFO_KEYS.contains(key)) {
+                    continue;
+                }
+                if (indicatorKeyHints != null && indicatorKeyHints.contains(key)) {
+                    continue;
+                }
+                keys.add(key);
+            }
+        }
+        return new ArrayList<>(keys);
+    }
+
+    private String resolveMeasurementLabel(String key, PacketDTO.SpecEntry specEntry, Spec savedSpec) {
+        if (specEntry != null) {
+            String label = sanitize(specEntry.getLabel());
+            if (label != null) {
+                return label;
+            }
+        }
+        if (savedSpec != null) {
+            String component = sanitize(savedSpec.getComponent());
+            String measurement = sanitize(savedSpec.getMeasurement());
+            if (component != null && measurement != null) {
+                if (component.equalsIgnoreCase(measurement)) {
+                    return component;
+                }
+                return component + " - " + measurement;
+            }
+            if (component != null) {
+                return component;
+            }
+            if (measurement != null) {
+                return measurement;
+            }
+        }
+        return key;
+    }
+
+    private String resolveMeasurementDisplayName(String key,
+                                                 String label,
+                                                 MeasurementMetadata metadata,
+                                                 Spec savedSpec) {
+        if (metadata != null && metadata.displayName() != null) {
+            return metadata.displayName();
+        }
+        if (savedSpec != null) {
+            String measurement = sanitize(savedSpec.getMeasurement());
+            if (measurement != null) {
+                String pretty = prettify(measurement);
+                if (pretty != null) {
+                    return pretty;
+                }
+            }
+            String component = sanitize(savedSpec.getComponent());
+            if (component != null) {
+                String pretty = prettify(component);
+                if (pretty != null) {
+                    return pretty;
+                }
+            }
+        }
+        if (label != null) {
+            return label;
+        }
+        return prettify(key);
+    }
+
+    private String resolveMeasurementUnit(MeasurementMetadata metadata, Spec savedSpec) {
+        if (metadata != null && metadata.unit() != null) {
+            return metadata.unit();
+        }
+        if (savedSpec != null) {
+            String unit = sanitize(savedSpec.getUnitOfMeasurement());
+            if (unit != null) {
+                return unit;
+            }
+        }
+        return null;
+    }
+
+    private List<IndicatorDescriptor> parseIndicatorDescriptors(List<String> indicatorLabels) {
+        if (indicatorLabels == null || indicatorLabels.isEmpty()) {
+            return List.of();
+        }
+        List<IndicatorDescriptor> descriptors = new ArrayList<>();
+        for (String raw : indicatorLabels) {
+            if (raw == null) {
+                descriptors.add(new IndicatorDescriptor(null, null));
+                continue;
+            }
+            String trimmed = raw.trim();
+            if (trimmed.isEmpty()) {
+                descriptors.add(new IndicatorDescriptor(null, null));
+                continue;
+            }
+            int separator = findSeparator(trimmed);
+            if (separator > 0) {
+                String keyPart = trimmed.substring(0, separator).trim();
+                String labelPart = trimmed.substring(separator + 1).trim();
+                descriptors.add(new IndicatorDescriptor(sanitize(keyPart), labelPart.isEmpty() ? null : labelPart));
+            } else {
+                descriptors.add(new IndicatorDescriptor(null, trimmed));
+            }
+        }
+        return descriptors;
+    }
+
+    private List<String> resolveIndicatorKeys(Map<String, Object> metrics,
+                                              List<IndicatorDescriptor> indicatorDescriptors,
+                                              Set<String> measurementKeys) {
+        LinkedHashSet<String> keys = new LinkedHashSet<>();
+        if (indicatorDescriptors != null) {
+            for (IndicatorDescriptor descriptor : indicatorDescriptors) {
+                if (descriptor == null) {
+                    continue;
+                }
+                String key = sanitize(descriptor.key());
+                if (key != null) {
+                    keys.add(key);
+                }
+            }
+        }
+        if (metrics != null) {
+            for (String rawKey : metrics.keySet()) {
+                String key = sanitize(rawKey);
+                if (key == null) {
+                    continue;
+                }
+                if (INFO_KEYS.contains(key)) {
+                    continue;
+                }
+                if (measurementKeys != null && measurementKeys.contains(key)) {
+                    continue;
+                }
+                keys.add(key);
+            }
+        }
+        LinkedHashSet<String> remaining = new LinkedHashSet<>(keys);
+        List<String> ordered = new ArrayList<>();
+        if (indicatorDescriptors != null) {
+            for (IndicatorDescriptor descriptor : indicatorDescriptors) {
+                if (descriptor == null) {
+                    continue;
+                }
+                String key = sanitize(descriptor.key());
+                if (key != null && remaining.remove(key)) {
+                    ordered.add(key);
+                } else if (key == null && !remaining.isEmpty()) {
+                    String next = remaining.iterator().next();
+                    remaining.remove(next);
+                    ordered.add(next);
+                }
+            }
+        }
+        ordered.addAll(remaining);
+        return ordered;
+    }
+
+    private String resolveIndicatorLabel(String key,
+                                         List<IndicatorDescriptor> descriptors,
+                                         int index) {
+        if (descriptors != null && !descriptors.isEmpty()) {
+            if (index < descriptors.size()) {
+                IndicatorDescriptor descriptor = descriptors.get(index);
+                if (descriptor != null) {
+                    String descriptorKey = sanitize(descriptor.key());
+                    String descriptorLabel = descriptor.label();
+                    if ((descriptorKey == null || descriptorKey.equals(key)) && descriptorLabel != null && !descriptorLabel.isBlank()) {
+                        return descriptorLabel;
+                    }
+                }
+            }
+            for (IndicatorDescriptor descriptor : descriptors) {
+                if (descriptor == null) {
+                    continue;
+                }
+                String descriptorKey = sanitize(descriptor.key());
+                if (descriptorKey != null && descriptorKey.equals(key)) {
+                    String descriptorLabel = descriptor.label();
+                    if (descriptorLabel != null && !descriptorLabel.isBlank()) {
+                        return descriptorLabel;
+                    }
+                }
+            }
+        }
+        if (INDICATOR_LABELS.containsKey(key)) {
+            return INDICATOR_LABELS.get(key);
+        }
+        String pretty = prettify(key);
+        return pretty != null ? pretty : key;
+    }
+
+    private int findSeparator(String value) {
+        int colon = value.indexOf(':');
+        int equal = value.indexOf('=');
+        int pipe = value.indexOf('|');
+        int separator = colon > 0 ? colon : -1;
+        if (separator < 0 || (equal > 0 && equal < separator)) {
+            separator = equal;
+        }
+        if (separator < 0 || (pipe > 0 && pipe < separator)) {
+            separator = pipe;
+        }
+        return separator;
+    }
+
+    private String prettify(String value) {
+        String sanitized = sanitize(value);
+        if (sanitized == null) {
+            return null;
+        }
+        String replaced = sanitized.replace('_', ' ').replace('-', ' ').trim();
+        if (replaced.isEmpty()) {
+            return sanitized;
+        }
+        String[] parts = replaced.split("\\s+");
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i];
+            if (part.isEmpty()) {
+                continue;
+            }
+            if (builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append(part.substring(0, 1).toUpperCase(Locale.ROOT));
+            if (part.length() > 1) {
+                builder.append(part.substring(1));
+            }
+        }
+        return builder.length() > 0 ? builder.toString() : sanitized;
+    }
+
+    private String sanitize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private Map<String, Object> extractInfo(Map<String, Object> metrics) {

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -75,8 +75,7 @@ public class PacketService {
         // Case 2: normal data packet -> forward metrics to ingest service
         Map<String, Object> payload = packet.getPayload();
         ingestService.process(
-                device.getMacAddress(),
-                device.getDevEui(),
+                device,
                 Instant.now(),
                 payload,
                 packet.getSpec(),

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -174,7 +174,30 @@
                                 throw new Error('Unable to load device specs.');
                         }
                         const specs = await response.json();
-                        state.specDescriptors = Array.isArray(specs) ? specs.map(buildDescriptorFromSpec) : [];
+                        const descriptors = Array.isArray(specs) ? specs.map(buildDescriptorFromSpec) : [];
+                        const changed = descriptorsDiffer(state.specDescriptors, descriptors);
+                        state.specDescriptors = descriptors;
+                        if (changed) {
+                                state.specCardsRendered = false;
+                                if (state.specDescriptors.length) {
+                                        renderMetricCards();
+                                        const latestSample = state.lastSamples[state.lastSamples.length - 1];
+                                        if (latestSample) {
+                                                updateFromSample(latestSample);
+                                                buildOrUpdateChart(state.lastSamples);
+                                        } else {
+                                                updateMetricCards(new Map());
+                                                resetChart();
+                                        }
+                                } else {
+                                        document.getElementById('metrics-grid').innerHTML = '';
+                                        resetChart();
+                                }
+                                const metricsEmpty = document.getElementById('metrics-empty');
+                                if (metricsEmpty) {
+                                        metricsEmpty.hidden = state.specDescriptors.length > 0;
+                                }
+                        }
                 }
 
                 async function loadHistory() {
@@ -193,20 +216,12 @@
                         const metricsEmpty = document.getElementById('metrics-empty');
                         const chartEmpty = document.getElementById('chart-empty');
 
-                        if (!state.lastSamples.length) {
-                                metricsGrid.innerHTML = '';
-                                metricsEmpty.hidden = false;
-                                chartEmpty.hidden = false;
-                                resetChart();
-                                updateStatusFlags([]);
-                                updateInfoPanel(null);
-                                document.getElementById('last-update').textContent = '--';
-                                return;
-                        }
-
-                        if (!state.specDescriptors.length) {
+                        if (!state.specDescriptors.length && state.lastSamples.length) {
                                 const fallback = buildDescriptorsFromSample(state.lastSamples[state.lastSamples.length - 1]);
-                                state.specDescriptors = fallback;
+                                if (fallback.length) {
+                                        state.specDescriptors = fallback;
+                                        state.specCardsRendered = false;
+                                }
                         }
 
                         if (!state.specDescriptors.length) {
@@ -215,6 +230,23 @@
                         } else if (!state.specCardsRendered) {
                                 renderMetricCards();
                                 metricsEmpty.hidden = true;
+                        } else {
+                                metricsEmpty.hidden = true;
+                        }
+
+                        if (!state.lastSamples.length) {
+                                if (state.specDescriptors.length) {
+                                        updateMetricCards(new Map());
+                                } else {
+                                        metricsGrid.innerHTML = '';
+                                }
+                                chartEmpty.hidden = false;
+                                resetChart();
+                                updateStatusFlags([]);
+                                updateInfoPanel(null);
+                                state.latestTimestamp = null;
+                                document.getElementById('last-update').textContent = '--';
+                                return;
                         }
 
                         const latestSample = state.lastSamples[state.lastSamples.length - 1];
@@ -427,6 +459,24 @@
                                 min: measurement.min,
                                 max: measurement.max
                         }));
+                }
+
+                function descriptorsDiffer(previous, next) {
+                        if (!Array.isArray(previous) || !Array.isArray(next)) {
+                                return true;
+                        }
+                        if (previous.length !== next.length) {
+                                return true;
+                        }
+                        for (let i = 0; i < previous.length; i += 1) {
+                                const a = previous[i] || {};
+                                const b = next[i] || {};
+                                if (a.key !== b.key || a.label !== b.label || a.displayName !== b.displayName
+                                        || a.unit !== b.unit || a.min !== b.min || a.max !== b.max) {
+                                        return true;
+                                }
+                        }
+                        return false;
                 }
 
                 function mapMeasurements(measurements) {


### PR DESCRIPTION
## Summary
- derive measurement and indicator keys dynamically in the ingest service using the saved type-of-device specs and packet metadata
- persist spec keys coming from packets, expose them in the DTOs, and pass the full device to the ingest service when handling telemetry packets
- refresh the device dashboard widgets whenever the API-provided specs change so the UI stays aligned with dynamic descriptors

## Testing
- `mvn test` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b9647ccc83278c515fdd05301e09