### PR TITLE
Adjust device dashboard layout and styling

### DIFF
--- a/src/main/resources/static/css/deviceDashboard.css
+++ b/src/main/resources/static/css/deviceDashboard.css
@@ -6,7 +6,7 @@
         margin: 0;
         min-height: 100vh;
         font-family: 'Roboto', sans-serif;
-        background: var(--page-background, #1B263B);
+        background: var(--page-background, #0b1a2f);
         color: var(--text-color, #ffffff);
 }
 
@@ -15,7 +15,7 @@
         --accent-contrast: #ffffff;
         --accent-soft: rgba(0, 123, 255, 0.2);
         --accent-border: rgb(142, 196, 255);
-        --page-background: #1B263B;
+        --page-background: #0b1a2f;
         --panel-background: rgba(13, 30, 54, 0.92);
         --muted-color: #d6e6ff;
 }
@@ -25,7 +25,7 @@
         --accent-contrast: #ffffff;
         --accent-soft: rgba(204, 0, 0, 0.25);
         --accent-border: rgb(255, 142, 142);
-        --page-background: #1B263B;
+        --page-background: #0b1a2f;
         --panel-background: rgba(27, 38, 59, 0.92);
         --muted-color: #ffd2d2;
 }
@@ -35,7 +35,7 @@
         --accent-contrast: #ffffff;
         --accent-soft: rgba(230, 126, 0, 0.25);
         --accent-border: rgb(255, 191, 128);
-        --page-background: #1B263B;
+        --page-background: #0b1a2f;
         --panel-background: rgba(27, 38, 59, 0.92);
         --muted-color: #ffe0c2;
 }
@@ -45,7 +45,7 @@
         --accent-contrast: #ffffff;
         --accent-soft: rgba(0, 123, 255, 0.2);
         --accent-border: rgb(142, 196, 255);
-        --page-background: #1B263B;
+        --page-background: #0b1a2f;
         --panel-background: rgba(13, 30, 54, 0.92);
         --muted-color: #d6e6ff;
 }
@@ -162,6 +162,34 @@
         gap: 1.5rem;
         flex-wrap: wrap;
         align-items: flex-end;
+}
+
+.device-actions {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.75rem;
+}
+
+.back-to-map {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.45rem 0.9rem;
+        border-radius: 999px;
+        border: 1px solid var(--accent-border, rgba(255, 255, 255, 0.2));
+        color: var(--accent-contrast);
+        background: rgba(255, 255, 255, 0.08);
+        text-decoration: none;
+        font-size: 0.85rem;
+        font-weight: 500;
+        transition: background-color 0.2s, border-color 0.2s;
+}
+
+.back-to-map:hover,
+.back-to-map:focus {
+        background: rgba(255, 255, 255, 0.18);
+        border-color: var(--accent-color);
 }
 
 .device-header h2 {
@@ -382,12 +410,12 @@
         border-radius: 0.6rem;
 }
 
-.flag-on {
+.flag-ok {
         background: rgba(102, 187, 106, 0.2);
         color: #9ef5ad;
 }
 
-.flag-off {
+.flag-issue {
         background: rgba(239, 83, 80, 0.25);
         color: #ffb3b0;
 }
@@ -435,6 +463,16 @@
 
         .device-header {
                 align-items: flex-start;
+        }
+
+        .device-actions {
+                align-items: flex-start;
+                width: 100%;
+        }
+
+        .device-location {
+                flex-wrap: wrap;
+                row-gap: 0.35rem;
         }
 }
 

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -54,9 +54,14 @@
                                         <span>Status: <strong th:text="${device.status}">--</strong></span>
                                 </p>
                         </div>
-                        <div class="device-location" th:if="${device.latitude != null && device.longitude != null}">
-                                <span>Lat: <strong th:text="${#numbers.formatDecimal(device.latitude, 1, 6)}">0</strong></span>
-                                <span>Lng: <strong th:text="${#numbers.formatDecimal(device.longitude, 1, 6)}">0</strong></span>
+                        <div class="device-actions">
+                                <a class="back-to-map" th:href="@{'/success'(projectId=${project.id})}" title="Back to map">
+                                        Back to map
+                                </a>
+                                <div class="device-location" th:if="${device.latitude != null && device.longitude != null}">
+                                        <span>Lat: <strong th:text="${#numbers.formatDecimal(device.latitude, 1, 6)}">0</strong></span>
+                                        <span>Lng: <strong th:text="${#numbers.formatDecimal(device.longitude, 1, 6)}">0</strong></span>
+                                </div>
                         </div>
                 </section>
 
@@ -132,6 +137,35 @@
                         'volcano': ['#6a040f', '#9d0208', '#f48c06'],
                         'default': ['#2d6cdf', '#4c9f70', '#dd6b20']
                 };
