### PR TITLE
Add gsheet support to Device DTO mapping

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -470,7 +470,8 @@ public class DeviceController {
         public void loadDeviceDTO(List<Device> devices, Model model) {
                 List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getId(), d.getName(),
                                 d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(),
-                                d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
+                                d.getTod() != null ? d.getTod().getName() : null, d.getVisibleUsername(), d.getStatus(),
+                                d.getGsheet()))
                                 .collect(Collectors.toList());
                 Comparator<DeviceDTO> cmp = Comparator.comparing(DeviceDTO::getEmailOwner,
                                 Comparator.nullsFirst(String::compareTo));

--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -300,7 +300,9 @@ private AdminService adminService;
                         }
                 });
                 List<DeviceDTO> deviceDTOs = orderedDevices.stream().map(d -> new DeviceDTO(d.getId(), d.getName(),
-                                d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
+                                d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(),
+                                d.getTod() != null ? d.getTod().getName() : null, d.getVisibleUsername(), d.getStatus(),
+                                d.getGsheet()))
                                 .collect(Collectors.toList());
                 model.addAttribute("devices", deviceDTOs);
         }

--- a/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
@@ -33,7 +33,18 @@ public class GroupControllerRest {
     public List<DeviceDTO> getDevicesByGroupId(@PathVariable("groupId") Long groupId) {
         List<Device> devices = groupService.findGroupById(groupId).getDevices();
         return devices.stream()
-                .map(d -> new DeviceDTO(d.getId(), d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
+                .map(d -> new DeviceDTO(
+                        d.getId(),
+                        d.getName(),
+                        d.getMacAddress(),
+                        d.getEmailOwner(),
+                        d.getDevEui(),
+                        d.getLongitude(),
+                        d.getLatitude(),
+                        d.getTod() != null ? d.getTod().getName() : null,
+                        d.getVisibleUsername(),
+                        d.getStatus(),
+                        d.getGsheet()))
                 .collect(Collectors.toList());
     }
     
@@ -43,7 +54,18 @@ public class GroupControllerRest {
 		Credentials credentials = credentialsService.getCredentials(userDetails.getUsername());
         List<Device> devices = groupService.findGroupByNameAndCredentials(groupName, credentials).getDevices();
         return devices.stream()
-                .map(d -> new DeviceDTO(d.getId(), d.getName(), d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(), d.getTod().getName(), d.getVisibleUsername(), d.getStatus()))
+                .map(d -> new DeviceDTO(
+                        d.getId(),
+                        d.getName(),
+                        d.getMacAddress(),
+                        d.getEmailOwner(),
+                        d.getDevEui(),
+                        d.getLongitude(),
+                        d.getLatitude(),
+                        d.getTod() != null ? d.getTod().getName() : null,
+                        d.getVisibleUsername(),
+                        d.getStatus(),
+                        d.getGsheet()))
                 .collect(Collectors.toList());
     }
     
@@ -64,7 +86,8 @@ public class GroupControllerRest {
                 device.getLatitude(),
                 device.getTod() != null ? device.getTod().getName() : null,
                 device.getVisibleUsername(),
-                device.getStatus()
+                device.getStatus(),
+                device.getGsheet()
             ))
             .toList();
     }

--- a/src/main/java/it/sensorplatform/dto/DeviceDTO.java
+++ b/src/main/java/it/sensorplatform/dto/DeviceDTO.java
@@ -15,8 +15,9 @@ public class DeviceDTO {
         private String tod;
         private String operator;
         private String status;
+        private String gsheet;
 
-        public DeviceDTO(Long id, String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator, String status) {
+        public DeviceDTO(Long id, String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator, String status, String gsheet) {
                 this.id = id;
                 this.name = name;
                 this.macAddress = macAddress;
@@ -27,6 +28,7 @@ public class DeviceDTO {
                 this.tod=tod;
                 this.operator=operator;
                 this.status = status;
+                this.gsheet = gsheet;
         }
 
         public Long getId() {
@@ -118,6 +120,14 @@ public class DeviceDTO {
 
         public void setStatus(String status) {
                 this.status = status;
+        }
+
+        public String getGsheet() {
+                return gsheet;
+        }
+
+        public void setGsheet(String gsheet) {
+                this.gsheet = gsheet;
         }
 
         public boolean isEmailOwnerMissing() {

--- a/src/main/java/it/sensorplatform/model/Device.java
+++ b/src/main/java/it/sensorplatform/model/Device.java
@@ -37,6 +37,9 @@ public class Device {
         @Column(nullable = true)
         private String emailOwner;
 
+        @Column(nullable = true)
+        private String gsheet;
+
         @Column(name="status")
         private String status = "deactivated";
 	
@@ -144,6 +147,14 @@ public class Device {
                 this.emailOwner = emailOwner;
         }
 
+        public String getGsheet() {
+                return normalizeBlank(gsheet);
+        }
+
+        public void setGsheet(String gsheet) {
+                this.gsheet = normalizeBlank(gsheet);
+        }
+
         public String getStatus() {
                 return status;
         }
@@ -216,6 +227,13 @@ public class Device {
                         return devEui;
                 }
                 return null;
+        }
+
+        private static String normalizeBlank(String value) {
+                if (value == null || value.isBlank()) {
+                        return null;
+                }
+                return value;
         }
 }
 


### PR DESCRIPTION
## Summary
- add a nullable gsheet column to Device with blank-to-null normalization
- expose the gsheet value on DeviceDTO and propagate it through controllers, guarding against missing type-of-device data

## Testing
- ./mvnw test *(fails: wget unable to fetch Maven distribution from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68cd391d340c8323b20ba74f600c7cdc