### PR TITLE
Add dynamic indicator support by type of device

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -3,12 +3,14 @@ package it.sensorplatform.controller.rest;
 import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.dto.UnknownDeviceNotification;
 import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Indicator;
 import it.sensorplatform.model.Project;
 import it.sensorplatform.model.Spec;
 import it.sensorplatform.model.TypeOfDevice;
 import it.sensorplatform.repository.DeviceRepository;
 import it.sensorplatform.repository.ProjectRepository;
 import it.sensorplatform.repository.TypeOfDeviceRepository;
+import it.sensorplatform.service.IndicatorService;
 import it.sensorplatform.service.SpecService;
 import it.sensorplatform.service.UnknownDeviceService;
 import it.sensorplatform.util.MacAddressUtils;
@@ -22,6 +24,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @RestController
 @RequestMapping("/api/notifications")
@@ -30,6 +33,7 @@ public class NotificationControllerRest {
     private final DeviceRepository deviceRepository;
     private final TypeOfDeviceRepository typeOfDeviceRepository;
     private final SpecService specService;
+    private final IndicatorService indicatorService;
     private final ProjectRepository projectRepository;
     private static final Logger logger = LoggerFactory.getLogger(NotificationControllerRest.class);
 
@@ -37,11 +41,13 @@ public class NotificationControllerRest {
                                       DeviceRepository deviceRepository,
                                       TypeOfDeviceRepository typeOfDeviceRepository,
                                       SpecService specService,
+                                      IndicatorService indicatorService,
                                       ProjectRepository projectRepository) {
         this.unknownDeviceService = unknownDeviceService;
         this.deviceRepository = deviceRepository;
         this.typeOfDeviceRepository = typeOfDeviceRepository;
         this.specService = specService;
+        this.indicatorService = indicatorService;
         this.projectRepository = projectRepository;
     }
 
@@ -60,43 +66,15 @@ public class NotificationControllerRest {
         }
         logger.info("Consumed notification for project {} key {}: mac {} devEui {}", projectId, normalizedKey, notif.getMacAddress(), notif.getDevEui());
         Project project = projectRepository.findById(projectId).orElse(null);
-        TypeOfDevice tod = typeOfDeviceRepository.findByName(notif.getTypeOfDevice()).orElse(null);
-        if (tod == null) {
-            tod = new TypeOfDevice();
-            tod.setName(notif.getTypeOfDevice());
-            List<Spec> specs = new ArrayList<>();
-            if (notif.getSpec() != null) {
-                for (PacketDTO.SpecEntry specEntry : notif.getSpec()) {
-                    if (specEntry == null) {
-                        continue;
-                    }
-                    String label = specEntry.getLabel();
-                    String specKey = sanitize(specEntry.getKey());
-                    if (label == null && specKey == null) {
-                        continue;
-                    }
-                    Spec spec = new Spec();
-                    if (label != null) {
-                        String[] parts = label.split("-");
-                        spec.setComponent(parts.length > 0 ? parts[0] : "");
-                        String measurementPart = parts.length > 1 ? parts[1] : "";
-                        spec.setMeasurement(specKey != null ? specKey : measurementPart);
-                        spec.setUnitOfMeasurement(parts.length > 2 ? parts[2] : "");
-                    } else {
-                        spec.setMeasurement(specKey != null ? specKey : "");
-                    }
-                    if (spec.getComponent() == null) {
-                        spec.setComponent("");
-                    }
-                    if (spec.getUnitOfMeasurement() == null) {
-                        spec.setUnitOfMeasurement("");
-                    }
-                    Spec managedSpec = specService.findByFields(spec)
-                            .orElseGet(() -> specService.save(spec));
-                    specs.add(managedSpec);
-                }
-            }
-            tod.setSpecs(specs);
+        TypeOfDevice tod = typeOfDeviceRepository.findByName(notif.getTypeOfDevice()).orElseGet(() -> {
+            TypeOfDevice created = new TypeOfDevice();
+            created.setName(notif.getTypeOfDevice());
+            return created;
+        });
+
+        boolean specsUpdated = ensureSpecs(tod, notif.getSpec());
+        boolean indicatorsUpdated = ensureIndicators(tod, notif.getIndicator());
+        if (tod.getId() == null || specsUpdated || indicatorsUpdated) {
             typeOfDeviceRepository.save(tod);
         }
 
@@ -141,5 +119,155 @@ public class NotificationControllerRest {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private boolean ensureSpecs(TypeOfDevice tod, List<PacketDTO.SpecEntry> specEntries) {
+        List<Spec> specs = tod.getSpecs() != null ? new ArrayList<>(tod.getSpecs()) : new ArrayList<>();
+        boolean updated = false;
+        if (specEntries != null) {
+            for (PacketDTO.SpecEntry specEntry : specEntries) {
+                if (specEntry == null) {
+                    continue;
+                }
+                String label = specEntry.getLabel();
+                String specKey = sanitize(specEntry.getKey());
+                if (label == null && specKey == null) {
+                    continue;
+                }
+                Spec spec = new Spec();
+                if (label != null) {
+                    String[] parts = label.split("-");
+                    spec.setComponent(parts.length > 0 ? sanitize(parts[0]) : "");
+                    String measurementPart = parts.length > 1 ? sanitize(parts[1]) : "";
+                    spec.setMeasurement(specKey != null ? specKey : measurementPart);
+                    spec.setUnitOfMeasurement(parts.length > 2 ? sanitize(parts[2]) : "");
+                } else {
+                    spec.setMeasurement(specKey != null ? specKey : "");
+                }
+                if (spec.getComponent() == null) {
+                    spec.setComponent("");
+                }
+                if (spec.getUnitOfMeasurement() == null) {
+                    spec.setUnitOfMeasurement("");
+                }
+                Spec managedSpec = specService.findByFields(spec)
+                        .orElseGet(() -> specService.save(spec));
+                if (!specs.contains(managedSpec)) {
+                    specs.add(managedSpec);
+                    updated = true;
+                }
+            }
+        }
+        if (tod.getSpecs() == null || updated) {
+            tod.setSpecs(specs);
+        }
+        return updated;
+    }
+
+    private boolean ensureIndicators(TypeOfDevice tod, List<String> indicatorEntries) {
+        List<Indicator> indicators = tod.getIndicators() != null ? new ArrayList<>(tod.getIndicators()) : new ArrayList<>();
+        boolean updated = false;
+        if (indicatorEntries != null) {
+            for (String raw : indicatorEntries) {
+                Indicator parsed = parseIndicator(raw);
+                if (parsed == null) {
+                    continue;
+                }
+                Indicator managed = indicatorService.findByKey(parsed.getKey())
+                        .map(existing -> updateIndicatorName(existing, parsed.getName()))
+                        .orElseGet(() -> indicatorService.save(parsed));
+                if (!indicators.contains(managed)) {
+                    indicators.add(managed);
+                    updated = true;
+                }
+            }
+        }
+        if (tod.getIndicators() == null || updated) {
+            tod.setIndicators(indicators);
+        }
+        return updated;
+    }
+
+    private Indicator parseIndicator(String raw) {
+        String sanitized = sanitize(raw);
+        if (sanitized == null) {
+            return null;
+        }
+        int separator = findSeparator(sanitized);
+        String keyPart;
+        String labelPart;
+        if (separator > 0) {
+            keyPart = sanitize(sanitized.substring(0, separator));
+            labelPart = sanitize(sanitized.substring(separator + 1));
+        } else {
+            keyPart = null;
+            labelPart = sanitized;
+        }
+        String key = keyPart != null ? keyPart : deriveKeyFromLabel(labelPart);
+        if (key == null) {
+            return null;
+        }
+        String label = labelPart != null ? labelPart : prettify(key);
+        Indicator indicator = new Indicator();
+        indicator.setKey(key);
+        indicator.setName(label != null ? label : key);
+        return indicator;
+    }
+
+    private Indicator updateIndicatorName(Indicator indicator, String candidate) {
+        String sanitizedCandidate = sanitize(candidate);
+        if (sanitizedCandidate != null && !sanitizedCandidate.equals(indicator.getName())) {
+            indicator.setName(sanitizedCandidate);
+            return indicatorService.save(indicator);
+        }
+        return indicator;
+    }
+
+    private int findSeparator(String value) {
+        int colon = value.indexOf(':');
+        int equal = value.indexOf('=');
+        int pipe = value.indexOf('|');
+        int separator = colon > 0 ? colon : -1;
+        if (separator < 0 || (equal > 0 && equal < separator)) {
+            separator = equal;
+        }
+        if (separator < 0 || (pipe > 0 && pipe < separator)) {
+            separator = pipe;
+        }
+        return separator;
+    }
+
+    private String deriveKeyFromLabel(String label) {
+        String sanitized = sanitize(label);
+        if (sanitized == null) {
+            return null;
+        }
+        return sanitized.replace(' ', '_').toLowerCase(Locale.ROOT);
+    }
+
+    private String prettify(String value) {
+        String sanitized = sanitize(value);
+        if (sanitized == null) {
+            return null;
+        }
+        String replaced = sanitized.replace('_', ' ').replace('-', ' ').trim();
+        if (replaced.isEmpty()) {
+            return sanitized;
+        }
+        String[] parts = replaced.split("\\s+");
+        StringBuilder builder = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            if (builder.length() > 0) {
+                builder.append(' ');
+            }
+            builder.append(part.substring(0, 1).toUpperCase());
+            if (part.length() > 1) {
+                builder.append(part.substring(1).toLowerCase());
+            }
+        }
+        return builder.length() > 0 ? builder.toString() : sanitized;
     }
 }

--- a/src/main/java/it/sensorplatform/model/Indicator.java
+++ b/src/main/java/it/sensorplatform/model/Indicator.java
@@ -1,0 +1,67 @@
+package it.sensorplatform.model;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotBlank;
+
+@Entity
+public class Indicator {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @NotBlank
+    @Column(unique = true, nullable = false)
+    private String key;
+
+    @NotBlank
+    @Column(nullable = false)
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Indicator that = (Indicator) o;
+        return Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key);
+    }
+}

