### PR TITLE
Adjust Volcano device pagination layout

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -134,10 +134,11 @@ html, body {
 
 .table-pagination-controls {
         display: none;
-        justify-content: center;
+        justify-content: flex-start;
         align-items: center;
         gap: 0.75rem;
-        margin-top: 0.75rem;
+        margin-top: 0.25rem;
+        width: 100%;
         flex-wrap: wrap;
 }
 
@@ -560,7 +561,7 @@ td {
         display: flex;
         justify-content: flex-start;
         width: 100%;
-        margin-top: 0.75rem;
+        margin-top: 0.5rem;
 }
 
 .top-bar-actions{


### PR DESCRIPTION
## Summary
- align the Volcano project device table pagination controls with the table
- keep the action buttons directly beneath the pagination, left-aligned for consistency

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cd6a3acd08832386a316e04215a571