### PR TITLE
Adjust volcano modal table column layout

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -454,6 +454,11 @@ td {
     display: table-cell;
 }
 
+.modal-table th:last-child,
+.modal-table td:last-child {
+    width: 6rem;
+}
+
 .modal-table .checkbox-cell {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- ensure the volcano theme keeps the modal tables' last column rendered as table cells
- set a fixed width on the Select column to keep checkboxes aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5881d1948323923d167746eab23f