### PR TITLE
Normalize spec measurement extracted from labels

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -135,21 +135,13 @@ public class NotificationControllerRest {
                     continue;
                 }
                 Spec spec = new Spec();
-                if (label != null) {
-                    String[] parts = label.split("-");
-                    spec.setComponent(parts.length > 0 ? sanitize(parts[0]) : "");
-                    String measurementPart = parts.length > 1 ? sanitize(parts[1]) : "";
-                    spec.setMeasurement(specKey != null ? specKey : measurementPart);
-                    spec.setUnitOfMeasurement(parts.length > 2 ? sanitize(parts[2]) : "");
-                } else {
-                    spec.setMeasurement(specKey != null ? specKey : "");
-                }
-                if (spec.getComponent() == null) {
-                    spec.setComponent("");
-                }
-                if (spec.getUnitOfMeasurement() == null) {
-                    spec.setUnitOfMeasurement("");
-                }
+                LabelParts parts = parseLabel(label);
+                spec.setComponent(parts.component());
+                spec.setUnitOfMeasurement(parts.unitOfMeasurement());
+                String normalizedMeasurement = parts.measurement() != null
+                        ? parts.measurement()
+                        : normalizeMeasurement(specKey);
+                spec.setMeasurement(normalizedMeasurement != null ? normalizedMeasurement : "");
                 Spec managedSpec = specService.findByFields(spec)
                         .orElseGet(() -> specService.save(spec));
                 if (!specs.contains(managedSpec)) {
@@ -162,6 +154,41 @@ public class NotificationControllerRest {
             tod.setSpecs(specs);
         }
         return updated;
+    }
+
+    private String normalizeMeasurement(String value) {
+        String sanitized = sanitize(value);
+        return sanitized != null ? sanitized.toLowerCase(Locale.ROOT) : null;
+    }
+
+    private LabelParts parseLabel(String rawLabel) {
+        String sanitizedLabel = sanitize(rawLabel);
+        if (sanitizedLabel == null) {
+            return new LabelParts("", null, "");
+        }
+        int firstHyphen = sanitizedLabel.indexOf('-');
+        int lastHyphen = sanitizedLabel.lastIndexOf('-');
+        String component = firstHyphen > 0
+                ? sanitize(sanitizedLabel.substring(0, firstHyphen))
+                : sanitize(sanitizedLabel);
+        String unit = lastHyphen >= 0 && lastHyphen < sanitizedLabel.length() - 1
+                ? sanitize(sanitizedLabel.substring(lastHyphen + 1))
+                : "";
+        String measurement = null;
+        if (firstHyphen >= 0 && lastHyphen > firstHyphen) {
+            String betweenHyphens = sanitizedLabel.substring(firstHyphen + 1, lastHyphen);
+            measurement = normalizeMeasurement(betweenHyphens);
+        }
+        if (component == null) {
+            component = "";
+        }
+        if (unit == null) {
+            unit = "";
+        }
+        return new LabelParts(component, measurement, unit);
+    }
+
+    private record LabelParts(String component, String measurement, String unitOfMeasurement) {
     }
 
     private boolean ensureIndicators(TypeOfDevice tod, List<String> indicatorEntries) {

--- a/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
+++ b/src/test/java/it/sensorplatform/test/NotificationControllerRestTests.java
@@ -5,6 +5,7 @@ import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.dto.UnknownDeviceNotification;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.model.Project;
+import it.sensorplatform.model.Spec;
 import it.sensorplatform.model.TypeOfDevice;
 import it.sensorplatform.repository.DeviceRepository;
 import it.sensorplatform.repository.ProjectRepository;
@@ -28,6 +29,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(OutputCaptureExtension.class)
@@ -129,6 +131,61 @@ class NotificationControllerRestTests {
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         verify(deviceRepository, never()).existsByDevEui(any());
+    }
+
+    @Test
+    void addDeviceExtractsMeasurementFromSpecLabel() {
+        UnknownDeviceService unknownDeviceService = mock(UnknownDeviceService.class);
+        DeviceRepository deviceRepository = mock(DeviceRepository.class);
+        TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
+        SpecService specService = mock(SpecService.class);
+        IndicatorService indicatorService = mock(IndicatorService.class);
+        ProjectRepository projectRepository = mock(ProjectRepository.class);
+
+        Long projectId = 1L;
+        String key = "key";
+        String normalizedKey = MacAddressUtils.normalize(key);
+
+        PacketDTO.SpecEntry specEntry = new PacketDTO.SpecEntry();
+        specEntry.setLabel("node-TEMPERATURE-celsius");
+        specEntry.setKey("node-TEMPERATURE-celsius");
+
+        UnknownDeviceNotification notif = new UnknownDeviceNotification(
+                normalizedKey,
+                "AA:BB:CC:DD:EE:FF",
+                "DEV123",
+                projectId,
+                "type",
+                Map.of(),
+                List.of(specEntry),
+                List.of(),
+                Instant.now()
+        );
+
+        when(unknownDeviceService.consume(projectId, normalizedKey)).thenReturn(notif);
+        when(typeOfDeviceRepository.findByName("type")).thenReturn(Optional.of(new TypeOfDevice()));
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(new Project()));
+        when(deviceRepository.existsByMacAddress(anyString())).thenReturn(false);
+        when(deviceRepository.existsByDevEui(anyString())).thenReturn(false);
+        when(deviceRepository.save(any(Device.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(specService.findByFields(any(Spec.class))).thenReturn(Optional.empty());
+        when(specService.save(any(Spec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationControllerRest controller = new NotificationControllerRest(
+                unknownDeviceService,
+                deviceRepository,
+                typeOfDeviceRepository,
+                specService,
+                indicatorService,
+                projectRepository
+        );
+
+        controller.addDevice(projectId, key);
+
+        ArgumentCaptor<Spec> specCaptor = ArgumentCaptor.forClass(Spec.class);
+        verify(specService).save(specCaptor.capture());
+        Spec savedSpec = specCaptor.getValue();
+        assertEquals("temperature", savedSpec.getMeasurement());
     }
 }
 


### PR DESCRIPTION
## Summary
- refine spec label parsing to capture the measurement strictly between hyphens while leaving the spec key untouched
- centralize label parsing in a dedicated helper that normalizes measurement tokens yet preserves component and unit defaults

## Testing
- `./mvnw -Dtest=NotificationControllerRestTests test` *(fails: wget cannot reach Maven repository to download Maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1cb6c8d48323a930b230231956b9