### PR TITLE
Normalize indicator deserialization in PacketDTO

### DIFF
--- a/src/main/java/it/sensorplatform/dto/PacketDTO.java
+++ b/src/main/java/it/sensorplatform/dto/PacketDTO.java
@@ -1,5 +1,9 @@
 package it.sensorplatform.dto;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -96,8 +100,103 @@ public class PacketDTO {
         return indicator;
     }
 
-    public void setIndicator(List<String> indicator) {
-        this.indicator = indicator;
+    @JsonSetter("indicator")
+    public void setIndicator(List<?> indicator) {
+        if (indicator == null) {
+            this.indicator = null;
+            return;
+        }
+        List<String> normalized = new ArrayList<>(indicator.size());
+        for (Object entry : indicator) {
+            normalized.add(normalizeIndicatorEntry(entry));
+        }
+        this.indicator = normalized;
+    }
+
+    private String normalizeIndicatorEntry(Object entry) {
+        if (entry == null) {
+            return null;
+        }
+        if (entry instanceof String stringEntry) {
+            return stringEntry;
+        }
+        if (entry instanceof Map<?, ?> mapEntry) {
+            String key = extractFromMap(mapEntry, "key");
+            String label = extractFromMap(mapEntry, "label", "name");
+            return buildCanonicalIndicator(key, label, mapEntry);
+        }
+        String key = extractProperty(entry, "getKey", "key");
+        String label = extractProperty(entry, "getLabel", "getName", "label", "name");
+        return buildCanonicalIndicator(key, label, entry);
+    }
+
+    private String extractFromMap(Map<?, ?> map, String... keys) {
+        for (String candidate : keys) {
+            Object value = map.get(candidate);
+            if (value == null) {
+                for (Map.Entry<?, ?> entry : map.entrySet()) {
+                    if (entry.getKey() instanceof String key && candidate.equalsIgnoreCase(key)) {
+                        value = entry.getValue();
+                        break;
+                    }
+                }
+            }
+            String extracted = trimToNull(asString(value));
+            if (extracted != null) {
+                return extracted;
+            }
+        }
+        return null;
+    }
+
+    private String extractProperty(Object target, String... methodNames) {
+        for (String methodName : methodNames) {
+            try {
+                Object value = target.getClass().getMethod(methodName).invoke(target);
+                String extracted = trimToNull(asString(value));
+                if (extracted != null) {
+                    return extracted;
+                }
+            } catch (NoSuchMethodException ignored) {
+                // Accessor not exposed, continue with the next candidate
+            } catch (IllegalAccessException | InvocationTargetException ignored) {
+                // Accessor not accessible, continue with the next candidate
+            }
+        }
+        return null;
+    }
+
+    private String buildCanonicalIndicator(String key, String label, Object fallback) {
+        String normalizedKey = trimToNull(key);
+        String normalizedLabel = trimToNull(label);
+        if (normalizedKey != null && normalizedLabel != null) {
+            return normalizedKey + ":" + normalizedLabel;
+        }
+        if (normalizedKey != null) {
+            return normalizedKey;
+        }
+        if (normalizedLabel != null) {
+            return normalizedLabel;
+        }
+        return fallback != null ? fallback.toString() : null;
+    }
+
+    private String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String stringValue) {
+            return stringValue;
+        }
+        return value.toString();
+    }
+
+    private String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     public static class SpecEntry {

--- a/src/test/java/it/sensorplatform/dto/PacketDTOTest.java
+++ b/src/test/java/it/sensorplatform/dto/PacketDTOTest.java
@@ -1,0 +1,55 @@
+package it.sensorplatform.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.sensorplatform.model.Indicator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PacketDTOTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void deserializesIndicatorObjectsIntoCanonicalStrings() throws Exception {
+        String json = """
+                {
+                  "indicator": [
+                    "plain",
+                    {"key": "fan_err", "label": "Fan Error"},
+                    {"key": "status", "name": "Status"},
+                    {"label": "Only Label"},
+                    {"name": "Name Only"},
+                    {"key": "solo_key"},
+                    {"key": "spaced", "label": " Trim "}
+                  ]
+                }
+                """;
+
+        PacketDTO dto = objectMapper.readValue(json, PacketDTO.class);
+
+        assertEquals(List.of(
+                "plain",
+                "fan_err:Fan Error",
+                "status:Status",
+                "Only Label",
+                "Name Only",
+                "solo_key",
+                "spaced:Trim"
+        ), dto.getIndicator());
+    }
+
+    @Test
+    void setterAcceptsPojoIndicators() {
+        PacketDTO dto = new PacketDTO();
+        Indicator indicator = new Indicator();
+        indicator.setKey("pojo_key");
+        indicator.setName("Pojo Name");
+
+        dto.setIndicator(List.of(indicator));
+
+        assertEquals(List.of("pojo_key:Pojo Name"), dto.getIndicator());
+    }
+}


### PR DESCRIPTION
## Summary
- allow PacketDTO to accept indicator entries provided as strings, maps or POJOs
- normalise indicator objects into the canonical "key:label" format expected downstream
- add unit tests covering JSON deserialisation and POJO setter usage

## Testing
- ./mvnw -q -Dtest=PacketDTOTest test *(fails: Maven wrapper cannot download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1902e560832384281aa4ba396885