### PR TITLE
Center pagination controls under device table

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -389,10 +389,10 @@ td:last-child {
 
 .table-pagination-controls {
     display: none;
-    justify-content: flex-start;
+    justify-content: center;
     align-items: center;
     gap: 0.75rem;
-    margin-top: 0.25rem;
+    margin: 0.5rem auto 0;
     width: 100%;
     flex-wrap: wrap;
 }

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -388,10 +388,10 @@ td:last-child {
 
 .table-pagination-controls {
     display: none;
-    justify-content: flex-start;
+    justify-content: center;
     align-items: center;
     gap: 0.75rem;
-    margin-top: 0.25rem;
+    margin: 0.5rem auto 0;
     width: 100%;
     flex-wrap: wrap;
 }

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -134,10 +134,10 @@ html, body {
 
 .table-pagination-controls {
         display: none;
-        justify-content: flex-start;
+        justify-content: center;
         align-items: center;
         gap: 0.75rem;
-        margin-top: 0.25rem;
+        margin: 0.5rem auto 0;
         width: 100%;
         flex-wrap: wrap;
 }


### PR DESCRIPTION
## Summary
- center the pagination controls beneath the device table on the manage project devices page for all project themes
- add consistent spacing so the pagination buttons sit neatly below the table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd6eddd49c8323accdd3a1175d9990