+
+                const INFO_PREFERRED_ORDER = ['date', 'time', 'mac', 'latitude', 'longitude', 'bat_pct', 'bat_v'];
+                const INFO_KEY_ALIASES = new Map([
+                        ['data', 'date'],
+                        ['date', 'date'],
+                        ['ora', 'time'],
+                        ['time', 'time'],
+                        ['mac', 'mac'],
+                        ['macaddress', 'mac'],
+                        ['mac_address', 'mac'],
+                        ['lat', 'latitude'],
+                        ['latitude', 'latitude'],
+                        ['latitudine', 'latitude'],
+                        ['lon', 'longitude'],
+                        ['lng', 'longitude'],
+                        ['longitude', 'longitude'],
+                        ['longitudine', 'longitude'],
+                        ['batpct', 'bat_pct'],
+                        ['bat_pct', 'bat_pct'],
+                        ['batpercent', 'bat_pct'],
+                        ['battery_pct', 'bat_pct'],
+                        ['batterypercent', 'bat_pct'],
+                        ['battery_percentage', 'bat_pct'],
+                        ['batv', 'bat_v'],
+                        ['bat_v', 'bat_v'],
+                        ['battery_v', 'bat_v'],
+                        ['batteryvolt', 'bat_v'],
+                        ['battery_voltage', 'bat_v']
+                ]);
 
                 document.addEventListener('DOMContentLoaded', () => {
                         setupDropdown();
@@ -315,6 +349,45 @@
                         return '';
                 }
 
+                function getDescriptorTitle(descriptor, componentOverride) {
+                        if (!descriptor) {
+                                return '';
+                        }
+                        const displayName = typeof descriptor.displayName === 'string' ? descriptor.displayName.trim() : '';
+                        if (!displayName) {
+                                return '';
+                        }
+                        const component = componentOverride || getDescriptorComponent(descriptor);
+                        let title = displayName;
+
+                        if (component) {
+                                const trimmedComponent = component.trim();
+                                if (trimmedComponent) {
+                                        const componentPattern = new RegExp(`^${escapeRegExp(trimmedComponent)}(?:\s*[\-–—:]\s*|\s+)`, 'i');
+                                        const stripped = title.replace(componentPattern, '').trim();
+                                        if (stripped) {
+                                                title = stripped;
+                                        }
+                                }
+                        }
+
+                        const unit = typeof descriptor.unit === 'string' ? descriptor.unit.trim() : '';
+                        if (unit) {
+                                const unitPattern = new RegExp(`\s*\(?${escapeRegExp(unit)}\)?$`, 'i');
+                                const strippedUnit = title.replace(unitPattern, '').trim();
+                                if (strippedUnit) {
+                                        title = strippedUnit;
+                                }
+                        }
+
+                        title = title.replace(/[\-–—:]+$/u, '').trim();
+                        return title || displayName;
+                }
+
+                function escapeRegExp(value) {
+                        return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\$&');
+                }
+
                 function renderMetricCards() {
                         const container = document.getElementById('metrics-grid');
                         container.innerHTML = '';
@@ -323,10 +396,11 @@
                                 card.className = 'metric-card';
                                 card.dataset.specKey = descriptor.key;
                                 const component = getDescriptorComponent(descriptor);
+                                const title = getDescriptorTitle(descriptor, component);
                                 const unit = descriptor.unit ? descriptor.unit : '';
                                 card.innerHTML = `
                                         <div class="metric-heading">
-                                                <span class="metric-title">${descriptor.displayName}</span>
+                                                <span class="metric-title">${title}</span>
                                                 <span class="metric-subtitle" data-component></span>
                                         </div>
                                         <div class="metric-reading">
@@ -398,7 +472,7 @@
                                 flag.className = 'status-flag';
                                 const numeric = toNumber(indicator.value);
                                 const isOn = numeric === 1;
-                                const valueClass = numeric === null ? 'flag-generic' : (isOn ? 'flag-on' : 'flag-off');
+                                const valueClass = numeric === null ? 'flag-generic' : (isOn ? 'flag-issue' : 'flag-ok');
                                 const normalizedValue = numeric === null ? '--' : (isOn ? 'Issue' : 'OK');
                                 flag.innerHTML = `
                                         <span class="flag-key">${indicator.label ?? prettifyKey(indicator.key)}</span>
@@ -626,7 +700,16 @@
                                 return;
                         }
                         emptyState.hidden = true;
-                        Object.entries(info).forEach(([key, value]) => {
+                        const sortedEntries = Object.entries(info)
+                                .map(([key, value], index) => ({ key, value, index, priority: getInfoPriority(key) }))
+                                .sort((a, b) => {
+                                        if (a.priority === b.priority) {
+                                                return a.index - b.index;
+                                        }
+                                        return a.priority - b.priority;
+                                });
+
+                        sortedEntries.forEach(({ key, value }) => {
                                 const row = document.createElement('div');
                                 row.className = 'info-row';
                                 row.innerHTML = `
@@ -635,6 +718,18 @@
                                 `;
                                 container.appendChild(row);
                         });
+                }
+
+                function getInfoPriority(key) {
+                        const normalizedKey = normalizeInfoKey(key);
+                        const simplifiedKey = normalizedKey.replace(/[^a-z0-9]/g, '');
+                        const mappedKey = INFO_KEY_ALIASES.get(normalizedKey) || INFO_KEY_ALIASES.get(simplifiedKey) || simplifiedKey;
+                        const index = INFO_PREFERRED_ORDER.indexOf(mappedKey);
+                        return index === -1 ? Number.POSITIVE_INFINITY : index;
+                }
+
+                function normalizeInfoKey(key) {
+                        return key === undefined || key === null ? '' : String(key).trim().toLowerCase();
                 }
 
                 function prettifyKey(key) {

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -358,34 +358,87 @@
                                 return '';
                         }
                         const component = componentOverride || getDescriptorComponent(descriptor);
-                        let title = displayName;
-
-                        if (component) {
-                                const trimmedComponent = component.trim();
-                                if (trimmedComponent) {
-                                        const componentPattern = new RegExp(`^${escapeRegExp(trimmedComponent)}(?:\s*[\-–—:]\s*|\s+)`, 'i');
-                                        const stripped = title.replace(componentPattern, '').trim();
-                                        if (stripped) {
-                                                title = stripped;
-                                        }
-                                }
-                        }
-
-                        const unit = typeof descriptor.unit === 'string' ? descriptor.unit.trim() : '';
-                        if (unit) {
-                                const unitPattern = new RegExp(`\s*\(?${escapeRegExp(unit)}\)?$`, 'i');
-                                const strippedUnit = title.replace(unitPattern, '').trim();
-                                if (strippedUnit) {
-                                        title = strippedUnit;
-                                }
-                        }
-
-                        title = title.replace(/[\-–—:]+$/u, '').trim();
+                        let title = stripComponentPrefix(displayName, component);
+                        title = stripUnitSuffix(title, descriptor.unit);
+                        title = stripTrailingDelimiters(title);
                         return title || displayName;
                 }
 
-                function escapeRegExp(value) {
-                        return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\$&');
+                function stripComponentPrefix(title, component) {
+                        const normalizedTitle = typeof title === 'string' ? title.trim() : '';
+                        const normalizedComponent = typeof component === 'string' ? component.trim() : '';
+                        if (!normalizedTitle || !normalizedComponent) {
+                                return normalizedTitle;
+                        }
+                        const lowerTitle = normalizedTitle.toLowerCase();
+                        const lowerComponent = normalizedComponent.toLowerCase();
+                        const variants = [
+                                `${normalizedComponent} - `,
+                                `${normalizedComponent}-`,
+                                `${normalizedComponent} – `,
+                                `${normalizedComponent} — `,
+                                `${normalizedComponent}: `,
+                                `${normalizedComponent}:`,
+                                `${normalizedComponent} `
+                        ];
+                        for (const variant of variants) {
+                                const variantLower = variant.toLowerCase();
+                                if (variantLower.length && lowerTitle.startsWith(variantLower)) {
+                                        const stripped = normalizedTitle.slice(variant.length).trim();
+                                        if (stripped) {
+                                                return stripped;
+                                        }
+                                }
+                        }
+                        if (lowerTitle.startsWith(lowerComponent)) {
+                                const stripped = normalizedTitle.slice(normalizedComponent.length).trim();
+                                if (stripped) {
+                                        return stripped;
+                                }
+                        }
+                        return normalizedTitle;
+                }
+
+                function stripUnitSuffix(title, unit) {
+                        const normalizedTitle = typeof title === 'string' ? title.trim() : '';
+                        const normalizedUnit = typeof unit === 'string' ? unit.trim() : '';
+                        if (!normalizedTitle || !normalizedUnit) {
+                                return normalizedTitle;
+                        }
+                        const lowerTitle = normalizedTitle.toLowerCase();
+                        const unitVariants = new Set([
+                                normalizedUnit,
+                                normalizedUnit.toLowerCase(),
+                                normalizedUnit.toUpperCase()
+                        ]);
+                        const suffixes = [];
+                        unitVariants.forEach(value => {
+                                if (!value) {
+                                        return;
+                                }
+                                suffixes.push(` (${value})`);
+                                suffixes.push(` [${value}]`);
+                                suffixes.push(` ${value}`);
+                                suffixes.push(value);
+                        });
+                        suffixes.sort((a, b) => b.length - a.length);
+                        for (const suffix of suffixes) {
+                                const suffixLower = suffix.toLowerCase();
+                                if (suffixLower.length && lowerTitle.endsWith(suffixLower)) {
+                                        const stripped = normalizedTitle.slice(0, normalizedTitle.length - suffix.length).trim();
+                                        if (stripped) {
+                                                return stripped;
+                                        }
+                                }
+                        }
+                        return normalizedTitle;
+                }
+
+                function stripTrailingDelimiters(value) {
+                        if (!value) {
+                                return '';
+                        }
+                        return value.replace(/[\-–—:]+$/u, '').trim();
                 }
 
                 function renderMetricCards() {


### PR DESCRIPTION
## Summary
- update the device dashboard theme to use the new #0b1a2f page background and add a "Back to map" action above the coordinates
- ensure metric cards show only the measurement name, reorder device information rows, and keep OK readings highlighted in green
- keep supporting utilities up to date for the updated layouts and ordering logic

## Testing
- ⚠️ `./mvnw -q -DskipTests package` *(fails: unable to download Maven wrapper dependencies because external network is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68cc71f8cb548323abf36451b6f33d9a