### PR TITLE
Align Volcano device manager actions under pagination

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -137,7 +137,7 @@ html, body {
         justify-content: center;
         align-items: center;
         gap: 0.75rem;
-        margin-top: 1.5rem;
+        margin-top: 0.75rem;
         flex-wrap: wrap;
 }
 
@@ -558,9 +558,9 @@ td {
 
 .table-actions {
         display: flex;
-        justify-content: flex-end;
+        justify-content: flex-start;
         width: 100%;
-        margin-top: 1.25rem;
+        margin-top: 0.75rem;
 }
 
 .top-bar-actions{
@@ -568,7 +568,7 @@ td {
         align-items: center;
         gap: 1rem;
         flex-wrap: wrap;
-        justify-content: flex-end;
+        justify-content: flex-start;
         width: 100%;
 }
 

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -96,6 +96,7 @@
                                 </tr>
                         </tbody>
                 </table>
+                <div id="devicesTablePagination" class="table-pagination-controls"></div>
                 <div class="table-actions">
                         <div class="top-bar-actions">
                                 <a th:href="@{'/superadmin/formNewDevice/' + ${project.id}}" class="btn-action btn-add">➕ Add new device</a>
@@ -111,7 +112,6 @@
                                 </button>
                         </div>
                 </div>
-                <div id="devicesTablePagination" class="table-pagination-controls"></div>
         </div>
 
 	<!-- Right panel: map -->


### PR DESCRIPTION
## Summary
- move the device action buttons below the pagination controls in the superadmin device manager view
- update the Volcano theme styles to left-align the action buttons and reduce spacing around the pagination

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd67d6e6cc8323afbecdee946d5b8c