### PR TITLE
Improve spec measurement derivation from labels

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -138,17 +138,21 @@ public class NotificationControllerRest {
                 if (label != null) {
                     String[] parts = label.split("-");
                     spec.setComponent(parts.length > 0 ? sanitize(parts[0]) : "");
-                    String measurementPart = parts.length > 1 ? sanitize(parts[1]) : "";
-                    spec.setMeasurement(specKey != null ? specKey : measurementPart);
                     spec.setUnitOfMeasurement(parts.length > 2 ? sanitize(parts[2]) : "");
                 } else {
-                    spec.setMeasurement(specKey != null ? specKey : "");
+                    spec.setComponent("");
+                    spec.setUnitOfMeasurement("");
                 }
+                String measurement = determineMeasurement(label, specKey);
+                spec.setMeasurement(measurement != null ? measurement : "");
                 if (spec.getComponent() == null) {
                     spec.setComponent("");
                 }
                 if (spec.getUnitOfMeasurement() == null) {
                     spec.setUnitOfMeasurement("");
+                }
+                if (spec.getMeasurement() == null) {
+                    spec.setMeasurement("");
                 }
                 Spec managedSpec = specService.findByFields(spec)
                         .orElseGet(() -> specService.save(spec));
@@ -162,6 +166,39 @@ public class NotificationControllerRest {
             tod.setSpecs(specs);
         }
         return updated;
+    }
+
+    private String determineMeasurement(String label, String specKey) {
+        String measurementFromLabel = extractMeasurementSegment(label);
+        if (measurementFromLabel != null) {
+            return measurementFromLabel;
+        }
+        String measurementFromKey = extractMeasurementSegment(specKey);
+        if (measurementFromKey != null) {
+            return measurementFromKey;
+        }
+        return sanitize(specKey);
+    }
+
+    private String extractMeasurementSegment(String value) {
+        String sanitized = sanitize(value);
+        if (sanitized == null) {
+            return null;
+        }
+        String[] parts = sanitized.split("-");
+        if (parts.length < 2) {
+            return null;
+        }
+        if (parts.length == 2) {
+            return sanitize(parts[1]);
+        }
+        for (int i = 1; i < parts.length - 1; i++) {
+            String candidate = sanitize(parts[i]);
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+        return sanitize(parts[1]);
     }
 
     private boolean ensureIndicators(TypeOfDevice tod, List<String> indicatorEntries) {

--- a/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
+++ b/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
@@ -1,0 +1,65 @@
+package it.sensorplatform.controller.rest;
+
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Spec;
+import it.sensorplatform.model.TypeOfDevice;
+import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.repository.ProjectRepository;
+import it.sensorplatform.repository.TypeOfDeviceRepository;
+import it.sensorplatform.service.IndicatorService;
+import it.sensorplatform.service.SpecService;
+import it.sensorplatform.service.UnknownDeviceService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationControllerRestTest {
+
+    @Test
+    void ensureSpecsUsesMeasurementSegmentFromLabel() throws Exception {
+        UnknownDeviceService unknownDeviceService = mock(UnknownDeviceService.class);
+        DeviceRepository deviceRepository = mock(DeviceRepository.class);
+        TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
+        SpecService specService = mock(SpecService.class);
+        IndicatorService indicatorService = mock(IndicatorService.class);
+        ProjectRepository projectRepository = mock(ProjectRepository.class);
+
+        when(specService.findByFields(any(Spec.class))).thenReturn(Optional.empty());
+        when(specService.save(any(Spec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationControllerRest controller = new NotificationControllerRest(
+                unknownDeviceService,
+                deviceRepository,
+                typeOfDeviceRepository,
+                specService,
+                indicatorService,
+                projectRepository
+        );
+
+        PacketDTO.SpecEntry specEntry = new PacketDTO.SpecEntry();
+        specEntry.setKey("SEN55-VOC-index");
+        specEntry.setLabel("SEN55-VOC-index");
+
+        List<PacketDTO.SpecEntry> entries = List.of(specEntry);
+        TypeOfDevice typeOfDevice = new TypeOfDevice();
+
+        Method ensureSpecs = NotificationControllerRest.class
+                .getDeclaredMethod("ensureSpecs", TypeOfDevice.class, List.class);
+        ensureSpecs.setAccessible(true);
+        ensureSpecs.invoke(controller, typeOfDevice, entries);
+
+        ArgumentCaptor<Spec> specCaptor = ArgumentCaptor.forClass(Spec.class);
+        verify(specService).save(specCaptor.capture());
+        assertEquals("VOC", specCaptor.getValue().getMeasurement());
+    }
+}
+


### PR DESCRIPTION
## Summary
- prefer extracting the measurement segment from spec labels or keys before falling back to the raw key
- add helper methods to keep spec measurement parsing consistent
- introduce a regression unit test that verifies SEN55 VOC specs persist the expected measurement

## Testing
- mvn test *(fails: unable to resolve the Spring Boot parent POM because external network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2c91012c83238f9037528971778c