### PR TITLE
Fix project info template paths

### DIFF
--- a/src/main/java/it/sensorplatform/controller/AuthenticationController.java
+++ b/src/main/java/it/sensorplatform/controller/AuthenticationController.java
@@ -262,16 +262,16 @@ public class AuthenticationController {
 	    }
 	    model.addAttribute("project", project);
 	    
-	    switch (project.getName()) {
-	        case "LTRAD":
-	            return "/project/ltradHome";
-	        case "FIRE":
-	            return "/project/fireHome";
-	        case "VOLCANO":
-	            return "/project/volcanoHome";
-	        default:
-	            return "error";
-	    }
+            switch (project.getName()) {
+                case "LTRAD":
+                    return "project/ltradHome";
+                case "FIRE":
+                    return "project/fireHome";
+                case "VOLCANO":
+                    return "project/volcanoHome";
+                default:
+                    return "error";
+            }
 	}
 
 }


### PR DESCRIPTION
## Summary
- remove the leading slash from the project info view names so Spring resolves the templates correctly for guests

## Testing
- `./mvnw -DskipTests package` *(fails: unable to download Maven wrapper distribution in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd54d094ec8327a56907fbac16c88b