### PR TITLE
Optimize chart rendering on device dashboard

### DIFF
--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -116,6 +116,8 @@
         </script>
 
         <script>
+                const CHART_SAMPLE_LIMIT = 120; // Keep render cost predictable; pairs with decimation settings below.
+
                 const state = {
                         specDescriptors: [],
                         specCardsRendered: false,
@@ -410,10 +412,21 @@
                                 return;
                         }
 
+                        let workingSamples = samples;
+                        if (samples.length > CHART_SAMPLE_LIMIT) {
+                                const excess = samples.length - CHART_SAMPLE_LIMIT;
+                                if (samples === state.lastSamples) {
+                                        // Trim the state array in-place so future updates operate on the reduced window.
+                                        workingSamples.splice(0, excess);
+                                } else {
+                                        workingSamples = samples.slice(samples.length - CHART_SAMPLE_LIMIT);
+                                }
+                        }
+
                         ensureTrendCanvases();
 
-                        const labels = samples.map(sample => formatTimestamp(sample.timestamp, true));
-                        const datasetsByKey = buildDatasetsByKey(samples);
+                        const labels = workingSamples.map(sample => formatTimestamp(sample.timestamp, true));
+                        const datasetsByKey = buildDatasetsByKey(workingSamples);
                         const descriptorKeys = new Set(state.specDescriptors.map(descriptor => descriptor.key));
                         let hasAnyChart = false;
 
@@ -448,9 +461,13 @@
                                                 options: {
                                                         responsive: true,
                                                         maintainAspectRatio: false,
+                                                        animation: false,
                                                         interaction: { mode: 'index', intersect: false },
                                                         plugins: {
                                                                 legend: { labels: { color: '#ffffff' } },
+                                                                // Enable LTTB decimation so charts stay smooth.
+                                                                // Paired with CHART_SAMPLE_LIMIT to cap rendered points.
+                                                                decimation: { enabled: true, algorithm: 'lttb', samples: 100 },
                                                                 tooltip: {
                                                                         callbacks: {
                                                                                 label: (context) => `${context.dataset.label}: ${formatValue(context.parsed.y)}`


### PR DESCRIPTION
## Summary
- cap chart data to the most recent 120 samples before building chart datasets
- enable Chart.js LTTB decimation and disable animations to cut per-frame work, documenting the tuning in code

## Testing
- ./mvnw -q -DskipTests compile *(fails: wget cannot fetch apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68cc617c1c44832384bf02582a12d78b