### PR TITLE
Adjust pagination spacing on manage project pages

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -329,8 +329,8 @@ table {
     width: 100%;
     border-collapse: collapse;
     margin-top: 1rem;
-    min-width: 600px; 
-	margin-bottom: 6rem;
+    min-width: 600px;
+    margin-bottom: 1rem;
 }
 
 th, td {
@@ -400,10 +400,11 @@ td {
 
 .table-pagination-controls {
     display: none;
-    justify-content: flex-start;
+    justify-content: center;
     align-items: center;
     gap: 0.75rem;
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.5rem;
     width: 100%;
     flex-wrap: wrap;
 }

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -328,8 +328,8 @@ table {
     width: 100%;
     border-collapse: collapse;
     margin-top: 1rem;
-    min-width: 600px; 
-	margin-bottom: 6rem;
+    min-width: 600px;
+    margin-bottom: 1rem;
 }
 
 th, td {
@@ -388,10 +388,11 @@ td {
 
 .table-pagination-controls {
     display: none;
-    justify-content: flex-start;
+    justify-content: center;
     align-items: center;
     gap: 0.75rem;
-    margin-top: 0.25rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.5rem;
     width: 100%;
     flex-wrap: wrap;
 }


### PR DESCRIPTION
## Summary
- center the pagination controls on the Fire project devices table and tighten spacing around the table
- apply the same pagination spacing adjustments on the Ltrad project devices table for consistent layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce5a9d0adc8327bb12db8ecf32bc33