### PR TITLE
Adjust Fire manage devices table select column styles

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -352,11 +352,22 @@ td {
 }
 
 /* Colonna Azioni */
-td:last-child {
+.device-table td:last-child {
     display: flex;
     gap: 0.5rem;
     align-items: center;
     justify-content: center;
+}
+
+.modal-table td:last-child {
+    display: table-cell;
+    text-align: center;
+}
+
+.modal-table .checkbox-cell {
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 


### PR DESCRIPTION
## Summary
- scope the last-column flex layout to the main device table to avoid affecting modal layouts
- ensure modal tables keep their select column width and centered checkboxes

## Testing
- not run (CSS change only)


------
https://chatgpt.com/codex/tasks/task_e_68ce546e8a7483278f4d1664a1141b1a