### PR TITLE
Add View Gsheet button to device dashboard

### DIFF
--- a/src/main/resources/static/css/deviceDashboard.css
+++ b/src/main/resources/static/css/deviceDashboard.css
@@ -384,6 +384,36 @@
         font-weight: 500;
 }
 
+.gsheet-link-wrapper {
+        margin-top: 1.5rem;
+}
+
+.gsheet-link-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.5rem 1.2rem;
+        border-radius: 0.6rem;
+        background: var(--accent-color);
+        color: var(--accent-contrast);
+        text-decoration: none;
+        font-weight: 600;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+        transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.gsheet-link-button:hover,
+.gsheet-link-button:focus-visible {
+        transform: translateY(-2px);
+        box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+        opacity: 0.95;
+}
+
+.gsheet-link-button:focus-visible {
+        outline: 2px solid var(--accent-contrast);
+        outline-offset: 3px;
+}
+
 .status-panel {
         display: flex;
         flex-direction: column;

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -96,6 +96,9 @@
                                 <span class="panel-subtitle">Metadata sent with the latest packet</span>
                         </div>
                         <dl id="info-grid" class="info-grid"></dl>
+                        <div class="gsheet-link-wrapper" th:if="${device.gsheet != null}">
+                                <a class="gsheet-link-button" th:href="${device.gsheet}" target="_blank" rel="noopener noreferrer">View Gsheet</a>
+                        </div>
                         <p id="info-empty" class="empty-state">No additional information available.</p>
                 </section>
 


### PR DESCRIPTION
## Summary
- add a "View Gsheet" call-to-action under the Device information cards when a link is available
- style the new button so it matches the dashboard accent colors and hover states

## Testing
- ./mvnw test *(fails: unable to download Apache Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd21bd0fec832397d0441251497805