### PR TITLE
Add pagination controls to project devices table

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -129,7 +129,50 @@ html, body {
 }
 
 .dropdown-logout:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
+}
+
+/* Pagination controls */
+.table-pagination-controls {
+        display: none;
+        margin-top: 1.5rem;
+        gap: 0.5rem;
+        justify-content: center;
+        align-items: center;
+        flex-wrap: wrap;
+}
+
+.table-pagination-controls .pagination-button {
+        background-color: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 999px;
+        color: #ffffff;
+        cursor: pointer;
+        padding: 0.4rem 0.75rem;
+        font-size: 0.95rem;
+        transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.table-pagination-controls .pagination-button:hover,
+.table-pagination-controls .pagination-button:focus-visible {
+        background-color: rgba(255, 191, 128, 0.25);
+        border-color: #ffbf80;
+        color: #ffbf80;
+        transform: translateY(-1px);
+        outline: none;
+}
+
+.table-pagination-controls .pagination-button.active {
+        background-color: #ffbf80;
+        border-color: #ffbf80;
+        color: #1b263b;
+        cursor: default;
+}
+
+.table-pagination-controls .pagination-button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+        transform: none;
 }
 
 .icon-user {

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -87,7 +87,7 @@
                         </form>
                 </div>
 
-		<table>
+                <table id="devicesTable" class="device-table">
 			<thead>
 				<tr>
 					<th scope="col">Name</th>
@@ -108,8 +108,9 @@
                                         <td th:text="${device.tod}">Type Of Device</td>
 				</tr>
 			</tbody>
-		</table>
-	</div>
+                </table>
+                <div id="devicesTablePagination" class="table-pagination-controls"></div>
+        </div>
 
 	<!-- Right panel: map -->
         <div id="map"></div>
@@ -368,6 +369,8 @@
                         const assignGsheetOverlay = document.getElementById("assignGsheetOverlay");
                         const closeAssignGsheetModal = document.getElementById("closeAssignGsheetModal");
                         const gsheetLinkInput = document.getElementById("gsheetLinkInput");
+                        const devicesTable = document.getElementById("devicesTable");
+                        const paginationContainer = document.getElementById("devicesTablePagination");
 
                         if (toggle && menu) {
                                 toggle.addEventListener("click", function (e) {
@@ -383,6 +386,103 @@
                         });
 
                         let activeModalContext = null;
+
+                        function initializeDeviceTablePagination() {
+                                if (!devicesTable || !paginationContainer) {
+                                        return;
+                                }
+
+                                const rows = Array.from(devicesTable.querySelectorAll("tbody tr"));
+                                const rowsPerPage = 8;
+
+                                if (rows.length === 0) {
+                                        paginationContainer.innerHTML = "";
+                                        paginationContainer.style.display = "none";
+                                        return;
+                                }
+
+                                let currentPage = 1;
+                                const totalPages = Math.ceil(rows.length / rowsPerPage);
+
+                                function updateVisibleRows(page) {
+                                        const startIndex = (page - 1) * rowsPerPage;
+                                        const endIndex = startIndex + rowsPerPage;
+
+                                        rows.forEach((row, index) => {
+                                                row.style.display = index >= startIndex && index < endIndex ? "" : "none";
+                                        });
+                                }
+
+                                function createButton(label, targetPage, { disabled = false, active = false, ariaLabel } = {}) {
+                                        const button = document.createElement("button");
+                                        button.type = "button";
+                                        button.textContent = label;
+                                        button.classList.add("pagination-button");
+
+                                        if (ariaLabel) {
+                                                button.setAttribute("aria-label", ariaLabel);
+                                        }
+
+                                        if (disabled) {
+                                                button.disabled = true;
+                                        } else {
+                                                button.addEventListener("click", () => {
+                                                        currentPage = targetPage;
+                                                        updateVisibleRows(currentPage);
+                                                        renderControls();
+                                                });
+                                        }
+
+                                        if (active) {
+                                                button.classList.add("active");
+                                                button.setAttribute("aria-current", "page");
+                                        }
+
+                                        return button;
+                                }
+
+                                function renderControls() {
+                                        paginationContainer.innerHTML = "";
+
+                                        if (totalPages <= 1) {
+                                                paginationContainer.style.display = "none";
+                                                rows.forEach(row => {
+                                                        row.style.display = "";
+                                                });
+                                                return;
+                                        }
+
+                                        paginationContainer.style.display = "flex";
+
+                                        const prevPage = Math.max(1, currentPage - 1);
+                                        paginationContainer.appendChild(
+                                                createButton("‹", prevPage, {
+                                                        disabled: currentPage === 1,
+                                                        ariaLabel: "Previous page"
+                                                })
+                                        );
+
+                                        for (let page = 1; page <= totalPages; page++) {
+                                                paginationContainer.appendChild(
+                                                        createButton(String(page), page, {
+                                                                active: page === currentPage,
+                                                                ariaLabel: `Go to page ${page}`
+                                                        })
+                                                );
+                                        }
+
+                                        const nextPage = Math.min(totalPages, currentPage + 1);
+                                        paginationContainer.appendChild(
+                                                createButton("›", nextPage, {
+                                                        disabled: currentPage === totalPages,
+                                                        ariaLabel: "Next page"
+                                                })
+                                        );
+                                }
+
+                                updateVisibleRows(currentPage);
+                                renderControls();
+                        }
 
                         function openModal(modal, overlay, hooks = {}) {
                                 if (!modal || !overlay) {
@@ -478,6 +578,8 @@
                                         }
                                 }
                         });
+
+                        initializeDeviceTablePagination();
 
                         if (existingEmailSelect) {
                                 existingEmailSelect.dataset.defaultDisabled = existingEmailSelect.disabled ? "true" : "false";


### PR DESCRIPTION
## Summary
- assign a dedicated identifier to the main devices table and add a placeholder container for pagination controls
- implement client-side pagination that paginates eight rows per page and renders navigation buttons into the new container on load
- style the Volcano project pagination controls for consistent layout, hover, and active states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd54e2b0788323a09cd577f5aff202