### PR TITLE
Scope device table column styles for LTRAD modals

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -351,7 +351,7 @@ td {
 }
 
 /* Colonna Azioni */
-td:last-child {
+.device-table td:last-child {
     display: flex;
     gap: 0.5rem;
     align-items: center;
@@ -613,6 +613,11 @@ body.modal-open {
 .modal-table td {
     background-color: #1a2f46;
     color: #ffffff;
+}
+
+.modal-table td:last-child {
+    display: table-cell;
+    text-align: center;
 }
 
 .gsheet-cell {


### PR DESCRIPTION
## Summary
- scope the flex layout applied to the last column so it only affects the main device table
- explicitly restore table-cell layout for modal Select columns to keep headers and checkboxes aligned

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce559e964c8327b542af0466e29558