### PR TITLE
Add support for assigning Google Sheet links to project devices

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -19,6 +19,8 @@ import it.sensorplatform.service.SuperadminService;
 import it.sensorplatform.util.MacAddressUtils;
 import jakarta.validation.Valid;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -43,8 +45,10 @@ import java.util.stream.Collectors;
 @Controller
 public class DeviceController {
 
-	@Autowired
-	private DeviceService deviceService;
+        private static final Logger logger = LoggerFactory.getLogger(DeviceController.class);
+
+        @Autowired
+        private DeviceService deviceService;
 
 	@Autowired
 	private ProjectService projectService;
@@ -133,6 +137,64 @@ public class DeviceController {
                                 devicesToUpdate.size() == 1
                                                 ? "Email owner assigned to 1 device."
                                                 : "Email owner assigned to " + devicesToUpdate.size() + " devices.");
+
+                return "redirect:/superadmin/manageProjectDevices/" + projectId;
+        }
+
+        @PostMapping("/superadmin/assignGsheet/{projectId}")
+        public String assignGsheet(@PathVariable("projectId") Long projectId,
+                        @RequestParam(value = "selectedDeviceIds", required = false) List<Long> selectedDeviceIds,
+                        @RequestParam(value = "gsheetLink", required = false) String gsheetLink,
+                        RedirectAttributes redirectAttributes) {
+
+                if (selectedDeviceIds == null || selectedDeviceIds.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("errorMessage",
+                                        "Select at least one device to assign a Google Sheet link.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
+
+                if (!StringUtils.hasText(gsheetLink)) {
+                        redirectAttributes.addFlashAttribute("errorMessage",
+                                        "Provide a Google Sheet link to assign to the selected devices.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
+
+                Set<Long> deviceIdsToAssign = selectedDeviceIds.stream().filter(Objects::nonNull)
+                                .collect(Collectors.toSet());
+
+                if (deviceIdsToAssign.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("errorMessage",
+                                        "Select at least one device to assign a Google Sheet link.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
+
+                Set<Device> projectDevices = deviceService.findAllByProjectId(projectId);
+                if (projectDevices == null) {
+                        projectDevices = Collections.emptySet();
+                }
+
+                List<Device> devicesToUpdate = projectDevices.stream()
+                                .filter(device -> deviceIdsToAssign.contains(device.getId()))
+                                .collect(Collectors.toList());
+
+                if (devicesToUpdate.isEmpty()) {
+                        redirectAttributes.addFlashAttribute("errorMessage",
+                                        "Unable to locate the selected devices.");
+                        return "redirect:/superadmin/manageProjectDevices/" + projectId;
+                }
+
+                String trimmedLink = gsheetLink.trim();
+                devicesToUpdate.forEach(device -> {
+                        device.setGsheet(trimmedLink);
+                        deviceService.save(device);
+                });
+
+                logger.info("Assigned Google Sheet link to {} device(s) for project {}", devicesToUpdate.size(), projectId);
+
+                redirectAttributes.addFlashAttribute("successMessage",
+                                devicesToUpdate.size() == 1
+                                                ? "Google Sheet link assigned to 1 device."
+                                                : "Google Sheet link assigned to " + devicesToUpdate.size() + " devices.");
 
                 return "redirect:/superadmin/manageProjectDevices/" + projectId;
         }

--- a/src/test/java/it/sensorplatform/test/DeviceControllerTests.java
+++ b/src/test/java/it/sensorplatform/test/DeviceControllerTests.java
@@ -4,14 +4,19 @@ import it.sensorplatform.controller.DeviceController;
 import it.sensorplatform.dto.DeviceDTO;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.model.TypeOfDevice;
+import it.sensorplatform.service.DeviceService;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
+import org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class DeviceControllerTests {
 
@@ -64,5 +69,66 @@ class DeviceControllerTests {
         assertNotNull(withoutOwner);
         assertEquals(1, withoutOwner.size());
         assertTrue(withoutOwner.get(0).isEmailOwnerMissing());
+    }
+
+    @Test
+    void assignGsheetReturnsErrorWhenNoDevicesSelected() {
+        DeviceController controller = new DeviceController();
+        RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+        String viewName = controller.assignGsheet(1L, null, "https://sheet", redirectAttributes);
+
+        assertEquals("redirect:/superadmin/manageProjectDevices/1", viewName);
+        assertEquals("Select at least one device to assign a Google Sheet link.",
+                redirectAttributes.getFlashAttributes().get("errorMessage"));
+    }
+
+    @Test
+    void assignGsheetReturnsErrorWhenLinkMissing() {
+        DeviceController controller = new DeviceController();
+        RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+
+        String viewName = controller.assignGsheet(1L, List.of(1L), "   ", redirectAttributes);
+
+        assertEquals("redirect:/superadmin/manageProjectDevices/1", viewName);
+        assertEquals("Provide a Google Sheet link to assign to the selected devices.",
+                redirectAttributes.getFlashAttributes().get("errorMessage"));
+    }
+
+    @Test
+    void assignGsheetPersistsTrimmedLinkForSelectedDevices() {
+        DeviceService deviceService = mock(DeviceService.class);
+        DeviceController controller = new DeviceController();
+        ReflectionTestUtils.setField(controller, "deviceService", deviceService);
+
+        Long projectId = 7L;
+        Device device1 = new Device();
+        device1.setId(1L);
+        Device device2 = new Device();
+        device2.setId(2L);
+        Device otherDevice = new Device();
+        otherDevice.setId(3L);
+
+        when(deviceService.findAllByProjectId(projectId))
+                .thenReturn(new HashSet<>(Arrays.asList(device1, device2, otherDevice)));
+
+        RedirectAttributesModelMap redirectAttributes = new RedirectAttributesModelMap();
+        List<Long> selectedDeviceIds = Arrays.asList(1L, 2L, 1L);
+
+        String viewName = controller.assignGsheet(projectId, selectedDeviceIds, " https://sheet.example/ ", redirectAttributes);
+
+        assertEquals("redirect:/superadmin/manageProjectDevices/" + projectId, viewName);
+
+        verify(deviceService).findAllByProjectId(projectId);
+        verify(deviceService).save(device1);
+        verify(deviceService).save(device2);
+        verify(deviceService, never()).save(otherDevice);
+
+        assertEquals("https://sheet.example/", device1.getGsheet());
+        assertEquals("https://sheet.example/", device2.getGsheet());
+        assertNull(otherDevice.getGsheet());
+
+        assertEquals("Google Sheet link assigned to 2 devices.",
+                redirectAttributes.getFlashAttributes().get("successMessage"));
     }
 }


### PR DESCRIPTION
## Summary
- add a superadmin handler to assign Google Sheet links to project devices with validation and logging
- persist the trimmed link on each selected device via the service layer
- add controller tests covering the happy path and validation failures using mocked dependencies

## Testing
- ./mvnw test *(fails: wget unable to fetch Maven binaries in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3a4b72e88323a74b61784e269ad0