### PR TITLE
Add client-side pagination to project devices table

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -138,6 +138,7 @@ html, body {
         align-items: center;
         gap: 0.75rem;
         margin-top: 1.5rem;
+        flex-wrap: wrap;
 }
 
 .table-pagination-controls .pagination-button {
@@ -148,16 +149,22 @@ html, body {
         border-radius: 999px;
         cursor: pointer;
         font-size: 0.95rem;
-        transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+        transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
 }
 
 .table-pagination-controls .pagination-button:hover {
         background-color: rgba(255, 255, 255, 0.15);
         border-color: rgba(255, 255, 255, 0.8);
+        transform: translateY(-1px);
 }
 
-.table-pagination-controls .pagination-button.active,
-.table-pagination-controls .pagination-button:focus {
+.table-pagination-controls .pagination-button:focus,
+.table-pagination-controls .pagination-button:focus-visible {
+        outline: 2px solid rgba(255, 255, 255, 0.4);
+        outline-offset: 2px;
+}
+
+.table-pagination-controls .pagination-button.active {
         background-color: #e67e00;
         border-color: #e67e00;
         color: #ffffff;

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -380,28 +380,47 @@
                                 const tbody = table.querySelector("tbody");
                                 const rows = tbody ? Array.from(tbody.querySelectorAll("tr")) : [];
                                 const rowsPerPage = 8;
-                                const totalPages = Math.ceil(rows.length / rowsPerPage);
+                                const totalPages = Math.max(1, Math.ceil(rows.length / rowsPerPage));
                                 let currentPage = 1;
 
-                                function showPage(pageNumber) {
-                                        currentPage = pageNumber;
-                                        const startIndex = (pageNumber - 1) * rowsPerPage;
+                                function updateVisibleRows() {
+                                        const startIndex = (currentPage - 1) * rowsPerPage;
                                         const endIndex = startIndex + rowsPerPage;
 
                                         rows.forEach((row, index) => {
                                                 row.style.display = index >= startIndex && index < endIndex ? "" : "none";
                                         });
+                                }
 
+                                function setActiveButton() {
                                         tablePaginationContainer.querySelectorAll("button[data-page]").forEach((button) => {
                                                 const buttonPage = Number(button.dataset.page);
                                                 button.classList.toggle("active", buttonPage === currentPage);
                                         });
                                 }
 
-                                function renderPagination() {
+                                function showPage(pageNumber) {
+                                        currentPage = pageNumber;
+                                        updateVisibleRows();
+                                        setActiveButton();
+                                }
+
+                                function createPaginationButton(pageNumber) {
+                                        const button = document.createElement("button");
+                                        button.type = "button";
+                                        button.dataset.page = String(pageNumber);
+                                        button.textContent = String(pageNumber);
+                                        button.classList.add("pagination-button");
+                                        button.addEventListener("click", () => {
+                                                showPage(pageNumber);
+                                        });
+                                        return button;
+                                }
+
+                                function renderPaginationControls() {
                                         tablePaginationContainer.innerHTML = "";
 
-                                        if (totalPages <= 1) {
+                                        if (rows.length <= rowsPerPage) {
                                                 rows.forEach((row) => {
                                                         row.style.display = "";
                                                 });
@@ -412,21 +431,14 @@
                                         tablePaginationContainer.style.display = "flex";
 
                                         for (let page = 1; page <= totalPages; page++) {
-                                                const button = document.createElement("button");
-                                                button.type = "button";
-                                                button.dataset.page = String(page);
-                                                button.textContent = String(page);
-                                                button.classList.add("pagination-button");
-                                                button.addEventListener("click", () => {
-                                                        showPage(page);
-                                                });
+                                                const button = createPaginationButton(page);
                                                 tablePaginationContainer.appendChild(button);
                                         }
 
                                         showPage(1);
                                 }
 
-                                renderPagination();
+                                renderPaginationControls();
                         }
 
                         if (toggle && menu) {


### PR DESCRIPTION
## Summary
- add a dedicated identifier and pagination container to the project devices table markup
- initialize client-side pagination on DOMContentLoaded so at most eight device rows are shown per page
- style the pagination controls for the Volcano theme with hover and focus states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd5872b9508323974188ce08a56b31