### PR TITLE
Show device type in notifications

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -335,10 +335,28 @@ body {
 }
 
 .delete-icon {
-	text-decoration: none;
-	font-size: 1.1em;
-	cursor: pointer;
-	color: #fff; /* oppure un colore più visibile */
-	padding: 2px 6px;
-	transition: color 0.2s ease;
+        text-decoration: none;
+        font-size: 1.1em;
+        cursor: pointer;
+        color: #fff; /* oppure un colore più visibile */
+        padding: 2px 6px;
+        transition: color 0.2s ease;
+}
+
+.notification-box .device-identifiers {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0 0 0.5rem;
+}
+
+.notification-box .device-address {
+    font-weight: 700;
+}
+
+.notification-box .device-type {
+    font-size: 0.85rem;
+    font-style: italic;
+    color: rgba(255, 255, 255, 0.75);
 }

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -348,6 +348,24 @@ body {
 }
 
 .delete-icon:hover {
-	color: #e74c3c;
+        color: #e74c3c;
+}
+
+.notification-box .device-identifiers {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0 0 0.5rem;
+}
+
+.notification-box .device-address {
+    font-weight: 700;
+}
+
+.notification-box .device-type {
+    font-size: 0.85rem;
+    font-style: italic;
+    color: rgba(255, 255, 255, 0.75);
 }
 

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -330,9 +330,27 @@ body {
 }
 
 .delete-icon {
-	text-decoration: none;
-	font-size: 1.2em;
-	cursor: pointer;
-	color: #fff;
-	margin-top: 3px; /* piccolo offset per centrare meglio */
+        text-decoration: none;
+        font-size: 1.2em;
+        cursor: pointer;
+        color: #fff;
+        margin-top: 3px; /* piccolo offset per centrare meglio */
+}
+
+.notification-box .device-identifiers {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0 0 0.5rem;
+}
+
+.notification-box .device-address {
+    font-weight: 700;
+}
+
+.notification-box .device-type {
+    font-size: 0.85rem;
+    font-style: italic;
+    color: rgba(255, 255, 255, 0.75);
 }

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -61,16 +61,26 @@
 
     function renderNotification(n) {
         let box = document.getElementById('notif-' + n.key);
+        const address = n.macAddress ? formatMac(n.macAddress) : formatMac(n.devEui);
+        const details = n.devEui && n.macAddress ? `/${n.devEui}` : '';
+        const identifierText = address ? `${address}${details}` : ((n.devEui && n.devEui.trim()) ? n.devEui : 'Identificativo non disponibile');
+        const typeLabel = n.typeOfDevice && n.typeOfDevice.trim() ? n.typeOfDevice : 'Tipologia non specificata';
         if (!box) {
             box = document.createElement('div');
             box.id = 'notif-' + n.key;
             box.className = 'notification-box';
-            const address = n.macAddress ? formatMac(n.macAddress) : formatMac(n.devEui);
-            const details = n.devEui && n.macAddress ? `/${n.devEui}` : '';
-            box.innerHTML = `<p><strong>${address}${details}</strong></p>
+            box.innerHTML = `<p class="device-identifiers"><strong class="device-address">${identifierText}</strong> <span class="device-type">${typeLabel}</span></p>
                              <p class="time"></p>
                              <button class="btn-add" onclick="addDevice('${n.key}')">Add</button>`;
             container.appendChild(box);
+        }
+        const addressElement = box.querySelector('.device-address');
+        if (addressElement) {
+            addressElement.textContent = identifierText;
+        }
+        const typeElement = box.querySelector('.device-type');
+        if (typeElement) {
+            typeElement.textContent = typeLabel;
         }
         box.dataset.timestamp = Date.parse(n.timestamp);
     }


### PR DESCRIPTION
## Summary
- display the notification device type next to the MAC/devEUI with a readable fallback when data is missing
- add CSS hooks across project themes to layout and style the new device metadata

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce703a69788327819811ddf546f760