### PR TITLE
Fix guest rendering for project info templates

### DIFF
--- a/src/main/resources/templates/project/fireHome.html
+++ b/src/main/resources/templates/project/fireHome.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 
 <head>
 	<title>FIRE – Home</title>
@@ -13,9 +13,9 @@
 			<h1>FIRE</h1>
 		</div>
 		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                        <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
 				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        Hi, <strong th:text="${user != null ? user.visibleUsername : 'utente'}">utente</strong>
 					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
 						height="16" fill="white">
 						<path d="M7 10l5 5 5-5z" />

--- a/src/main/resources/templates/project/ltradHome.html
+++ b/src/main/resources/templates/project/ltradHome.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 
 <head>
 	<title>L-TRAD – Home</title>
@@ -13,9 +13,9 @@
 			<h1>L-TRAD</h1>
 		</div>
 		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                        <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
 				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        Hi, <strong th:text="${user != null ? user.visibleUsername : 'utente'}">utente</strong>
 					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
 						height="16" fill="white">
 						<path d="M7 10l5 5 5-5z" />

--- a/src/main/resources/templates/project/volcanoHome.html
+++ b/src/main/resources/templates/project/volcanoHome.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 
 <head>
 	<title>VOLCANO – Home</title>
@@ -15,9 +15,9 @@
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 		</div>
 		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                        <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
 				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        Hi, <strong th:text="${user != null ? user.visibleUsername : 'utente'}">utente</strong>
 					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
 						height="16" fill="white">
 						<path d="M7 10l5 5 5-5z" />


### PR DESCRIPTION
## Summary
- add the Spring Security dialect namespace to each project info template so `sec:authorize` is applied
- guard the authenticated-user dropdown so missing user data no longer breaks template rendering
- keep the greeting safe by defaulting to a guest label when no user is present

## Testing
- `./mvnw -q test` *(fails: wrapper cannot download Maven due to network restrictions)*
- `mvn -q test` *(fails: cannot reach Maven Central to resolve the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68cd52b04bc4832799f930930fa3dcb5