### PR TITLE
Normalize legacy specs when ensuring specs

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -135,25 +135,62 @@ public class NotificationControllerRest {
                     continue;
                 }
                 Spec spec = new Spec();
+                String component;
+                String unitOfMeasurement;
                 if (label != null) {
                     String[] parts = label.split("-");
-                    spec.setComponent(parts.length > 0 ? sanitize(parts[0]) : "");
-                    spec.setUnitOfMeasurement(parts.length > 2 ? sanitize(parts[2]) : "");
+                    component = parts.length > 0 ? sanitize(parts[0]) : "";
+                    unitOfMeasurement = parts.length > 2 ? sanitize(parts[2]) : "";
                 } else {
-                    spec.setComponent("");
-                    spec.setUnitOfMeasurement("");
+                    component = "";
+                    unitOfMeasurement = "";
                 }
                 String measurement = determineMeasurement(label, specKey);
-                spec.setMeasurement(measurement != null ? measurement : "");
-                if (spec.getComponent() == null) {
-                    spec.setComponent("");
+                String normalizedComponent = component != null ? component : "";
+                String normalizedUnitOfMeasurement = unitOfMeasurement != null ? unitOfMeasurement : "";
+                String normalizedMeasurement = measurement != null ? measurement : "";
+
+                List<String> legacyCandidates = new ArrayList<>();
+                String sanitizedLabel = label != null ? sanitize(label) : null;
+                if (sanitizedLabel != null) {
+                    legacyCandidates.add(sanitizedLabel);
                 }
-                if (spec.getUnitOfMeasurement() == null) {
-                    spec.setUnitOfMeasurement("");
+                if (specKey != null) {
+                    legacyCandidates.add(specKey);
                 }
-                if (spec.getMeasurement() == null) {
-                    spec.setMeasurement("");
+
+                if (!legacyCandidates.isEmpty()) {
+                    final String componentKey = normalizedComponent;
+                    Spec legacySpec = specs.stream()
+                            .filter(existing -> componentKey.equals(existing.getComponent())
+                                    && legacyCandidates.contains(existing.getMeasurement()))
+                            .findFirst()
+                            .orElse(null);
+                    if (legacySpec != null) {
+                        boolean changed = false;
+                        if (!normalizedMeasurement.equals(legacySpec.getMeasurement())) {
+                            legacySpec.setMeasurement(normalizedMeasurement);
+                            changed = true;
+                        }
+                        if (!normalizedUnitOfMeasurement.equals(legacySpec.getUnitOfMeasurement())) {
+                            legacySpec.setUnitOfMeasurement(normalizedUnitOfMeasurement);
+                            changed = true;
+                        }
+                        if (changed) {
+                            Spec savedLegacy = specService.save(legacySpec);
+                            int index = specs.indexOf(legacySpec);
+                            if (index >= 0) {
+                                specs.set(index, savedLegacy);
+                            }
+                            updated = true;
+                        }
+                        continue;
+                    }
                 }
+
+                spec.setComponent(normalizedComponent);
+                spec.setUnitOfMeasurement(normalizedUnitOfMeasurement);
+                spec.setMeasurement(normalizedMeasurement);
                 Spec managedSpec = specService.findByFields(spec)
                         .orElseGet(() -> specService.save(spec));
                 if (!specs.contains(managedSpec)) {

--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -138,17 +138,21 @@ public class NotificationControllerRest {
                 if (label != null) {
                     String[] parts = label.split("-");
                     spec.setComponent(parts.length > 0 ? sanitize(parts[0]) : "");
-                    String measurementPart = parts.length > 1 ? sanitize(parts[1]) : "";
-                    spec.setMeasurement(specKey != null ? specKey : measurementPart);
                     spec.setUnitOfMeasurement(parts.length > 2 ? sanitize(parts[2]) : "");
                 } else {
-                    spec.setMeasurement(specKey != null ? specKey : "");
+                    spec.setComponent("");
+                    spec.setUnitOfMeasurement("");
                 }
+                String measurement = determineMeasurement(label, specKey);
+                spec.setMeasurement(measurement != null ? measurement : "");
                 if (spec.getComponent() == null) {
                     spec.setComponent("");
                 }
                 if (spec.getUnitOfMeasurement() == null) {
                     spec.setUnitOfMeasurement("");
+                }
+                if (spec.getMeasurement() == null) {
+                    spec.setMeasurement("");
                 }
                 Spec managedSpec = specService.findByFields(spec)
                         .orElseGet(() -> specService.save(spec));
@@ -162,6 +166,39 @@ public class NotificationControllerRest {
             tod.setSpecs(specs);
         }
         return updated;
+    }
+
+    private String determineMeasurement(String label, String specKey) {
+        String measurementFromLabel = extractMeasurementSegment(label);
+        if (measurementFromLabel != null) {
+            return measurementFromLabel;
+        }
+        String measurementFromKey = extractMeasurementSegment(specKey);
+        if (measurementFromKey != null) {
+            return measurementFromKey;
+        }
+        return sanitize(specKey);
+    }
+
+    private String extractMeasurementSegment(String value) {
+        String sanitized = sanitize(value);
+        if (sanitized == null) {
+            return null;
+        }
+        String[] parts = sanitized.split("-");
+        if (parts.length < 2) {
+            return null;
+        }
+        if (parts.length == 2) {
+            return sanitize(parts[1]);
+        }
+        for (int i = 1; i < parts.length - 1; i++) {
+            String candidate = sanitize(parts[i]);
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+        return sanitize(parts[1]);
     }
 
     private boolean ensureIndicators(TypeOfDevice tod, List<String> indicatorEntries) {

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -83,7 +83,7 @@ insert into device(latitude, longitude, id, project_id, email_owner, mac_address
 insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(40.639470, 17.694360, 17, 101, 'jhon30.herrera@gmail.com', '7C:06:1C:EC:E7:36', 'Amber5', 3, 7, 'activated'); -- Lecce
 insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(38.193791, 15.554045, 18, 101, 'jhon30.herrera@gmail.com', '8D:06:1C:EC:E7:37', 'Amber6', 3, 7, 'deactivated'); -- Messina
 
-insert into spec(id, measurement, unit_of_measurement, component)values(1, 'Temperature', '°C' ,'Sen5x')
+/*insert into spec(id, measurement, unit_of_measurement, component)values(1, 'Temperature', '°C' ,'Sen5x')
 insert into spec(id, measurement, unit_of_measurement, component)values(2, 'Relative Humidity', '%RH' ,'Sen5x')
 insert into spec(id, measurement, unit_of_measurement, component)values(3, 'VOC', 'Index (0-500)' ,'Sen5x')
 insert into spec(id, measurement, unit_of_measurement, component)values(4, 'PM 1.0', 'µg/m³' ,'Sen5x')
@@ -112,7 +112,7 @@ insert into type_of_device_specs(specs_id, type_of_device_id)values(11, 3)
 insert into type_of_device_specs(specs_id, type_of_device_id)values(12, 3)
 insert into type_of_device_specs(specs_id, type_of_device_id)values(13, 3)
 insert into type_of_device_specs(specs_id, type_of_device_id)values(14, 2)
-
+*/
 
 
 -- 6. Reset sequenze
@@ -124,6 +124,7 @@ SELECT setval('app_group_seq', (SELECT MAX(id) FROM app_group));
 SELECT setval('device_seq', (SELECT MAX(id) FROM device));
 SELECT setval('type_of_device_seq', (SELECT MAX(id) FROM type_of_device));
 SELECT setval('spec_seq', (SELECT MAX(id) FROM spec));
+
 
 
 

--- a/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
+++ b/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
@@ -1,0 +1,65 @@
+package it.sensorplatform.controller.rest;
+
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Spec;
+import it.sensorplatform.model.TypeOfDevice;
+import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.repository.ProjectRepository;
+import it.sensorplatform.repository.TypeOfDeviceRepository;
+import it.sensorplatform.service.IndicatorService;
+import it.sensorplatform.service.SpecService;
+import it.sensorplatform.service.UnknownDeviceService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NotificationControllerRestTest {
+
+    @Test
+    void ensureSpecsUsesMeasurementSegmentFromLabel() throws Exception {
+        UnknownDeviceService unknownDeviceService = mock(UnknownDeviceService.class);
+        DeviceRepository deviceRepository = mock(DeviceRepository.class);
+        TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
+        SpecService specService = mock(SpecService.class);
+        IndicatorService indicatorService = mock(IndicatorService.class);
+        ProjectRepository projectRepository = mock(ProjectRepository.class);
+
+        when(specService.findByFields(any(Spec.class))).thenReturn(Optional.empty());
+        when(specService.save(any(Spec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationControllerRest controller = new NotificationControllerRest(
+                unknownDeviceService,
+                deviceRepository,
+                typeOfDeviceRepository,
+                specService,
+                indicatorService,
+                projectRepository
+        );
+
+        PacketDTO.SpecEntry specEntry = new PacketDTO.SpecEntry();
+        specEntry.setKey("SEN55-VOC-index");
+        specEntry.setLabel("SEN55-VOC-index");
+
+        List<PacketDTO.SpecEntry> entries = List.of(specEntry);
+        TypeOfDevice typeOfDevice = new TypeOfDevice();
+
+        Method ensureSpecs = NotificationControllerRest.class
+                .getDeclaredMethod("ensureSpecs", TypeOfDevice.class, List.class);
+        ensureSpecs.setAccessible(true);
+        ensureSpecs.invoke(controller, typeOfDevice, entries);
+
+        ArgumentCaptor<Spec> specCaptor = ArgumentCaptor.forClass(Spec.class);
+        verify(specService).save(specCaptor.capture());
+        assertEquals("VOC", specCaptor.getValue().getMeasurement());
+    }
+}
+

--- a/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
+++ b/src/test/java/it/sensorplatform/controller/rest/NotificationControllerRestTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,6 +61,52 @@ class NotificationControllerRestTest {
         ArgumentCaptor<Spec> specCaptor = ArgumentCaptor.forClass(Spec.class);
         verify(specService).save(specCaptor.capture());
         assertEquals("VOC", specCaptor.getValue().getMeasurement());
+    }
+
+    @Test
+    void ensureSpecsNormalizesLegacyMeasurementEntries() throws Exception {
+        UnknownDeviceService unknownDeviceService = mock(UnknownDeviceService.class);
+        DeviceRepository deviceRepository = mock(DeviceRepository.class);
+        TypeOfDeviceRepository typeOfDeviceRepository = mock(TypeOfDeviceRepository.class);
+        SpecService specService = mock(SpecService.class);
+        IndicatorService indicatorService = mock(IndicatorService.class);
+        ProjectRepository projectRepository = mock(ProjectRepository.class);
+
+        when(specService.save(any(Spec.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationControllerRest controller = new NotificationControllerRest(
+                unknownDeviceService,
+                deviceRepository,
+                typeOfDeviceRepository,
+                specService,
+                indicatorService,
+                projectRepository
+        );
+
+        PacketDTO.SpecEntry specEntry = new PacketDTO.SpecEntry();
+        specEntry.setKey("SEN55-VOC-index");
+        specEntry.setLabel("SEN55-VOC-index");
+
+        Spec legacySpec = new Spec();
+        legacySpec.setComponent("SEN55");
+        legacySpec.setMeasurement("SEN55-VOC-index");
+        legacySpec.setUnitOfMeasurement("");
+
+        TypeOfDevice typeOfDevice = new TypeOfDevice();
+        typeOfDevice.setSpecs(new ArrayList<>(List.of(legacySpec)));
+
+        Method ensureSpecs = NotificationControllerRest.class
+                .getDeclaredMethod("ensureSpecs", TypeOfDevice.class, List.class);
+        ensureSpecs.setAccessible(true);
+        ensureSpecs.invoke(controller, typeOfDevice, List.of(specEntry));
+
+        List<Spec> resultingSpecs = typeOfDevice.getSpecs();
+        assertEquals(1, resultingSpecs.size());
+        Spec updatedSpec = resultingSpecs.get(0);
+        assertEquals("VOC", updatedSpec.getMeasurement());
+        assertEquals("index", updatedSpec.getUnitOfMeasurement());
+
+        verify(specService).save(legacySpec);
     }
 }
 


### PR DESCRIPTION
## Summary
- update ensureSpecs to normalize existing specs whose measurements still contain legacy key or label values
- persist updated legacy specs and reuse them instead of creating duplicates on the type of device
- add a unit test verifying that legacy specs are normalized in place
- ensure normalized component/unit values are captured by final references so the lambda filter compiles

## Testing
- ./mvnw -DskipTests compile *(fails: unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc352b782883238d686b9ce5eca2e2