### PR TITLE
Relocate device action buttons under device table

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -284,7 +284,6 @@ html, body {
 .btn-add {
     background-color: #2e7d32;
     color: white;
-    margin-bottom: 1rem;
     padding: 0.5rem 1rem;
     border-radius: 6px;
     font-weight: bold;
@@ -302,7 +301,6 @@ html, body {
 .btn-assign-owner {
     background-color: #ffb347;
     color: #331600;
-    margin-bottom: 1rem;
     padding: 0.5rem 1rem;
     border-radius: 6px;
     font-weight: bold;
@@ -319,7 +317,6 @@ html, body {
 .btn-assign-gsheet {
     background-color: #76c893;
     color: #10201a;
-    margin-bottom: 1rem;
     padding: 0.5rem 1rem;
     border-radius: 6px;
     font-weight: bold;
@@ -506,11 +503,27 @@ td:last-child {
         gap: 1rem;
 }
 
-.top-bar-actions{
+.table-actions {
+        display: flex;
+        justify-content: flex-end;
+        margin-top: 1.5rem;
+        width: 100%;
+}
+
+.table-actions .top-bar-actions {
         display: flex;
         align-items: center;
         gap: 1rem;
         flex-wrap: wrap;
+        justify-content: flex-end;
+        width: 100%;
+}
+
+@media (max-width: 768px) {
+        .table-actions,
+        .table-actions .top-bar-actions {
+                justify-content: flex-start;
+        }
 }
 
 .modal-overlay {

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -57,19 +57,6 @@
                 <div class="devices-panel">
                 <div class="devices-header">
                         <h1>Device Manager</h1>
-                        <div class="top-bar-actions">
-                                <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
-                                <button type="button" id="openAssignOwnerModal" class="btn-action btn-assign-owner"
-                                        th:classappend="${#lists.isEmpty(devicesWithoutOwner)} ? ' btn-disabled' : ''"
-                                        th:disabled="${#lists.isEmpty(devicesWithoutOwner)}">
-                                        📧 Assign owner
-                                </button>
-                                <button type="button" id="openAssignGsheetModal" class="btn-action btn-assign-gsheet"
-                                        th:classappend="${#lists.isEmpty(devices)} ? ' btn-disabled' : ''"
-                                        th:disabled="${#lists.isEmpty(devices)}">
-                                        📄 Assign GSheet
-                                </button>
-                        </div>
                 </div>
 
                 <div th:if="${successMessage}" class="alert-success" th:text="${successMessage}"></div>
@@ -87,10 +74,10 @@
                         </form>
                 </div>
 
-		<table>
-			<thead>
-				<tr>
-					<th scope="col">Name</th>
+                <table>
+                        <thead>
+                                <tr>
+                                        <th scope="col">Name</th>
                                         <th scope="col">Mac Address/DevEui</th>
                                         <th scope="col">Owner Email</th>
                                         <th scope="col">Type Of Device</th>
@@ -106,10 +93,26 @@
                                         </td>
                                         <td th:text="${device.emailOwner}">Email</td>
                                         <td th:text="${device.tod}">Type Of Device</td>
-				</tr>
-			</tbody>
-		</table>
-	</div>
+                                </tr>
+                        </tbody>
+                </table>
+
+                <div class="table-actions">
+                        <div class="top-bar-actions">
+                                <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
+                                <button type="button" id="openAssignOwnerModal" class="btn-action btn-assign-owner"
+                                        th:classappend="${#lists.isEmpty(devicesWithoutOwner)} ? ' btn-disabled' : ''"
+                                        th:disabled="${#lists.isEmpty(devicesWithoutOwner)}">
+                                        📧 Assign owner
+                                </button>
+                                <button type="button" id="openAssignGsheetModal" class="btn-action btn-assign-gsheet"
+                                        th:classappend="${#lists.isEmpty(devices)} ? ' btn-disabled' : ''"
+                                        th:disabled="${#lists.isEmpty(devices)}">
+                                        📄 Assign GSheet
+                                </button>
+                        </div>
+                </div>
+        </div>
 
 	<!-- Right panel: map -->
         <div id="map"></div>


### PR DESCRIPTION
## Summary
- move the superadmin device action buttons below the device table inside a new wrapper
- adjust the Volcano theme styles to remove obsolete button margins and ensure the new action bar stays responsive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd54eb071c8323a78a7f1ee3880c28