### PR TITLE
Normalize MAC handling and use safe device keys

### DIFF
--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -39,6 +39,7 @@ import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.Comparator;
@@ -181,9 +182,22 @@ private AdminService adminService;
         @PostMapping("/group/{projectId}/{groupId}/removeDevice/{macAddress}")
         public String removeDeviceFromGroup(@PathVariable Long projectId, @PathVariable Long groupId,
                         @PathVariable String macAddress, RedirectAttributes redirectAttributes) {
-                macAddress = MacAddressUtils.normalize(macAddress);
+                String normalizedKey = MacAddressUtils.normalize(macAddress);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found");
+                        return "redirect:/manageGroups/" + projectId;
+                }
                 Group group = groupService.findGroupById(groupId);
-                Device device = deviceService.findByMacAddress(macAddress);
+                if (group == null) {
+                        redirectAttributes.addFlashAttribute("error", "Group not found");
+                        return "redirect:/manageGroups/" + projectId;
+                }
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found");
+                        return "redirect:/manageGroups/" + projectId;
+                }
+                Device device = deviceOpt.get();
                 List<Device> devices = group.getDevices();
                 devices.remove(device);
                 group.setDevices(devices);
@@ -197,23 +211,28 @@ private AdminService adminService;
         @PostMapping("/group/{groupId}/add-device/{macAddress}")
         public String addDeviceToGroup(@PathVariable Long groupId, @PathVariable("macAddress") String macAddress,
                         Principal principal, RedirectAttributes redirectAttributes) {
-                macAddress = MacAddressUtils.normalize(macAddress);
                 Group group = groupService.findGroupById(groupId);
                 if (group == null) {
                         redirectAttributes.addFlashAttribute("error", "Group not found");
                         return "error";
                 }
-                Device device = deviceService.findByMacAddress(macAddress);
-		if (device == null) {
-			redirectAttributes.addFlashAttribute("error", "Device not found");
-		} else {
-			device.setGroup(group);
-			deviceService.save(device);
-			redirectAttributes.addFlashAttribute("success", "Device added successfully.");
-		}
+                String normalizedKey = MacAddressUtils.normalize(macAddress);
+                if (normalizedKey == null || normalizedKey.isBlank()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found");
+                        return "redirect:/manageGroups/" + group.getProject().getId();
+                }
+                Optional<Device> deviceOpt = deviceService.findOptionalByDeviceKey(normalizedKey);
+                if (deviceOpt.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("error", "Device not found");
+                } else {
+                        Device device = deviceOpt.get();
+                        device.setGroup(group);
+                        deviceService.save(device);
+                        redirectAttributes.addFlashAttribute("success", "Device added successfully.");
+                }
 
-		return "redirect:/manageGroups/" + group.getProject().getId();
-	}
+                return "redirect:/manageGroups/" + group.getProject().getId();
+        }
 	
 	
 	/*OPERATOR*/

--- a/src/main/java/it/sensorplatform/dto/DeviceDTO.java
+++ b/src/main/java/it/sensorplatform/dto/DeviceDTO.java
@@ -61,13 +61,23 @@ public class DeviceDTO {
 		this.devEui = devEui;
 	}
 
-	public String getMacAddress() {
-		return macAddress;
-	}
+        public String getMacAddress() {
+                return macAddress;
+        }
 
-	public void setMacAddress(String macAddress) {
-		this.macAddress = macAddress;
-	}
+        public void setMacAddress(String macAddress) {
+                this.macAddress = macAddress;
+        }
+
+        public String getDeviceKey() {
+                if (macAddress != null && !macAddress.isBlank()) {
+                        return macAddress;
+                }
+                if (devEui != null && !devEui.isBlank()) {
+                        return devEui;
+                }
+                return null;
+        }
 
 	public Double getLongitude() {
 		return longitude;

--- a/src/main/java/it/sensorplatform/model/Device.java
+++ b/src/main/java/it/sensorplatform/model/Device.java
@@ -110,9 +110,9 @@ public class Device {
 	}
 	
 	
-	public void setDevEui(String devEui) {
-		this.devEui = devEui;
-	}
+        public void setDevEui(String devEui) {
+                this.devEui = MacAddressUtils.normalize(devEui);
+        }
 
 
 	public String getMacAddress() {
@@ -202,10 +202,20 @@ public class Device {
 		return Objects.equals(id, other.id) && Objects.equals(macAddress, other.macAddress);
 	}
 	
-	public String getVisibleUsername() {
-		if(operator!=null) 
-			return operator.getVisibleUsername();
-		return null;
-	}
+        public String getVisibleUsername() {
+                if(operator!=null)
+                        return operator.getVisibleUsername();
+                return null;
+        }
+
+        public String getDeviceKey() {
+                if (macAddress != null && !macAddress.isBlank()) {
+                        return macAddress;
+                }
+                if (devEui != null && !devEui.isBlank()) {
+                        return devEui;
+                }
+                return null;
+        }
 }
 

--- a/src/main/java/it/sensorplatform/service/DeviceService.java
+++ b/src/main/java/it/sensorplatform/service/DeviceService.java
@@ -1,5 +1,6 @@
 package it.sensorplatform.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -38,20 +39,33 @@ public class DeviceService {
                 }
         }
 
