### PR TITLE
Relocate Volcano device actions beneath table

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -316,7 +316,7 @@ html, body {
 .btn-add {
     background-color: #2e7d32;
     color: white;
-    margin-bottom: 1rem;
+    margin-bottom: 0;
     padding: 0.5rem 1rem;
     border-radius: 6px;
     font-weight: bold;
@@ -334,7 +334,7 @@ html, body {
 .btn-assign-owner {
     background-color: #ffb347;
     color: #331600;
-    margin-bottom: 1rem;
+    margin-bottom: 0;
     padding: 0.5rem 1rem;
     border-radius: 6px;
     font-weight: bold;
@@ -351,7 +351,7 @@ html, body {
 .btn-assign-gsheet {
     background-color: #76c893;
     color: #10201a;
-    margin-bottom: 1rem;
+    margin-bottom: 0;
     padding: 0.5rem 1rem;
     border-radius: 6px;
     font-weight: bold;
@@ -536,10 +536,6 @@ td {
         font-size: 2rem;
 }
 
-.devices-header .btn-action {
-        margin-bottom: 0;
-}
-
 .top-bar{
         display: flex;
         justify-content: flex-end;
@@ -548,11 +544,20 @@ td {
         gap: 1rem;
 }
 
+.table-actions {
+        display: flex;
+        justify-content: flex-end;
+        width: 100%;
+        margin-top: 1.25rem;
+}
+
 .top-bar-actions{
         display: flex;
         align-items: center;
         gap: 1rem;
         flex-wrap: wrap;
+        justify-content: flex-end;
+        width: 100%;
 }
 
 .modal-overlay {

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -57,19 +57,6 @@
                 <div class="devices-panel">
                 <div class="devices-header">
                         <h1>Device Manager</h1>
-                        <div class="top-bar-actions">
-                                <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
-                                <button type="button" id="openAssignOwnerModal" class="btn-action btn-assign-owner"
-                                        th:classappend="${#lists.isEmpty(devicesWithoutOwner)} ? ' btn-disabled' : ''"
-                                        th:disabled="${#lists.isEmpty(devicesWithoutOwner)}">
-                                        📧 Assign owner
-                                </button>
-                                <button type="button" id="openAssignGsheetModal" class="btn-action btn-assign-gsheet"
-                                        th:classappend="${#lists.isEmpty(devices)} ? ' btn-disabled' : ''"
-                                        th:disabled="${#lists.isEmpty(devices)}">
-                                        📄 Assign GSheet
-                                </button>
-                        </div>
                 </div>
 
                 <div th:if="${successMessage}" class="alert-success" th:text="${successMessage}"></div>
@@ -109,6 +96,21 @@
                                 </tr>
                         </tbody>
                 </table>
+                <div class="table-actions">
+                        <div class="top-bar-actions">
+                                <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
+                                <button type="button" id="openAssignOwnerModal" class="btn-action btn-assign-owner"
+                                        th:classappend="${#lists.isEmpty(devicesWithoutOwner)} ? ' btn-disabled' : ''"
+                                        th:disabled="${#lists.isEmpty(devicesWithoutOwner)}">
+                                        📧 Assign owner
+                                </button>
+                                <button type="button" id="openAssignGsheetModal" class="btn-action btn-assign-gsheet"
+                                        th:classappend="${#lists.isEmpty(devices)} ? ' btn-disabled' : ''"
+                                        th:disabled="${#lists.isEmpty(devices)}">
+                                        📄 Assign GSheet
+                                </button>
+                        </div>
+                </div>
                 <div id="devicesTablePagination" class="table-pagination-controls"></div>
         </div>
 


### PR DESCRIPTION
## Summary
- move the action buttons below the device table and wrap them in a new container so the layout flows better
- update the Volcano-specific stylesheet to style the new container, keep the buttons right-aligned when wrapping, and remove obsolete margins from the action buttons

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd588008388323946b08f49fc41b65