--- a/src/main/java/it/sensorplatform/model/TypeOfDevice.java
+++ b/src/main/java/it/sensorplatform/model/TypeOfDevice.java
@@ -3,11 +3,15 @@ package it.sensorplatform.model;
 
 import java.util.List;
 import java.util.Objects;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotBlank;
 
 @Entity
@@ -19,8 +23,15 @@ public class TypeOfDevice {
 	@NotBlank
 	private String name;
 	
-	@ManyToMany
-	private List<Spec> specs;
+        @ManyToMany
+        private List<Spec> specs;
+
+        @OneToMany
+        @JoinTable(
+                        name = "type_of_device_indicator",
+                        joinColumns = @JoinColumn(name = "type_of_device_id"),
+                        inverseJoinColumns = @JoinColumn(name = "indicator_id"))
+        private List<Indicator> indicators;
 
 	public Long getId() {
 		return id;
@@ -42,9 +53,17 @@ public class TypeOfDevice {
 		return specs;
 	}
 
-	public void setSpecs(List<Spec> specs) {
-		this.specs = specs;
-	}
+        public void setSpecs(List<Spec> specs) {
+                this.specs = specs;
+        }
+
+        public List<Indicator> getIndicators() {
+                return indicators;
+        }
+
+        public void setIndicators(List<Indicator> indicators) {
+                this.indicators = indicators;
+        }
 
 	@Override
 	public int hashCode() {

--- a/src/main/java/it/sensorplatform/repository/IndicatorRepository.java
+++ b/src/main/java/it/sensorplatform/repository/IndicatorRepository.java
@@ -1,0 +1,14 @@
+package it.sensorplatform.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import it.sensorplatform.model.Indicator;
+
+@Repository
+public interface IndicatorRepository extends CrudRepository<Indicator, Long> {
+
+        Optional<Indicator> findByKey(String key);
+}

--- a/src/main/java/it/sensorplatform/service/IndicatorService.java
+++ b/src/main/java/it/sensorplatform/service/IndicatorService.java
@@ -1,0 +1,29 @@
+package it.sensorplatform.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import it.sensorplatform.model.Indicator;
+import it.sensorplatform.repository.IndicatorRepository;
+
+@Service
+public class IndicatorService {
+
+        @Autowired
+        private IndicatorRepository indicatorRepository;
+
+        public List<Indicator> findAll() {
+                return (List<Indicator>) indicatorRepository.findAll();
+        }
+
+        public Optional<Indicator> findByKey(String key) {
+                return indicatorRepository.findByKey(key);
+        }
+
+        public Indicator save(Indicator indicator) {
+                return indicatorRepository.save(indicator);
+        }
+}

--- a/src/main/java/it/sensorplatform/service/IngestService.java
+++ b/src/main/java/it/sensorplatform/service/IngestService.java
@@ -2,6 +2,7 @@ package it.sensorplatform.service;
 
 import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Indicator;
 import it.sensorplatform.model.Spec;
 import org.springframework.stereotype.Service;
 
@@ -51,19 +52,11 @@ public class IngestService {
     private final Map<String, Deque<Sample>> store = new ConcurrentHashMap<>();
     private static final int MAX_SAMPLES_PER_DEVICE = 200;
 
-    private static final Map<String, String> INDICATOR_LABELS = Map.of(
-            "sen55_fan_err", "SEN55 Fan Error",
-            "sen55_speed_warn", "SEN55 Speed Warning",
-            "sen55_laser_err", "SEN55 Laser Error",
-            "sen55_rht_err", "SEN55 RHT Error",
-            "sen55_gas_err", "SEN55 Gas Error",
-            "sen55_cleaning", "SEN55 Cleaning"
-    );
-
     private static final Set<String> INFO_KEYS = Set.of(
             "currentDate",
             "currentTime",
             "macAddress",
+            "devEui",
             "bat_V",
             "bat_pct",
             "latitude",
@@ -89,7 +82,10 @@ public class IngestService {
         List<Spec> savedSpecs = device != null && device.getTod() != null && device.getTod().getSpecs() != null
                 ? device.getTod().getSpecs()
                 : List.of();
-        process(deviceId, devEui, ts, metrics, specEntries, indicatorLabels, savedSpecs);
+        List<Indicator> savedIndicators = device != null && device.getTod() != null && device.getTod().getIndicators() != null
+                ? device.getTod().getIndicators()
+                : List.of();
+        process(deviceId, devEui, ts, metrics, specEntries, indicatorLabels, savedSpecs, savedIndicators);
     }
 
     public void process(String deviceId,
@@ -98,7 +94,7 @@ public class IngestService {
                         Map<String, Object> metrics,
                         List<PacketDTO.SpecEntry> specEntries,
                         List<String> indicatorLabels) {
-        process(deviceId, devEui, ts, metrics, specEntries, indicatorLabels, List.of());
+        process(deviceId, devEui, ts, metrics, specEntries, indicatorLabels, List.of(), List.of());
     }
 
     private void process(String deviceId,
@@ -107,7 +103,8 @@ public class IngestService {
                          Map<String, Object> metrics,
                          List<PacketDTO.SpecEntry> specEntries,
                          List<String> indicatorLabels,
-                         List<Spec> savedSpecs) {
+                         List<Spec> savedSpecs,
+                         List<Indicator> savedIndicators) {
         if (deviceId == null && devEui != null) {
             deviceId = devEui.toLowerCase(Locale.ROOT);
         }
@@ -119,6 +116,7 @@ public class IngestService {
         Map<String, Object> safeMetrics = metrics != null ? new LinkedHashMap<>(metrics) : new LinkedHashMap<>();
         List<PacketDTO.SpecEntry> safeSpecEntries = specEntries != null ? specEntries : List.of();
         List<Spec> safeSavedSpecs = savedSpecs != null ? savedSpecs : List.of();
+        List<Indicator> safeSavedIndicators = savedIndicators != null ? savedIndicators : List.of();
 
         List<IndicatorDescriptor> indicatorDescriptors = parseIndicatorDescriptors(indicatorLabels);
         Set<String> indicatorKeyHints = new LinkedHashSet<>();
@@ -127,13 +125,22 @@ public class IngestService {
                 indicatorKeyHints.add(descriptor.key());
             }
         }
+        for (Indicator indicator : safeSavedIndicators) {
+            if (indicator == null) {
+                continue;
+            }
+            String key = sanitize(indicator.getKey());
+            if (key != null) {
+                indicatorKeyHints.add(key);
+            }
+        }
 
         List<MeasurementSample> measurements = buildMeasurements(safeMetrics, safeSpecEntries, safeSavedSpecs, indicatorKeyHints);
         Set<String> measurementKeys = new LinkedHashSet<>();
         for (MeasurementSample measurement : measurements) {
             measurementKeys.add(measurement.key());
         }
-        List<IndicatorSample> indicators = buildIndicators(safeMetrics, indicatorDescriptors, measurementKeys);
+        List<IndicatorSample> indicators = buildIndicators(safeMetrics, indicatorDescriptors, measurementKeys, safeSavedIndicators);
         Map<String, Object> info = extractInfo(safeMetrics);
 
         Deque<Sample> queue = store.computeIfAbsent(deviceId, k -> new ArrayDeque<>());
@@ -190,15 +197,17 @@ public class IngestService {
 
     private List<IndicatorSample> buildIndicators(Map<String, Object> metrics,
                                                   List<IndicatorDescriptor> indicatorDescriptors,
-                                                  Set<String> measurementKeys) {
+                                                  Set<String> measurementKeys,
+                                                  List<Indicator> savedIndicators) {
         List<IndicatorSample> result = new ArrayList<>();
         List<IndicatorDescriptor> safeDescriptors = indicatorDescriptors != null ? indicatorDescriptors : List.of();
-        List<String> indicatorKeys = resolveIndicatorKeys(metrics, safeDescriptors, measurementKeys);
+        Map<String, Indicator> savedIndicatorsByKey = indexSavedIndicators(savedIndicators);
+        List<String> indicatorKeys = resolveIndicatorKeys(metrics, safeDescriptors, measurementKeys, savedIndicatorsByKey);
         for (int i = 0; i < indicatorKeys.size(); i++) {
             String key = indicatorKeys.get(i);
             Object rawValue = metrics.get(key);
             Integer value = toInteger(rawValue);
-            String label = resolveIndicatorLabel(key, safeDescriptors, i);
+            String label = resolveIndicatorLabel(key, safeDescriptors, i, savedIndicatorsByKey);
             result.add(new IndicatorSample(key, label, value));
         }
         return result;
@@ -233,6 +242,23 @@ public class IngestService {
             String key = sanitize(spec.getMeasurement());
             if (key != null && !map.containsKey(key)) {
                 map.put(key, spec);
+            }
+        }
+        return map;
+    }
+
+    private Map<String, Indicator> indexSavedIndicators(List<Indicator> indicators) {
+        Map<String, Indicator> map = new LinkedHashMap<>();
+        if (indicators == null) {
+            return map;
+        }
+        for (Indicator indicator : indicators) {
+            if (indicator == null) {
+                continue;
+            }
+            String key = sanitize(indicator.getKey());
+            if (key != null && !map.containsKey(key)) {
+                map.put(key, indicator);
             }
         }
         return map;
@@ -427,8 +453,12 @@ public class IngestService {
 
     private List<String> resolveIndicatorKeys(Map<String, Object> metrics,
                                               List<IndicatorDescriptor> indicatorDescriptors,
-                                              Set<String> measurementKeys) {
+                                              Set<String> measurementKeys,
+                                              Map<String, Indicator> savedIndicatorsByKey) {
         LinkedHashSet<String> keys = new LinkedHashSet<>();
+        if (savedIndicatorsByKey != null) {
+            keys.addAll(savedIndicatorsByKey.keySet());
+        }
         if (indicatorDescriptors != null) {
             for (IndicatorDescriptor descriptor : indicatorDescriptors) {
                 if (descriptor == null) {
@@ -478,7 +508,8 @@ public class IngestService {
 
     private String resolveIndicatorLabel(String key,
                                          List<IndicatorDescriptor> descriptors,
-                                         int index) {
+                                         int index,
+                                         Map<String, Indicator> savedIndicatorsByKey) {
         if (descriptors != null && !descriptors.isEmpty()) {
             if (index < descriptors.size()) {
                 IndicatorDescriptor descriptor = descriptors.get(index);
@@ -503,8 +534,14 @@ public class IngestService {
                 }
             }
         }
-        if (INDICATOR_LABELS.containsKey(key)) {
-            return INDICATOR_LABELS.get(key);
+        if (savedIndicatorsByKey != null) {
+            Indicator indicator = savedIndicatorsByKey.get(key);
+            if (indicator != null) {
+                String name = sanitize(indicator.getName());
+                if (name != null) {
+                    return name;
+                }
+            }
         }
         String pretty = prettify(key);
         return pretty != null ? pretty : key;

--- a/src/test/java/it/sensorplatform/service/IngestServiceTests.java
+++ b/src/test/java/it/sensorplatform/service/IngestServiceTests.java
@@ -2,6 +2,7 @@ package it.sensorplatform.service;
 
 import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Indicator;
 import it.sensorplatform.model.Spec;
 import it.sensorplatform.model.TypeOfDevice;
 import org.junit.jupiter.api.Test;
@@ -92,6 +93,39 @@ class IngestServiceTests {
         assertEquals("Voc Index", measurement.displayName());
         assertEquals("index", measurement.unit());
         assertEquals(123.0, measurement.value());
+    }
+
+    @Test
+    void usesSavedIndicatorsForLabels() {
+        IngestService ingestService = new IngestService();
+
+        Indicator indicator = new Indicator();
+        indicator.setKey("sen55_fan_err");
+        indicator.setName("SEN55 Fan Error");
+
+        TypeOfDevice typeOfDevice = new TypeOfDevice();
+        typeOfDevice.setName("Indicator Test");
+        typeOfDevice.setIndicators(List.of(indicator));
+
+        Device device = new Device();
+        device.setMacAddress("22:33:44:55:66:77");
+        device.setTod(typeOfDevice);
+
+        ingestService.process(
+                device,
+                Instant.parse("2024-03-01T00:00:00Z"),
+                Map.of("sen55_fan_err", 1),
+                List.of(),
+                List.of()
+        );
+
+        List<IngestService.Sample> samples = ingestService.last(device.getMacAddress(), 1);
+        assertEquals(1, samples.size());
+        IngestService.IndicatorSample indicatorSample = samples.get(0).indicators().get(0);
+
+        assertEquals("sen55_fan_err", indicatorSample.key());
+        assertEquals("SEN55 Fan Error", indicatorSample.label());
+        assertEquals(1, indicatorSample.value());
     }
 }
 

--- a/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
+++ b/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
@@ -9,6 +9,7 @@ import it.sensorplatform.model.TypeOfDevice;
 import it.sensorplatform.repository.DeviceRepository;
 import it.sensorplatform.repository.ProjectRepository;
 import it.sensorplatform.repository.TypeOfDeviceRepository;
+import it.sensorplatform.service.IndicatorService;
 import it.sensorplatform.service.SpecService;
 import it.sensorplatform.service.UnknownDeviceService;
 import it.sensorplatform.util.MacAddressUtils;
@@ -38,6 +39,7 @@ class NotificationControllerRestTests {
         DeviceRepository deviceRepository = mock(DeviceRepository.class);
         TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
         SpecService specService = mock(SpecService.class);
+        IndicatorService indicatorService = mock(IndicatorService.class);
         ProjectRepository projectRepository = mock(ProjectRepository.class);
 
         Long projectId = 1L;
@@ -67,6 +69,7 @@ class NotificationControllerRestTests {
                 deviceRepository,
                 typeOfDeviceRepository,
                 specService,
+                indicatorService,
                 projectRepository
         );
 
@@ -77,10 +80,10 @@ class NotificationControllerRestTests {
         ArgumentCaptor<Device> deviceCaptor = ArgumentCaptor.forClass(Device.class);
         verify(deviceRepository).save(deviceCaptor.capture());
         Device savedDevice = deviceCaptor.getValue();
-        assertEquals("DEV123", savedDevice.getMacAddress());
+        assertNull(savedDevice.getMacAddress());
         assertEquals("DEV123", savedDevice.getDevEui());
 
-        assertTrue(output.getOut().contains("using DevEUI DEV123 as MAC address"));
+        assertTrue(output.getOut().contains("MAC address missing; persisting device with DevEUI DEV123 only"));
     }
 
     @Test
@@ -89,6 +92,7 @@ class NotificationControllerRestTests {
         DeviceRepository deviceRepository = mock(DeviceRepository.class);
         TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
         SpecService specService = mock(SpecService.class);
+        IndicatorService indicatorService = mock(IndicatorService.class);
         ProjectRepository projectRepository = mock(ProjectRepository.class);
 
         Long projectId = 1L;
@@ -117,6 +121,7 @@ class NotificationControllerRestTests {
                 deviceRepository,
                 typeOfDeviceRepository,
                 specService,
+                indicatorService,
                 projectRepository
         );
 


### PR DESCRIPTION
## Summary
- introduce the Indicator entity with repository/service and link it to TypeOfDevice through a one-to-many association
- extend the notification flow to dynamically create or associate specs and indicators per type of device while reusing existing definitions
- update the ingest pipeline to consume stored indicators for labeling, remove static indicator mappings, and add coverage for the new behaviour
- adjust NotificationControllerRest unit tests to inject the new IndicatorService dependency and match the updated logging behaviour when DevEUI is used without a MAC

## Testing
- mvn test *(fails: unable to reach repo.maven.apache.org to download parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe2b56dd48327819a9642ac4bb8d0