### PR TITLE
Align GSheet selection column

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -542,6 +542,12 @@ body.modal-open {
 .gsheet-table th:nth-child(4),
 .gsheet-table td:nth-child(4) {
     width: 10%;
+    text-align: center;
+}
+
+.gsheet-table th:nth-child(4) {
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .modal-table th,
@@ -581,6 +587,9 @@ body.modal-open {
 
 .checkbox-cell {
     text-align: center;
+    vertical-align: middle;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .checkbox-cell input {

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -541,6 +541,12 @@ body.modal-open {
 .gsheet-table th:nth-child(4),
 .gsheet-table td:nth-child(4) {
     width: 10%;
+    text-align: center;
+}
+
+.gsheet-table th:nth-child(4) {
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .modal-table th,
@@ -580,6 +586,9 @@ body.modal-open {
 
 .checkbox-cell {
     text-align: center;
+    vertical-align: middle;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .checkbox-cell input {

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -615,6 +615,12 @@ body.modal-open {
 .gsheet-table th:nth-child(4),
 .gsheet-table td:nth-child(4) {
     width: 10%;
+    text-align: center;
+}
+
+.gsheet-table th:nth-child(4) {
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .modal-table th,
@@ -654,6 +660,9 @@ body.modal-open {
 
 .checkbox-cell {
     text-align: center;
+    vertical-align: middle;
+    padding-left: 0;
+    padding-right: 0;
 }
 
 .checkbox-cell input {


### PR DESCRIPTION
## Summary
- center the "Select" column header and checkbox cells in the Assign GSheet modal
- remove extra horizontal padding so the checkboxes sit centered within their column across all project themes

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd4e2e8d8483239fdd9cf5f1cbabe9