### PR TITLE
Limit GSheet link display width in assignment modal

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -520,6 +520,30 @@ body.modal-open {
     margin-bottom: 0.5rem;
 }
 
+.gsheet-table {
+    table-layout: fixed;
+}
+
+.gsheet-table th:nth-child(1),
+.gsheet-table td:nth-child(1) {
+    width: 25%;
+}
+
+.gsheet-table th:nth-child(2),
+.gsheet-table td:nth-child(2) {
+    width: 25%;
+}
+
+.gsheet-table th:nth-child(3),
+.gsheet-table td:nth-child(3) {
+    width: 40%;
+}
+
+.gsheet-table th:nth-child(4),
+.gsheet-table td:nth-child(4) {
+    width: 10%;
+}
+
 .modal-table th,
 .modal-table td {
     border: 1px solid #324a5f;
@@ -538,16 +562,20 @@ body.modal-open {
 }
 
 .gsheet-cell {
-    overflow-wrap: anywhere;
+    overflow: hidden;
 }
 
-.gsheet-cell a {
+.gsheet-link {
     color: #8ecae6;
     text-decoration: underline;
-    word-break: break-word;
+    display: inline-block;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.gsheet-cell a:hover {
+.gsheet-link:hover {
     text-decoration: none;
 }
 

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -519,6 +519,30 @@ body.modal-open {
     margin-bottom: 0.5rem;
 }
 
+.gsheet-table {
+    table-layout: fixed;
+}
+
+.gsheet-table th:nth-child(1),
+.gsheet-table td:nth-child(1) {
+    width: 25%;
+}
+
+.gsheet-table th:nth-child(2),
+.gsheet-table td:nth-child(2) {
+    width: 25%;
+}
+
+.gsheet-table th:nth-child(3),
+.gsheet-table td:nth-child(3) {
+    width: 40%;
+}
+
+.gsheet-table th:nth-child(4),
+.gsheet-table td:nth-child(4) {
+    width: 10%;
+}
+
 .modal-table th,
 .modal-table td {
     border: 1px solid #324a5f;
@@ -537,16 +561,20 @@ body.modal-open {
 }
 
 .gsheet-cell {
-    overflow-wrap: anywhere;
+    overflow: hidden;
 }
 
-.gsheet-cell a {
+.gsheet-link {
     color: #4fc3f7;
     text-decoration: underline;
-    word-break: break-word;
+    display: inline-block;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.gsheet-cell a:hover {
+.gsheet-link:hover {
     text-decoration: none;
 }
 

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -593,6 +593,30 @@ body.modal-open {
     margin-bottom: 0.5rem;
 }
 
+.gsheet-table {
+    table-layout: fixed;
+}
+
+.gsheet-table th:nth-child(1),
+.gsheet-table td:nth-child(1) {
+    width: 25%;
+}
+
+.gsheet-table th:nth-child(2),
+.gsheet-table td:nth-child(2) {
+    width: 25%;
+}
+
+.gsheet-table th:nth-child(3),
+.gsheet-table td:nth-child(3) {
+    width: 40%;
+}
+
+.gsheet-table th:nth-child(4),
+.gsheet-table td:nth-child(4) {
+    width: 10%;
+}
+
 .modal-table th,
 .modal-table td {
     border: 1px solid #324a5f;
@@ -611,16 +635,20 @@ body.modal-open {
 }
 
 .gsheet-cell {
-    overflow-wrap: anywhere;
+    overflow: hidden;
 }
 
-.gsheet-cell a {
+.gsheet-link {
     color: #76c893;
     text-decoration: underline;
-    word-break: break-word;
+    display: inline-block;
+    max-width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.gsheet-cell a:hover {
+.gsheet-link:hover {
     text-decoration: none;
 }
 

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -188,7 +188,7 @@
                                 No devices available to assign a GSheet link.
                         </p>
                         <div th:if="${!#lists.isEmpty(devices)}">
-                                <table class="modal-table">
+                                <table class="modal-table gsheet-table">
                                         <thead>
                                                 <tr>
                                                         <th scope="col">Name</th>
@@ -207,7 +207,13 @@
                                                         </td>
                                                         <td class="gsheet-cell">
                                                                 <span th:if="${#strings.isEmpty(device.gsheet)}">—</span>
-                                                                <a th:if="${!#strings.isEmpty(device.gsheet)}" th:href="${device.gsheet}" target="_blank" rel="noopener noreferrer" th:text="${device.gsheet}"></a>
+                                                                <a th:if="${!#strings.isEmpty(device.gsheet)}"
+                                                                   class="gsheet-link"
+                                                                   th:href="${device.gsheet}"
+                                                                   target="_blank"
+                                                                   rel="noopener noreferrer"
+                                                                   th:title="${device.gsheet}"
+                                                                   th:text="${device.gsheet}"></a>
                                                         </td>
                                                         <td class="checkbox-cell">
                                                                 <input type="checkbox" name="selectedDeviceIds" th:value="${device.id}" />


### PR DESCRIPTION
## Summary
- truncate displayed GSheet URLs in the assignment modal and expose the full link via tooltip
- add layout rules for the assignment table across project themes to prevent popup overflow

## Testing
- ./mvnw test *(fails: unable to download dependencies from Maven Central in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd4ab9ecc08323a7a3b7b3610ec9a8