-	public Device findById(Long deviceId) {
-		return this.deviceRepository.findById(deviceId).get();
-	}
+        public Device findById(Long deviceId) {
+                return this.deviceRepository.findById(deviceId).get();
+        }
 
-    public Device findByMacAddress(String macAddress) {
-                return this.deviceRepository.findByMacAddress(MacAddressUtils.normalize(macAddress)).get();
+        public Device findByMacAddress(String macAddress) {
+                String normalizedMac = MacAddressUtils.normalize(macAddress);
+                if (normalizedMac == null || normalizedMac.isBlank()) {
+                        throw new IllegalArgumentException("MAC address is required");
+                }
+                return this.deviceRepository.findByMacAddress(normalizedMac)
+                                .orElseThrow(() -> new IllegalArgumentException("Device not found for key: " + normalizedMac));
         }
 
         public Optional<Device> findOptionalByMacAddress(String macAddress) {
-                return this.deviceRepository.findByMacAddress(MacAddressUtils.normalize(macAddress));
+                String normalizedMac = MacAddressUtils.normalize(macAddress);
+                if (normalizedMac == null || normalizedMac.isBlank()) {
+                        return Optional.empty();
+                }
+                return this.deviceRepository.findByMacAddress(normalizedMac);
         }
 
         public Optional<Device> findOptionalByDevEui(String devEui) {
-                return this.deviceRepository.findByDevEui(MacAddressUtils.normalize(devEui));
+                String normalizedDevEui = MacAddressUtils.normalize(devEui);
+                if (normalizedDevEui == null || normalizedDevEui.isBlank()) {
+                        return Optional.empty();
+                }
+                return this.deviceRepository.findByDevEui(normalizedDevEui);
         }
 
         public Optional<Device> findOptionalByDeviceKey(String deviceKey) {
@@ -79,7 +93,11 @@ public class DeviceService {
         }
 
         public boolean existsByMacAddress(String macAddress) {
-                return this.deviceRepository.existsByMacAddress(MacAddressUtils.normalize(macAddress));
+                String normalizedMac = MacAddressUtils.normalize(macAddress);
+                if (normalizedMac == null || normalizedMac.isBlank()) {
+                        return false;
+                }
+                return this.deviceRepository.existsByMacAddress(normalizedMac);
         }
 
 	public Set<Device> findByNameStartingWithIgnoreCase(String deviceInfo) {
@@ -87,7 +105,11 @@ public class DeviceService {
     }
 
     public Set<Device> findByMacAddressStartingWithIgnoreCase(String deviceInfo) {
-        return this.deviceRepository.findByMacAddressStartingWithIgnoreCase(MacAddressUtils.normalize(deviceInfo));
+        String normalizedInfo = MacAddressUtils.normalize(deviceInfo);
+        if (normalizedInfo == null || normalizedInfo.isBlank()) {
+            return Collections.emptySet();
+        }
+        return this.deviceRepository.findByMacAddressStartingWithIgnoreCase(normalizedInfo);
     }
 
     public Set<Device> findByEmailOwnerStartingWithIgnoreCase(String deviceQuery) {

--- a/src/main/java/it/sensorplatform/util/MacAddressUtils.java
+++ b/src/main/java/it/sensorplatform/util/MacAddressUtils.java
@@ -1,5 +1,7 @@
 package it.sensorplatform.util;
 
+import java.util.Locale;
+
 public final class MacAddressUtils {
 
     private MacAddressUtils() {
@@ -7,7 +9,14 @@ public final class MacAddressUtils {
     }
 
     public static String normalize(String mac) {
-        return mac == null ? null : mac.replace(":", "").toUpperCase();
+        if (mac == null) {
+            return null;
+        }
+        String cleaned = mac.replaceAll("[^0-9A-Fa-f]", "");
+        if (cleaned.isEmpty()) {
+            return null;
+        }
+        return cleaned.toUpperCase(Locale.ROOT);
     }
 
     public static String format(String mac) {

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -108,7 +108,7 @@
 
         <script th:inline="javascript">
                 /*<![CDATA[*/
-                const DEVICE_KEY = /*[[${device.macAddress != null ? device.macAddress : (device.devEui != null ? device.devEui : '')}]]*/ '';
+                const DEVICE_KEY = /*[[${device.deviceKey != null ? device.deviceKey : ''}]]*/ '';
                 const PROJECT_ID = /*[[${project.id}]]*/ 0;
                 const DEVICE_NAME = /*[[${device.name}]]*/ '';
                 const PROJECT_KEY = /*[[${projectKey}]]*/ 'default';

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -134,7 +134,7 @@
                                           <thead>
                                                   <tr>
                                                           <th scope="col">Name</th>
-                                                          <th scope="col">Mac Address</th>
+                                                          <th scope="col">Device Key</th>
                                                           <th scope="col">Type of device</th>
                                                           <th scope="col">Operator</th>
                                                           <th scope="col">Activated</th>
@@ -145,7 +145,7 @@
                                           <tbody>
                                                   <tr th:each="device : ${devices}">
                                                           <td th:text="${device.name}">Name</td>
-                                                          <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">Mac Address</td>
+                                                          <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.deviceKey)}">Device Key</td>
                                                           <td th:text="${device.tod}">Mac Address</td>
                                                           <td>
                                                                   <span th:if="${device.operator != null}" th:text="${device.operator}">Operator</span>
@@ -153,7 +153,7 @@
                                                           <td th:text="${device.status}"></td>
                                                           <td>
                                                                   <!-- Edit (icona a matita) -->
-                                                                  <a th:href="@{'/device/' + ${project.id} + '/' + ${device.macAddress}}"
+                                                                  <a th:href="@{'/device/' + ${project.id} + '/' + ${device.deviceKey}}"
                                                                           class="btn-action btn-edit btn-icon" title="Edit Device" aria-label="Edit device">
                                                                           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18"
                                                                                   aria-hidden="true">
@@ -166,7 +166,7 @@
                                                                   <button th:if="${device.operator != null}"
                                                                           class="btn-action btn-danger btn-icon"
                                                                           title="Remove operator" aria-label="Remove operator"
-                                                                          th:attr="data-mac=${device.macAddress}"
+                                                                          th:attr="data-mac=${device.deviceKey}"
                                                                           data-remove-operator>
                                                                           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
                                                                               <path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1z" />
@@ -210,17 +210,24 @@
 			attribution: '&copy; OpenStreetMap contributors'
 		}).addTo(map);
 
-                let markerByMac = new Map();
+                let markerByDeviceKey = new Map();
 
                 let allLatLngs = [];
 
-                function formatMac(mac) {
-                        if (!mac) {
+                function formatIdentifier(value) {
+                        if (!value) {
                                 return '';
                         }
-                        const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+                        const cleaned = String(value).replace(/[^a-fA-F0-9]/g, '').toUpperCase();
                         const pairs = cleaned.match(/.{1,2}/g);
-                        return pairs ? pairs.join(':') : '';
+                        return pairs ? pairs.join(':') : cleaned;
+                }
+
+                function resolveDeviceKey(device) {
+                        if (!device) {
+                                return '';
+                        }
+                        return device.deviceKey || device.devEui || '';
                 }
 
                 initialDevices.forEach(function (d) {
@@ -228,20 +235,26 @@
                         allLatLngs.push(latlng);
 
                         const marker = L.marker(latlng).addTo(map);
-                        const popupContent = "Device: " + d.name + "<br>" +
-                                "MacAddress: " + formatMac(d.macAddress) + "<br>" +
+                        const key = resolveDeviceKey(d);
+                        const formattedKey = formatIdentifier(key);
+                        const fallbackDevEui = d.devEui ? formatIdentifier(d.devEui) : '';
+                        const identifierLabel = formattedKey || fallbackDevEui || 'N/A';
+                        const deviceName = d.name || '';
+                        const popupContent = "Device: " + deviceName + "<br>" +
+                                "Identifier: " + identifierLabel + "<br>" +
                                 "Latitude: " + d.latitude + "<br>" +
                                 "Longitude: " + d.longitude;
 
                         marker.bindPopup(popupContent);
                         marker.on("mouseover", function () {this.openPopup();});
                         marker.on("mouseout", function () {this.closePopup();});
-                        marker.on("click", function () {
-                                const destination = `/admin/device-dashboard/${PROJECT_ID}/${encodeURIComponent(d.macAddress)}`;
-                                window.location.href = destination;
-                        });
-
-                        markerByMac.set(d.macAddress, marker);
+                        if (key) {
+                                marker.on("click", function () {
+                                        const destination = `/admin/device-dashboard/${PROJECT_ID}/${encodeURIComponent(key)}`;
+                                        window.location.href = destination;
+                                });
+                                markerByDeviceKey.set(key, marker);
+                        }
                 });
 
 		// Disegna il poligono solo se ci sono almeno 3 punti
@@ -270,7 +283,9 @@
                                                 ul.innerHTML = '';
                                                 validDevices.forEach(device => {
                                                         const li = document.createElement('li');
-                                                        li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
+                                                        const identifier = formatIdentifier(resolveDeviceKey(device));
+                                                        const deviceName = device.name || '';
+                                                        li.textContent = identifier ? `${deviceName} (${identifier})` : deviceName;
                                                         ul.appendChild(li);
                                                 });
                                         });
@@ -313,37 +328,40 @@
                 document.addEventListener('DOMContentLoaded', function () {
 
                         const LIST_OP_URL = `/api/projects/${PROJECT_ID}/operators`;
-                        const ASSIGN_OP_URL = ({mac, opId}) =>
-                                `/admin/selectOperator/${encodeURIComponent(mac)}/${opId}/${PROJECT_ID}`;
+                        const ASSIGN_OP_URL = ({deviceKey, opId}) =>
+                                `/admin/selectOperator/${encodeURIComponent(deviceKey)}/${opId}/${PROJECT_ID}`;
                         // oppure la tua variante opId=0:
-                        const REMOVE_OP_URL = ({mac}) =>
-                          `/admin/removeOperator/${encodeURIComponent(mac)}/${PROJECT_ID}`;
+                        const REMOVE_OP_URL = ({deviceKey}) =>
+                          `/admin/removeOperator/${encodeURIComponent(deviceKey)}/${PROJECT_ID}`;
                         const ADMIN_ID = /*[[${user.admin != null ? user.admin.id : 0}]]*/ 0;
                         const AUTH_OP_URL = (opId) => `/api/admin/${ADMIN_ID}/authorize/${opId}`;
 
 			const modal = document.getElementById('assignOperatorModal');
 			const form = document.getElementById('assignOperatorForm');
 			const select = document.getElementById('operatorSelect');
-			let currentMac = null;
+                        let currentDeviceKey = null;
 
 			const openModal = () => {
 				modal.classList.add('show');
 				document.body.classList.add('no-scroll');
 			};
-			const closeModal = () => {
-				modal.classList.remove('show');
-				document.body.classList.remove('no-scroll');
-				currentMac = null;
-				form.reset();
-				select.innerHTML = '<option value="" selected disabled>Choose an operator…</option>';
-			};
+                        const closeModal = () => {
+                                modal.classList.remove('show');
+                                document.body.classList.remove('no-scroll');
+                                currentDeviceKey = null;
+                                form.reset();
+                                select.innerHTML = '<option value="" selected disabled>Choose an operator…</option>';
+                        };
 
 			// chiusure
 			modal.addEventListener('click', e => {if (e.target === modal) closeModal();});
 			modal.querySelectorAll('[data-modal-close]').forEach(b => b.addEventListener('click', closeModal));
 
-			async function handleOpenAssign(mac) {
-				currentMac = mac;
+                        async function handleOpenAssign(deviceKey) {
+                                if (!deviceKey) {
+                                        return;
+                                }
+                                currentDeviceKey = deviceKey;
 				try {
 					const res = await fetch(LIST_OP_URL, {headers: {'Accept': 'application/json'}});
 					if (!res.ok) throw new Error('load operators failed');
@@ -372,13 +390,14 @@
                                 const removeBtn = e.target.closest('[data-remove-operator]');
                                 if (removeBtn) {
                                         e.preventDefault();
-                                        const mac = removeBtn.getAttribute('data-mac');
+                                        const deviceKey = removeBtn.getAttribute('data-mac');
+                                        if (!deviceKey) return;
                                         if (!confirm('Remove operator from this device?')) return;
 
-					// POST via form per includere CSRF
-					const f = document.createElement('form');
-					f.method = 'post';
-					f.action = REMOVE_OP_URL({mac});
+                                        // POST via form per includere CSRF
+                                        const f = document.createElement('form');
+                                        f.method = 'post';
+                                        f.action = REMOVE_OP_URL({deviceKey});
 					const csrf = document.querySelector('input[name="_csrf"]');
 					if (csrf) {
 						const t = document.createElement('input');
@@ -435,11 +454,11 @@
                         form.addEventListener('submit', function (e) {
                                 e.preventDefault();
                                 const opId = select.value;
-                                if (!currentMac || !opId) return;
+                                if (!currentDeviceKey || !opId) return;
 
-				const f = document.createElement('form');
-				f.method = 'post';
-				f.action = ASSIGN_OP_URL({mac: currentMac, opId});
+                                const f = document.createElement('form');
+                                f.method = 'post';
+                                f.action = ASSIGN_OP_URL({deviceKey: currentDeviceKey, opId});
 
 				const csrf = document.querySelector('input[name="_csrf"]');
 				if (csrf) {

--- a/src/main/resources/templates/superadmin/formUpdateDevice.html
+++ b/src/main/resources/templates/superadmin/formUpdateDevice.html
@@ -55,8 +55,8 @@
             <!-- Informazioni generali -->
             <table>
                 <tr>
-                    <th>MAC Address</th>
-                    <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}"></td>
+                    <th>Device Key</th>
+                    <td th:text="${device.deviceKey != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.deviceKey) : 'N/A'}"></td>
                 </tr>
                 <tr>
                     <th>Owner Email</th>
@@ -64,7 +64,7 @@
                 </tr>
                 <tr>
                     <th>DevEUI</th>
-                    <td th:text="${device.devEui} ?: 'N/A'"></td>
+                    <td th:text="${device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui) : 'N/A'}"></td>
                 </tr>
                 <tr>
                     <th>Group</th>
@@ -99,7 +99,7 @@
 			<div class="card-edit-device">
 			    <h2>Edit Device</h2>
 				<span class="success" th:if="${success}" th:text="${success}"></span>
-			    <form th:action="@{'/superadmin/updateDevice/' + ${project.id} + '/' + ${device.macAddress}}" method="post" class="device-form">
+                            <form th:action="@{'/superadmin/updateDevice/' + ${project.id} + '/' + ${device.deviceKey}}" method="post" class="device-form">
 			        
 					<label for="name">Name:</label>
 					<span class="errorform" th:if="${error}" th:text="${error}"></span>

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -90,7 +90,11 @@
 			<tbody>
 				<tr th:each="device : ${devices}">
 					<td th:text="${device.name}">Name</td>
-                                        <td th:text="${device.macAddress != null ? (device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress) + '/' + device.devEui : T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)) : device.devEui}">Mac Address</td>
+                                        <td>
+                                                <span th:text="${device.macAddress != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress) : (device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui) : 'N/A')}"></span>
+                                                <span th:if="${device.macAddress != null && device.devEui != null}"
+                                                      th:text="${' / ' + T(it.sensorplatform.util.MacAddressUtils).format(device.devEui)}"></span>
+                                        </td>
                                         <td th:text="${device.emailOwner}">Email</td>
                                         <td th:text="${device.tod}">Type Of Device</td>
 				</tr>
@@ -126,8 +130,10 @@
                                         </thead>
                                         <tbody>
                                                 <tr th:each="device : ${devicesWithoutOwner}">
-                                                        <td th:text="${device.macAddress != null ? (device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress) + '/' + device.devEui : T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)) : device.devEui}">
-                                                                Device identifier
+                                                        <td>
+                                                                <span th:text="${device.macAddress != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress) : (device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui) : 'N/A')}"></span>
+                                                                <span th:if="${device.macAddress != null && device.devEui != null}"
+                                                                      th:text="${' / ' + T(it.sensorplatform.util.MacAddressUtils).format(device.devEui)}"></span>
                                                         </td>
                                                         <td class="checkbox-cell">
                                                                 <input type="checkbox" name="selectedDeviceIds" th:value="${device.id}" />
@@ -170,17 +176,36 @@
 		attribution: '&copy; OpenStreetMap contributors'
 	}).addTo(map);
 
-        let markerByMac = new Map();
+        let markerByDeviceKey = new Map();
 
         let allLatLngs = [];
 
-        function formatMac(mac) {
-                if (!mac) {
+        function formatIdentifier(value) {
+                if (!value) {
                         return '';
                 }
-                const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+                const cleaned = String(value).replace(/[^a-fA-F0-9]/g, '').toUpperCase();
                 const pairs = cleaned.match(/.{1,2}/g);
-                return pairs ? pairs.join(':') : '';
+                return pairs ? pairs.join(':') : cleaned;
+        }
+
+        function resolveDeviceKey(device) {
+                if (!device) {
+                        return '';
+                }
+                return device.deviceKey || device.devEui || '';
+        }
+
+        function buildIdentifierDisplay(device) {
+                if (!device) {
+                        return 'N/A';
+                }
+                const mac = device.macAddress ? formatIdentifier(device.macAddress) : '';
+                const devEui = device.devEui ? formatIdentifier(device.devEui) : '';
+                if (mac && devEui) {
+                        return `${mac}/${devEui}`;
+                }
+                return mac || devEui || 'N/A';
         }
 
         initialDevices.forEach(function (d) {
@@ -189,8 +214,10 @@
                         allLatLngs.push(latlng);
 
                         const marker = L.marker(latlng).addTo(map);
-                        const popupContent = "Device: " + d.name + "<br>" +
-                                "MacAddress/DevEui: " + (d.macAddress ? formatMac(d.macAddress) : "") + (d.devEui ? '/' + d.devEui : "") + "<br>" +
+                        const key = resolveDeviceKey(d);
+                        const identifierLabel = buildIdentifierDisplay(d);
+                        const popupContent = "Device: " + (d.name || '') + "<br>" +
+                                "Identifier: " + identifierLabel + "<br>" +
                                 "Latitude: " + d.latitude + "<br>" +
                                 "Longitude: " + d.longitude;
 
@@ -198,7 +225,9 @@
                         marker.on("mouseover", function () { this.openPopup(); });
                         marker.on("mouseout", function () { this.closePopup(); });
 
-                        markerByMac.set(d.macAddress ? d.macAddress : d.devEui, marker);
+                        if (key) {
+                                markerByDeviceKey.set(key, marker);
+                        }
                 }
         });
 
@@ -224,11 +253,19 @@
 					const details = summary.parentElement;
 					const ul = details.querySelector('.device-list');
 					ul.innerHTML = '';
-					devices.forEach(device => {
-						const li = document.createElement('li');
-                                                li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
-						ul.appendChild(li);
-					});
+                                        devices.forEach(device => {
+                                                const li = document.createElement('li');
+                                                const identifier = buildIdentifierDisplay(device);
+                                                const name = device.name || '';
+                                                if (name && identifier && identifier !== 'N/A') {
+                                                        li.textContent = `${name} (${identifier})`;
+                                                } else if (name) {
+                                                        li.textContent = name;
+                                                } else {
+                                                        li.textContent = identifier;
+                                                }
+                                                ul.appendChild(li);
+                                        });
 				});
 			});
 	}

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -57,8 +57,8 @@
             <!-- Informazioni generali -->
             <table>
                 <tr>
-                    <th>MAC Address</th>
-                    <td th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}"></td>
+                    <th>Device Key</th>
+                    <td th:text="${device.deviceKey != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.deviceKey) : 'N/A'}"></td>
                 </tr>
                 <tr>
                     <th>Owner Email</th>
@@ -66,7 +66,7 @@
                 </tr>
                 <tr>
                     <th>DevEUI</th>
-                    <td th:text="${device.devEui} ?: 'N/A'"></td>
+                    <td th:text="${device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui) : 'N/A'}"></td>
                 </tr>
                 <tr>
                     <th>Group</th>
@@ -101,7 +101,7 @@
 			<div class="card-edit-device">
 			    <h2>Edit Device</h2>
 				<span class="success" th:if="${success}" th:text="${success}"></span>
-			    <form th:action="@{'/updateDevice/' + ${project.id} + '/' + ${device.macAddress}}" method="post" class="device-form">
+                            <form th:action="@{'/updateDevice/' + ${project.id} + '/' + ${device.deviceKey}}" method="post" class="device-form">
 			        
 					<label for="name">Name:</label>
 					<span class="errorform" th:if="${error}" th:text="${error}"></span>


### PR DESCRIPTION
## Summary
- strip non-hex characters during MAC normalization and reuse the helper so empty inputs persist as null
- propagate the normalized MAC/DevEUI handling through the device entity, service, and group controller to support safe device keys
- expose the safe key in DTOs/views and update admin/superadmin templates to fall back to the DevEUI for links and display

## Testing
- ./mvnw -q test *(fails: unable to download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd16e647f083279df01fa534e3af15