### PR TITLE
Add GSheet assignment modal and styling

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -257,8 +257,27 @@ navbar h1 {
     transform: scale(1.03);
 }
 
+.btn-assign-gsheet {
+    background-color: #8ecae6;
+    color: #0d1b2a;
+    margin-bottom: 1rem;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-weight: bold;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.btn-assign-gsheet:hover {
+    background-color: #219ebc;
+    transform: scale(1.03);
+}
+
 .btn-assign-owner:disabled,
-.btn-assign-owner.btn-disabled {
+.btn-assign-owner.btn-disabled,
+.btn-assign-gsheet:disabled,
+.btn-assign-gsheet.btn-disabled {
     background-color: #546e7a;
     color: #d0d7de;
     cursor: not-allowed;
@@ -347,6 +366,13 @@ td:last-child {
     align-items: center;
     margin-bottom: 1rem;
     gap: 1rem;
+}
+
+.top-bar-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
 .search-form {
@@ -492,6 +518,20 @@ body.modal-open {
     color: #ffffff;
 }
 
+.gsheet-cell {
+    overflow-wrap: anywhere;
+}
+
+.gsheet-cell a {
+    color: #8ecae6;
+    text-decoration: underline;
+    word-break: break-word;
+}
+
+.gsheet-cell a:hover {
+    text-decoration: none;
+}
+
 .checkbox-cell {
     text-align: center;
 }
@@ -512,7 +552,8 @@ body.modal-open {
 }
 
 .select-input,
-.form-row input[type="email"] {
+.form-row input[type="email"],
+.form-row input[type="url"] {
     background-color: #203047;
     border: 1px solid #324a5f;
     border-radius: 6px;
@@ -526,7 +567,8 @@ body.modal-open {
     cursor: not-allowed;
 }
 
-.form-row input[type="email"]::placeholder {
+.form-row input[type="email"]::placeholder,
+.form-row input[type="url"]::placeholder {
     color: rgba(255, 255, 255, 0.6);
 }
 

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -256,8 +256,27 @@ navbar h1 {
     transform: scale(1.03);
 }
 
+.btn-assign-gsheet {
+    background-color: #26c6da;
+    color: #0d1b2a;
+    margin-bottom: 1rem;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-weight: bold;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.btn-assign-gsheet:hover {
+    background-color: #00acc1;
+    transform: scale(1.03);
+}
+
 .btn-assign-owner:disabled,
-.btn-assign-owner.btn-disabled {
+.btn-assign-owner.btn-disabled,
+.btn-assign-gsheet:disabled,
+.btn-assign-gsheet.btn-disabled {
     background-color: #546e7a;
     color: #d0d7de;
     cursor: not-allowed;
@@ -346,6 +365,13 @@ td:last-child {
     align-items: center;
     margin-bottom: 1rem;
     gap: 1rem;
+}
+
+.top-bar-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
 }
 
 .search-form {
@@ -491,6 +517,20 @@ body.modal-open {
     color: #ffffff;
 }
 
+.gsheet-cell {
+    overflow-wrap: anywhere;
+}
+
+.gsheet-cell a {
+    color: #4fc3f7;
+    text-decoration: underline;
+    word-break: break-word;
+}
+
+.gsheet-cell a:hover {
+    text-decoration: none;
+}
+
 .checkbox-cell {
     text-align: center;
 }
@@ -511,7 +551,8 @@ body.modal-open {
 }
 
 .select-input,
-.form-row input[type="email"] {
+.form-row input[type="email"],
+.form-row input[type="url"] {
     background-color: #10243d;
     border: 1px solid #324a5f;
     border-radius: 6px;
@@ -525,7 +566,8 @@ body.modal-open {
     cursor: not-allowed;
 }
 
-.form-row input[type="email"]::placeholder {
+.form-row input[type="email"]::placeholder,
+.form-row input[type="url"]::placeholder {
     color: rgba(255, 255, 255, 0.6);
 }
 

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -316,8 +316,27 @@ html, body {
     transform: scale(1.03);
 }
 
+.btn-assign-gsheet {
+    background-color: #76c893;
+    color: #10201a;
+    margin-bottom: 1rem;
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-weight: bold;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.btn-assign-gsheet:hover {
+    background-color: #52b788;
+    transform: scale(1.03);
+}
+
 .btn-assign-owner:disabled,
-.btn-assign-owner.btn-disabled {
+.btn-assign-owner.btn-disabled,
+.btn-assign-gsheet:disabled,
+.btn-assign-gsheet.btn-disabled {
     background-color: #546e7a;
     color: #d0d7de;
     cursor: not-allowed;
@@ -461,8 +480,18 @@ td:last-child {
 }
 
 .top-bar{
-	display: flex;
-	justify-content: space-between;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 1rem;
+        gap: 1rem;
+}
+
+.top-bar-actions{
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
 }
 
 .modal-overlay {
@@ -562,6 +591,20 @@ body.modal-open {
     color: #ffffff;
 }
 
+.gsheet-cell {
+    overflow-wrap: anywhere;
+}
+
+.gsheet-cell a {
+    color: #76c893;
+    text-decoration: underline;
+    word-break: break-word;
+}
+
+.gsheet-cell a:hover {
+    text-decoration: none;
+}
+
 .checkbox-cell {
     text-align: center;
 }
@@ -582,7 +625,8 @@ body.modal-open {
 }
 
 .select-input,
-.form-row input[type="email"] {
+.form-row input[type="email"],
+.form-row input[type="url"] {
     background-color: #203047;
     border: 1px solid #324a5f;
     border-radius: 6px;
@@ -596,7 +640,8 @@ body.modal-open {
     cursor: not-allowed;
 }
 
-.form-row input[type="email"]::placeholder {
+.form-row input[type="email"]::placeholder,
+.form-row input[type="url"]::placeholder {
     color: rgba(255, 255, 255, 0.6);
 }
 

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -61,22 +61,29 @@
                 <div th:if="${errorMessage}" class="alert-error" th:text="${errorMessage}"></div>
 
                 <div class="top-bar">
-                        <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
-                        <button type="button" id="openAssignOwnerModal" class="btn-action btn-assign-owner"
-                                th:classappend="${#lists.isEmpty(devicesWithoutOwner)} ? ' btn-disabled' : ''"
-                                th:disabled="${#lists.isEmpty(devicesWithoutOwner)}">
-                                📧 Assign owner
-                        </button>
+                        <div class="top-bar-actions">
+                                <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
+                                <button type="button" id="openAssignOwnerModal" class="btn-action btn-assign-owner"
+                                        th:classappend="${#lists.isEmpty(devicesWithoutOwner)} ? ' btn-disabled' : ''"
+                                        th:disabled="${#lists.isEmpty(devicesWithoutOwner)}">
+                                        📧 Assign owner
+                                </button>
+                                <button type="button" id="openAssignGsheetModal" class="btn-action btn-assign-gsheet"
+                                        th:classappend="${#lists.isEmpty(devices)} ? ' btn-disabled' : ''"
+                                        th:disabled="${#lists.isEmpty(devices)}">
+                                        📄 Assign GSheet
+                                </button>
+                        </div>
                         <form th:action="@{'/superadmin/manageProjectDevices/' + ${project.id}}" method="get" class="search-form">
                                 <input type="text" name="deviceQuery" placeholder="Search..." th:value="${param.deviceQuery}" />
                                 <button type="submit" title="Search">
                                         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="white" viewBox="0 0 24 24">
-						<circle cx="11" cy="11" r="8" stroke="white" stroke-width="2" fill="none"/>
-						<line x1="17" y1="17" x2="22" y2="22" stroke="white" stroke-width="2"/>
-					</svg>
-				</button>
-			</form>
-		</div>
+                                                <circle cx="11" cy="11" r="8" stroke="white" stroke-width="2" fill="none"/>
+                                                <line x1="17" y1="17" x2="22" y2="22" stroke="white" stroke-width="2"/>
+                                        </svg>
+                                </button>
+                        </form>
+                </div>
 
 		<table>
 			<thead>
@@ -107,6 +114,7 @@
 </div>
 
 <div id="assignEmailOverlay" class="modal-overlay"></div>
+<div id="assignGsheetOverlay" class="modal-overlay"></div>
 
 <div id="assignEmailModal" class="modal-container"
         th:classappend="${project.id == 1} ? ' ltrad' : (${project.id == 51} ? ' fire' : (${project.id == 101} ? ' volcano' : ''))">
@@ -161,6 +169,60 @@
                 <div class="modal-footer">
                         <button type="submit" class="btn-save-modal"
                                 th:disabled="${#lists.isEmpty(devicesWithoutOwner)}">Save</button>
+                </div>
+        </form>
+</div>
+
+<div id="assignGsheetModal" class="modal-container"
+        th:classappend="${project.id == 1} ? ' ltrad' : (${project.id == 51} ? ' fire' : (${project.id == 101} ? ' volcano' : ''))">
+        <div class="modal-header">
+                <h2>Assign GSheet link</h2>
+                <button type="button" class="modal-close" id="closeAssignGsheetModal" aria-label="Close">&times;</button>
+        </div>
+        <form id="assignGsheetForm" th:action="@{'/superadmin/assignGsheet/' + ${project.id}}" method="post" class="assign-gsheet-form">
+                <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <div class="modal-body">
+                        <p class="empty-modal-message" th:if="${#lists.isEmpty(devices)}">
+                                No devices available to assign a GSheet link.
+                        </p>
+                        <div th:if="${!#lists.isEmpty(devices)}">
+                                <table class="modal-table">
+                                        <thead>
+                                                <tr>
+                                                        <th scope="col">Name</th>
+                                                        <th scope="col">Identifier</th>
+                                                        <th scope="col">Current GSheet</th>
+                                                        <th scope="col">Select</th>
+                                                </tr>
+                                        </thead>
+                                        <tbody>
+                                                <tr th:each="device : ${devices}">
+                                                        <td th:text="${device.name != null ? device.name : 'N/A'}">Name</td>
+                                                        <td>
+                                                                <span th:text="${device.macAddress != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress) : (device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui) : 'N/A')}"></span>
+                                                                <span th:if="${device.macAddress != null && device.devEui != null}"
+                                                                      th:text="${' / ' + T(it.sensorplatform.util.MacAddressUtils).format(device.devEui)}"></span>
+                                                        </td>
+                                                        <td class="gsheet-cell">
+                                                                <span th:if="${#strings.isEmpty(device.gsheet)}">—</span>
+                                                                <a th:if="${!#strings.isEmpty(device.gsheet)}" th:href="${device.gsheet}" target="_blank" rel="noopener noreferrer" th:text="${device.gsheet}"></a>
+                                                        </td>
+                                                        <td class="checkbox-cell">
+                                                                <input type="checkbox" name="selectedDeviceIds" th:value="${device.id}" />
+                                                        </td>
+                                                </tr>
+                                        </tbody>
+                                </table>
+
+                                <div class="form-row">
+                                        <label for="gsheetLinkInput">New GSheet link</label>
+                                        <input type="url" id="gsheetLinkInput" name="gsheetLink" placeholder="https://..."
+                                               th:disabled="${#lists.isEmpty(devices)}" />
+                                </div>
+                        </div>
+                </div>
+                <div class="modal-footer">
+                        <button type="submit" class="btn-save-modal" th:disabled="${#lists.isEmpty(devices)}">Save</button>
                 </div>
         </form>
 </div>
@@ -287,68 +349,125 @@
                 document.addEventListener("DOMContentLoaded", function () {
                         const toggle = document.getElementById("userDropdown");
                         const menu = document.getElementById("userDropdownMenu");
-                        const openModalButton = document.getElementById("openAssignOwnerModal");
-                        const modal = document.getElementById("assignEmailModal");
-                        const overlay = document.getElementById("assignEmailOverlay");
-                        const closeModalButton = document.getElementById("closeAssignEmailModal");
                         const existingEmailSelect = document.getElementById("existingEmailSelect");
                         const newEmailInput = document.getElementById("newEmailInput");
+                        const openAssignOwnerModal = document.getElementById("openAssignOwnerModal");
+                        const assignEmailModal = document.getElementById("assignEmailModal");
+                        const assignEmailOverlay = document.getElementById("assignEmailOverlay");
+                        const closeAssignEmailModal = document.getElementById("closeAssignEmailModal");
+                        const openAssignGsheetModal = document.getElementById("openAssignGsheetModal");
+                        const assignGsheetModal = document.getElementById("assignGsheetModal");
+                        const assignGsheetOverlay = document.getElementById("assignGsheetOverlay");
+                        const closeAssignGsheetModal = document.getElementById("closeAssignGsheetModal");
+                        const gsheetLinkInput = document.getElementById("gsheetLinkInput");
 
-                        toggle.addEventListener("click", function (e) {
-                                e.stopPropagation();
-                                menu.classList.toggle("show");
-                        });
+                        if (toggle && menu) {
+                                toggle.addEventListener("click", function (e) {
+                                        e.stopPropagation();
+                                        menu.classList.toggle("show");
+                                });
+                        }
 
                         document.addEventListener("click", function (e) {
-                                if (!toggle.contains(e.target)) {
+                                if (toggle && menu && !toggle.contains(e.target)) {
                                         menu.classList.remove("show");
                                 }
                         });
 
-                        function openModal() {
-                                if (openModalButton && openModalButton.disabled) {
+                        let activeModalContext = null;
+
+                        function openModal(modal, overlay, hooks = {}) {
+                                if (!modal || !overlay) {
                                         return;
                                 }
-                                if (modal) {
-                                        modal.classList.add("show");
+                                if (activeModalContext && activeModalContext.modal !== modal) {
+                                        closeModal(activeModalContext.modal, activeModalContext.overlay);
                                 }
-                                if (overlay) {
-                                        overlay.classList.add("show");
+                                if (typeof hooks.onBeforeOpen === "function") {
+                                        hooks.onBeforeOpen();
                                 }
+                                modal.classList.add("show");
+                                overlay.classList.add("show");
                                 document.body.classList.add("modal-open");
-                        }
-
-                        function closeModal() {
-                                if (modal) {
-                                        modal.classList.remove("show");
+                                activeModalContext = { modal, overlay, hooks };
+                                if (typeof hooks.onAfterOpen === "function") {
+                                        hooks.onAfterOpen();
                                 }
-                                if (overlay) {
-                                        overlay.classList.remove("show");
+                        }
+
+                        function closeModal(modal, overlay) {
+                                if (!modal || !overlay || !modal.classList.contains("show")) {
+                                        return;
                                 }
-                                document.body.classList.remove("modal-open");
+                                modal.classList.remove("show");
+                                overlay.classList.remove("show");
+                                if (!document.querySelector(".modal-container.show")) {
+                                        document.body.classList.remove("modal-open");
+                                }
+                                if (activeModalContext && activeModalContext.modal === modal) {
+                                        const hooks = activeModalContext.hooks || {};
+                                        if (typeof hooks.onClose === "function") {
+                                                hooks.onClose();
+                                        }
+                                        activeModalContext = null;
+                                }
                         }
 
-                        if (openModalButton) {
-                                openModalButton.addEventListener("click", function () {
-                                        openModal();
-                                });
-                        }
+                        function registerModal({ openButton, closeButton, modal, overlay, hooks = {} }) {
+                                if (!modal || !overlay) {
+                                        return;
+                                }
 
-                        if (closeModalButton) {
-                                closeModalButton.addEventListener("click", function () {
-                                        closeModal();
-                                });
-                        }
+                                if (openButton) {
+                                        openButton.addEventListener("click", () => {
+                                                if (openButton.disabled) {
+                                                        return;
+                                                }
+                                                openModal(modal, overlay, hooks);
+                                        });
+                                }
 
-                        if (overlay) {
-                                overlay.addEventListener("click", function () {
-                                        closeModal();
-                                });
+                                if (closeButton) {
+                                        closeButton.addEventListener("click", () => closeModal(modal, overlay));
+                                }
+
+                                overlay.addEventListener("click", () => closeModal(modal, overlay));
                         }
 
                         document.addEventListener("keydown", function (event) {
-                                if (event.key === "Escape") {
-                                        closeModal();
+                                if (event.key === "Escape" && activeModalContext) {
+                                        closeModal(activeModalContext.modal, activeModalContext.overlay);
+                                }
+                        });
+
+                        registerModal({
+                                openButton: openAssignOwnerModal,
+                                closeButton: closeAssignEmailModal,
+                                modal: assignEmailModal,
+                                overlay: assignEmailOverlay
+                        });
+
+                        registerModal({
+                                openButton: openAssignGsheetModal,
+                                closeButton: closeAssignGsheetModal,
+                                modal: assignGsheetModal,
+                                overlay: assignGsheetOverlay,
+                                hooks: {
+                                        onBeforeOpen: () => {
+                                                if (gsheetLinkInput) {
+                                                        gsheetLinkInput.value = "";
+                                                }
+                                        },
+                                        onAfterOpen: () => {
+                                                if (gsheetLinkInput && !gsheetLinkInput.disabled) {
+                                                        gsheetLinkInput.focus();
+                                                }
+                                        },
+                                        onClose: () => {
+                                                if (gsheetLinkInput) {
+                                                        gsheetLinkInput.value = "";
+                                                }
+                                        }
                                 }
                         });
 
@@ -385,6 +504,8 @@
                         if (newEmailInput) {
                                 newEmailInput.addEventListener("input", handleNewEmailInput);
                         }
+
+                        handleNewEmailInput();
                 });
         </script>
 </html>


### PR DESCRIPTION
## Summary
- add an Assign GSheet button, overlay, and modal listing all project devices with link input and selection controls
- refactor the page script to share open/close logic for both email and GSheet modals, including Escape handling and field resets
- extend the L-TRAD, FIRE, and VOLCANO stylesheets with button, modal, and URL input styling updates

## Testing
- `./mvnw -q -DskipTests verify` *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3b7343f483238bce49f8e2804f94