### PR TITLE
Align pagination spacing across group views

### DIFF
--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -346,7 +346,48 @@ details[open] summary {
     border-collapse: collapse;
     margin-top: 1rem;
     min-width: 100%;
-	margin-bottom: 6rem;
+    margin-bottom: 1rem;
+}
+
+.table-pagination-controls {
+    display: none;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.5rem;
+    width: 100%;
+    flex-wrap: wrap;
+}
+
+.table-pagination-controls .pagination-button {
+    background-color: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    color: #ffffff;
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.table-pagination-controls .pagination-button:hover {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.8);
+    transform: translateY(-1px);
+}
+
+.table-pagination-controls .pagination-button:focus,
+.table-pagination-controls .pagination-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 2px;
+}
+
+.table-pagination-controls .pagination-button.active {
+    background-color: #e63946;
+    border-color: #e63946;
+    color: #ffffff;
+    outline: none;
 }
 
 .group-panel th,

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -346,7 +346,48 @@ details[open] summary {
     border-collapse: collapse;
     margin-top: 1rem;
     min-width: 100%;
-	margin-bottom: 6rem;
+    margin-bottom: 1rem;
+}
+
+.table-pagination-controls {
+    display: none;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.5rem;
+    width: 100%;
+    flex-wrap: wrap;
+}
+
+.table-pagination-controls .pagination-button {
+    background-color: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    color: #ffffff;
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.table-pagination-controls .pagination-button:hover {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.8);
+    transform: translateY(-1px);
+}
+
+.table-pagination-controls .pagination-button:focus,
+.table-pagination-controls .pagination-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 2px;
+}
+
+.table-pagination-controls .pagination-button.active {
+    background-color: #007bff;
+    border-color: #007bff;
+    color: #ffffff;
+    outline: none;
 }
 
 .group-panel th,

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -346,7 +346,48 @@ details[open] summary {
     border-collapse: collapse;
     margin-top: 1rem;
     min-width: 100%;
-	margin-bottom: 6rem;
+    margin-bottom: 1rem;
+}
+
+.table-pagination-controls {
+    display: none;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+    margin-bottom: 1.5rem;
+    width: 100%;
+    flex-wrap: wrap;
+}
+
+.table-pagination-controls .pagination-button {
+    background-color: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    color: #ffffff;
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.table-pagination-controls .pagination-button:hover {
+    background-color: rgba(255, 255, 255, 0.15);
+    border-color: rgba(255, 255, 255, 0.8);
+    transform: translateY(-1px);
+}
+
+.table-pagination-controls .pagination-button:focus,
+.table-pagination-controls .pagination-button:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.4);
+    outline-offset: 2px;
+}
+
+.table-pagination-controls .pagination-button.active {
+    background-color: #e67e00;
+    border-color: #e67e00;
+    color: #ffffff;
+    outline: none;
 }
 
 .group-panel th,


### PR DESCRIPTION
## Summary
- tighten spacing below group tables in volcano, fire, and ltrad views to prepare for pagination controls
- add hidden pagination control styles consistent with manage project device views so upcoming pagination matches existing design

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce6b729f6483278faefada3df9af0c