### PR TITLE
Normalize legacy specs when ensuring specs

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -135,25 +135,61 @@ public class NotificationControllerRest {
                     continue;
                 }
                 Spec spec = new Spec();
+                String component;
+                String unitOfMeasurement;
                 if (label != null) {
                     String[] parts = label.split("-");
-                    spec.setComponent(parts.length > 0 ? sanitize(parts[0]) : "");
-                    spec.setUnitOfMeasurement(parts.length > 2 ? sanitize(parts[2]) : "");
+                    component = parts.length > 0 ? sanitize(parts[0]) : "";
+                    unitOfMeasurement = parts.length > 2 ? sanitize(parts[2]) : "";
                 } else {
-                    spec.setComponent("");
-                    spec.setUnitOfMeasurement("");
+                    component = "";
+                    unitOfMeasurement = "";
                 }
                 String measurement = determineMeasurement(label, specKey);
-                spec.setMeasurement(measurement != null ? measurement : "");
-                if (spec.getComponent() == null) {
-                    spec.setComponent("");
+                component = component != null ? component : "";
+                unitOfMeasurement = unitOfMeasurement != null ? unitOfMeasurement : "";
+                String normalizedMeasurement = measurement != null ? measurement : "";
+
+                List<String> legacyCandidates = new ArrayList<>();
+                String sanitizedLabel = label != null ? sanitize(label) : null;
+                if (sanitizedLabel != null) {
+                    legacyCandidates.add(sanitizedLabel);
                 }
-                if (spec.getUnitOfMeasurement() == null) {
-                    spec.setUnitOfMeasurement("");
+                if (specKey != null) {
+                    legacyCandidates.add(specKey);
                 }
-                if (spec.getMeasurement() == null) {
-                    spec.setMeasurement("");
+
+                if (!legacyCandidates.isEmpty()) {
+                    Spec legacySpec = specs.stream()
+                            .filter(existing -> component.equals(existing.getComponent())
+                                    && legacyCandidates.contains(existing.getMeasurement()))
+                            .findFirst()
+                            .orElse(null);
+                    if (legacySpec != null) {
+                        boolean changed = false;
+                        if (!normalizedMeasurement.equals(legacySpec.getMeasurement())) {
+                            legacySpec.setMeasurement(normalizedMeasurement);
+                            changed = true;
+                        }
+                        if (!unitOfMeasurement.equals(legacySpec.getUnitOfMeasurement())) {
+                            legacySpec.setUnitOfMeasurement(unitOfMeasurement);
+                            changed = true;
+                        }
+                        if (changed) {
+                            Spec savedLegacy = specService.save(legacySpec);
+                            int index = specs.indexOf(legacySpec);
+                            if (index >= 0) {
+                                specs.set(index, savedLegacy);
+                            }
+                            updated = true;
+                        }
+                        continue;
+                    }
                 }
+
+                spec.setComponent(component);
+                spec.setUnitOfMeasurement(unitOfMeasurement);
+                spec.setMeasurement(normalizedMeasurement);
                 Spec managedSpec = specService.findByFields(spec)
                         .orElseGet(() -> specService.save(spec));
                 if (!specs.contains(managedSpec)) {

--- a/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
+++ b/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,6 +61,52 @@ class NotificationControllerRestTest {
         ArgumentCaptor<Spec> specCaptor = ArgumentCaptor.forClass(Spec.class);
         verify(specService).save(specCaptor.capture());
         assertEquals("VOC", specCaptor.getValue().getMeasurement());
+    }
+
+    @Test
+    void ensureSpecsNormalizesLegacyMeasurementEntries() throws Exception {
+        UnknownDeviceService unknownDeviceService = mock(UnknownDeviceService.class);
+        DeviceRepository deviceRepository = mock(DeviceRepository.class);
+        TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
+        SpecService specService = mock(SpecService.class);
+        IndicatorService indicatorService = mock(IndicatorService.class);
+        ProjectRepository projectRepository = mock(ProjectRepository.class);
+
+        when(specService.save(any(Spec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationControllerRest controller = new NotificationControllerRest(
+                unknownDeviceService,
+                deviceRepository,
+                typeOfDeviceRepository,
+                specService,
+                indicatorService,
+                projectRepository
+        );
+
+        PacketDTO.SpecEntry specEntry = new PacketDTO.SpecEntry();
+        specEntry.setKey("SEN55-VOC-index");
+        specEntry.setLabel("SEN55-VOC-index");
+
+        Spec legacySpec = new Spec();
+        legacySpec.setComponent("SEN55");
+        legacySpec.setMeasurement("SEN55-VOC-index");
+        legacySpec.setUnitOfMeasurement("");
+
+        TypeOfDevice typeOfDevice = new TypeOfDevice();
+        typeOfDevice.setSpecs(new ArrayList<>(List.of(legacySpec)));
+
+        Method ensureSpecs = NotificationControllerRest.class
+                .getDeclaredMethod("ensureSpecs", TypeOfDevice.class, List.class);
+        ensureSpecs.setAccessible(true);
+        ensureSpecs.invoke(controller, typeOfDevice, List.of(specEntry));
+
+        List<Spec> resultingSpecs = typeOfDevice.getSpecs();
+        assertEquals(1, resultingSpecs.size());
+        Spec updatedSpec = resultingSpecs.get(0);
+        assertEquals("VOC", updatedSpec.getMeasurement());
+        assertEquals("index", updatedSpec.getUnitOfMeasurement());
+
+        verify(specService).save(legacySpec);
     }
 }
 


### PR DESCRIPTION
## Summary
- update ensureSpecs to normalize existing specs whose measurements still contain legacy key or label values
- persist updated legacy specs and reuse them instead of creating duplicates on the type of device
- add a unit test verifying that legacy specs are normalized in place

## Testing
- ./mvnw -q test *(fails: unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc352b782883238d686b9ce5eca2e2