### PR TITLE
Ensure new devices reuse existing specs

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -91,10 +91,9 @@ public class NotificationControllerRest {
                     if (spec.getUnitOfMeasurement() == null) {
                         spec.setUnitOfMeasurement("");
                     }
-                    if (!specService.existsByFields(spec)) {
-                        specService.save(spec);
-                    }
-                    specs.add(spec);
+                    Spec managedSpec = specService.findByFields(spec)
+                            .orElseGet(() -> specService.save(spec));
+                    specs.add(managedSpec);
                 }
             }
             tod.setSpecs(specs);

--- a/src/main/java/it/sensorplatform/repository/SpecRepository.java
+++ b/src/main/java/it/sensorplatform/repository/SpecRepository.java
@@ -1,5 +1,6 @@
 package it.sensorplatform.repository;
 
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -11,13 +12,23 @@ import it.sensorplatform.model.Spec;
 @Repository
 public interface SpecRepository extends CrudRepository<Spec, Long>{
 
-	@Query(value = """
-		    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
-		    FROM spec
-		    WHERE measurement = :#{#spec.measurement}
-		      AND unit_of_measurement = :#{#spec.unitOfMeasurement}
-		      AND component = :#{#spec.component}
-		    """, nativeQuery = true)
-		boolean existsByFields(@Param("spec") Spec spec);
-	
+        @Query(value = """
+                    SELECT CASE WHEN COUNT(*) > 0 THEN TRUE ELSE FALSE END
+                    FROM spec
+                    WHERE measurement = :#{#spec.measurement}
+                      AND unit_of_measurement = :#{#spec.unitOfMeasurement}
+                      AND component = :#{#spec.component}
+                    """, nativeQuery = true)
+                boolean existsByFields(@Param("spec") Spec spec);
+
+        @Query(value = """
+                    SELECT *
+                    FROM spec
+                    WHERE measurement = :#{#spec.measurement}
+                      AND unit_of_measurement = :#{#spec.unitOfMeasurement}
+                      AND component = :#{#spec.component}
+                    LIMIT 1
+                    """, nativeQuery = true)
+                Optional<Spec> findByFields(@Param("spec") Spec spec);
+
 }

--- a/src/main/java/it/sensorplatform/service/SpecService.java
+++ b/src/main/java/it/sensorplatform/service/SpecService.java
@@ -1,43 +1,48 @@
 package it.sensorplatform.service;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import it.sensorplatform.model.Spec;
 
+import it.sensorplatform.model.Spec;
 import it.sensorplatform.repository.SpecRepository;
 
 @Service
 public class SpecService {
-	@Autowired
-	private SpecRepository specRepository;
+        @Autowired
+        private SpecRepository specRepository;
 
-	public List<Spec> findAll() {
-		return (List<Spec>) specRepository.findAll();
-	}
+        public List<Spec> findAll() {
+                return (List<Spec>) specRepository.findAll();
+        }
 
-	public void save(Spec spec) {
-		specRepository.save(spec);
-	}
-	
-	public boolean existsByFields(Spec spec) {
-		return specRepository.existsByFields(spec);
-	}
+        public Spec save(Spec spec) {
+                return specRepository.save(spec);
+        }
 
-	public List<Spec> findAllById(List<Long> specsId) {
-		return (List<Spec>) specRepository.findAllById(specsId);
-	}
+        public boolean existsByFields(Spec spec) {
+                return specRepository.existsByFields(spec);
+        }
 
-	public void deleteSpecById(Long specId) {
-		this.specRepository.deleteById(specId);
-	}
+        public Optional<Spec> findByFields(Spec spec) {
+                return specRepository.findByFields(spec);
+        }
 
-	public Spec findById(Long specId) {
-		return this.specRepository.findById(specId).get();
-	}
+        public List<Spec> findAllById(List<Long> specsId) {
+                return (List<Spec>) specRepository.findAllById(specsId);
+        }
 
-	
-	
-	
+        public void deleteSpecById(Long specId) {
+                this.specRepository.deleteById(specId);
+        }
+
+        public Spec findById(Long specId) {
+                return this.specRepository.findById(specId).get();
+        }
+
+
+
+
 }


### PR DESCRIPTION
## Summary
- add repository and service support for loading specs by measurement/component/unit
- update notification handling to reuse managed specs and persist new ones before saving the type of device

## Testing
- ./mvnw -q test *(fails: unable to download Maven wrapper binaries in the execution environment)*
- mvn -q test *(fails: execution environment cannot reach Maven Central to resolve the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cbcc073e28832790a68a58a4b177ec