### PR TITLE
Strip units from measurement column in device specs

### DIFF
--- a/src/main/resources/templates/superadmin/formUpdateDevice.html
+++ b/src/main/resources/templates/superadmin/formUpdateDevice.html
@@ -139,6 +139,8 @@
                                         const measurementCells = document.querySelectorAll("td[data-measurement]");
                                         measurementCells.forEach(function (cell) {
                                                 const componentCell = cell.previousElementSibling;
+                                                const unitCell = cell.nextElementSibling;
+                                                const unitText = unitCell ? (unitCell.textContent || "").trim() : "";
                                                 const originalText = cell.textContent || "";
                                                 let measurementText = originalText.trim();
 
@@ -164,8 +166,22 @@
                                                         }
                                                 }
 
+                                                if (unitText) {
+                                                        const unitPattern = escapeRegExp(unitText).replace(/\\s+/g, "[\\s._-]*");
+                                                        const trailingUnitRegex = new RegExp(
+                                                                "[\\s\\(\\[\\{\/:-]*" + unitPattern + "[\\s\\)\\]\\}]*$",
+                                                                "i"
+                                                        );
+                                                        measurementText = measurementText.replace(trailingUnitRegex, "");
+                                                        measurementText = measurementText.replace(/[\\s._-]+$/, "");
+                                                }
+
                                                 if (!measurementText) {
-                                                        cell.textContent = originalText.trim();
+                                                        if (unitText && originalText.trim().toLowerCase() === unitText.toLowerCase()) {
+                                                                cell.textContent = "";
+                                                        } else {
+                                                                cell.textContent = originalText.trim();
+                                                        }
                                                         return;
                                                 }
 

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -142,6 +142,8 @@
                                 const measurementCells = document.querySelectorAll("td[data-measurement]");
                                 measurementCells.forEach(function (cell) {
                                         const componentCell = cell.previousElementSibling;
+                                        const unitCell = cell.nextElementSibling;
+                                        const unitText = unitCell ? (unitCell.textContent || "").trim() : "";
                                         const originalText = cell.textContent || "";
                                         let measurementText = originalText.trim();
 
@@ -167,8 +169,22 @@
                                                 }
                                         }
 
+                                        if (unitText) {
+                                                const unitPattern = escapeRegExp(unitText).replace(/\\s+/g, "[\\s._-]*");
+                                                const trailingUnitRegex = new RegExp(
+                                                        "[\\s\\(\\[\\{\/:-]*" + unitPattern + "[\\s\\)\\]\\}]*$",
+                                                        "i"
+                                                );
+                                                measurementText = measurementText.replace(trailingUnitRegex, "");
+                                                measurementText = measurementText.replace(/[\\s._-]+$/, "");
+                                        }
+
                                         if (!measurementText) {
-                                                cell.textContent = originalText.trim();
+                                                if (unitText && originalText.trim().toLowerCase() === unitText.toLowerCase()) {
+                                                        cell.textContent = "";
+                                                } else {
+                                                        cell.textContent = originalText.trim();
+                                                }
                                                 return;
                                         }
 


### PR DESCRIPTION
## Summary
- ensure the measurement column scripts strip trailing unit labels using the unit column value
- avoid restoring unit text when it is the only content by leaving the cell blank instead

## Testing
- `./mvnw -q -DskipTests package` *(fails: wget could not fetch Maven distribution in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc57d3e8d08323b739a7c84755a67d