### PR TITLE
Adjust pagination spacing on Volcano table

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -134,10 +134,11 @@ html, body {
 
 .table-pagination-controls {
         display: none;
-        justify-content: flex-start;
+        justify-content: center;
         align-items: center;
         gap: 0.75rem;
-        margin-top: 0.25rem;
+        margin-top: 0.5rem;
+        margin-bottom: 1.5rem;
         width: 100%;
         flex-wrap: wrap;
 }
@@ -429,7 +430,7 @@ table {
     border-collapse: collapse;
     margin-top: 1rem;
     min-width: 600px;
-	margin-bottom: 6rem; 
+        margin-bottom: 1rem;
 }
 
 th, td {


### PR DESCRIPTION
## Summary
- center the Volcano device pagination controls and adjust vertical margins for better spacing
- reduce the table's bottom margin so pagination sits closer to the data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce57ad23d483278de4b75b3f3ecb03