### PR TITLE
Adjust device manager header layout

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -360,9 +360,28 @@ td:last-child {
 }
 
 
-.top-bar {
+
+.devices-header {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.devices-header h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.devices-header .btn-action {
+    margin-bottom: 0;
+}
+
+.top-bar {
+    display: flex;
+    justify-content: flex-end;
     align-items: center;
     margin-bottom: 1rem;
     gap: 1rem;

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -359,9 +359,28 @@ td:last-child {
 }
 
 
-.top-bar {
+
+.devices-header {
     display: flex;
     justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.devices-header h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.devices-header .btn-action {
+    margin-bottom: 0;
+}
+
+.top-bar {
+    display: flex;
+    justify-content: flex-end;
     align-items: center;
     margin-bottom: 1rem;
     gap: 1rem;

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -479,9 +479,28 @@ td:last-child {
     display: block;
 }
 
-.top-bar{
+
+.devices-header {
         display: flex;
         justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+}
+
+.devices-header h1 {
+        margin: 0;
+        font-size: 2rem;
+}
+
+.devices-header .btn-action {
+        margin-bottom: 0;
+}
+
+.top-bar{
+        display: flex;
+        justify-content: flex-end;
         align-items: center;
         margin-bottom: 1rem;
         gap: 1rem;

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -55,12 +55,8 @@
 <div class="main-layout">
 	<!-- Left panel: device management -->
                 <div class="devices-panel">
-                <h1 th:text="'Device Manager - ' + ${project.name}">Device Manager</h1>
-
-                <div th:if="${successMessage}" class="alert-success" th:text="${successMessage}"></div>
-                <div th:if="${errorMessage}" class="alert-error" th:text="${errorMessage}"></div>
-
-                <div class="top-bar">
+                <div class="devices-header">
+                        <h1>Device Manager</h1>
                         <div class="top-bar-actions">
                                 <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
                                 <button type="button" id="openAssignOwnerModal" class="btn-action btn-assign-owner"
@@ -74,6 +70,12 @@
                                         📄 Assign GSheet
                                 </button>
                         </div>
+                </div>
+
+                <div th:if="${successMessage}" class="alert-success" th:text="${successMessage}"></div>
+                <div th:if="${errorMessage}" class="alert-error" th:text="${errorMessage}"></div>
+
+                <div class="top-bar">
                         <form th:action="@{'/superadmin/manageProjectDevices/' + ${project.id}}" method="get" class="search-form">
                                 <input type="text" name="deviceQuery" placeholder="Search..." th:value="${param.deviceQuery}" />
                                 <button type="submit" title="Search">


### PR DESCRIPTION
## Summary
- align the Device Manager actions alongside the page title and drop the redundant project name suffix
- keep success and error messaging below the header while moving the search form into its own toolbar
- update the L-TRAD, FIRE, and VOLCANO stylesheets to support the new header layout and right-align the search field

## Testing
- ./mvnw spring-boot:run *(fails: unable to download Maven distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd453a98d88323ac569fcccfd1917e