### PR TITLE
Revamp device notifications layout and themes

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -343,20 +343,292 @@ body {
         transition: color 0.2s ease;
 }
 
+.notifications-panel {
+    max-width: 860px;
+    width: 100%;
+    margin: 3.5rem auto;
+    padding: 2.5rem 2.25rem;
+    background: linear-gradient(155deg, rgba(38, 11, 17, 0.95), rgba(24, 7, 12, 0.95));
+    border-radius: 22px;
+    box-shadow: 0 28px 60px rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(255, 107, 107, 0.28);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.notifications-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1.2rem;
+}
+
+.notifications-header-text {
+    flex: 1 1 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.notifications-title {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.6vw, 2rem);
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    color: #ffe8e8;
+}
+
+.notifications-description {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: rgba(255, 214, 214, 0.78);
+    max-width: 60ch;
+}
+
+.notifications-header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+}
+
+.notifications-panel .btn-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 107, 107, 0.45);
+    background: rgba(255, 107, 107, 0.16);
+    color: #ffd6d6;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-decoration: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.notifications-panel .btn-back::before {
+    content: '\2190';
+    font-size: 1rem;
+}
+
+.notifications-panel .btn-back:hover {
+    background: rgba(255, 107, 107, 0.26);
+    border-color: rgba(255, 107, 107, 0.6);
+    transform: translateX(-2px);
+}
+
+.notifications-panel .btn-back:focus-visible {
+    outline: 2px solid rgba(255, 138, 138, 0.8);
+    outline-offset: 2px;
+}
+
+.notifications-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.notifications-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.notifications-empty {
+    margin: 0 auto;
+    padding: 1.2rem 1.5rem;
+    border-radius: 16px;
+    border: 1px dashed rgba(255, 107, 107, 0.45);
+    background: rgba(45, 12, 17, 0.85);
+    color: rgba(255, 210, 210, 0.88);
+    text-align: center;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    max-width: 30rem;
+}
+
+.notification-box {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1.5rem;
+    align-items: center;
+    padding: 1.25rem 1.6rem;
+    border-radius: 18px;
+    background: linear-gradient(145deg, rgba(53, 12, 17, 0.96), rgba(38, 9, 14, 0.92));
+    border: 1px solid rgba(255, 107, 107, 0.22);
+    border-left: 4px solid rgba(255, 107, 107, 0.6);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    animation: notification-in 0.35s ease;
+}
+
+.notification-box:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 26px 52px rgba(255, 96, 86, 0.32);
+    border-color: rgba(255, 107, 107, 0.5);
+}
+
+.notification-icon {
+    width: 3.3rem;
+    height: 3.3rem;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    font-size: 1.45rem;
+    background: rgba(255, 107, 107, 0.15);
+    color: #ffd9d9;
+    box-shadow: 0 0 0 1px rgba(255, 107, 107, 0.32) inset;
+}
+
+.notification-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-width: 0;
+}
+
 .notification-box .device-identifiers {
+    margin: 0;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0 0 0.5rem;
+    gap: 0.55rem;
 }
 
 .notification-box .device-address {
     font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: 0.02em;
+    word-break: break-all;
 }
 
 .notification-box .device-type {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(255, 107, 107, 0.22);
+    color: #ffb4b4;
+    font-weight: 600;
+}
+
+.notifications-panel .time {
+    margin: 0;
     font-size: 0.85rem;
-    font-style: italic;
-    color: rgba(255, 255, 255, 0.75);
+    color: rgba(255, 214, 214, 0.78);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    letter-spacing: 0.03em;
+}
+
+.notifications-panel .time::before {
+    content: '\23F0';
+    font-size: 1rem;
+}
+
+.notification-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-end;
+}
+
+.notifications-panel .btn-add {
+    background: linear-gradient(135deg, #ff7b6b, #ff3b30);
+    color: #ffffff;
+    padding: 0.65rem 1.4rem;
+    border-radius: 999px;
+    border: none;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    box-shadow: 0 14px 30px rgba(255, 91, 77, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+}
+
+.notifications-panel .btn-add::before {
+    content: '\2795';
+    font-size: 0.9rem;
+}
+
+.notifications-panel .btn-add:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 40px rgba(255, 91, 77, 0.45);
+    filter: brightness(1.05);
+}
+
+.notifications-panel .btn-add:focus-visible {
+    outline: 2px solid rgba(255, 150, 130, 0.85);
+    outline-offset: 3px;
+}
+
+@media (max-width: 900px) {
+    .notifications-panel {
+        margin: 3rem 1.5rem;
+        padding: 2rem 1.75rem;
+    }
+}
+
+@media (max-width: 720px) {
+    .notification-box {
+        grid-template-columns: auto 1fr;
+    }
+
+    .notification-actions {
+        grid-column: 1 / -1;
+        align-items: stretch;
+    }
+
+    .notifications-panel .btn-add {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 560px) {
+    .notifications-panel {
+        margin: 2.5rem 1rem;
+        padding: 1.75rem 1.25rem;
+    }
+
+    .notification-box {
+        grid-template-columns: 1fr;
+    }
+
+    .notification-icon {
+        width: 3rem;
+        height: 3rem;
+    }
+
+    .notifications-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .notifications-header-actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+}
+
+@keyframes notification-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -351,21 +351,293 @@ body {
         color: #e74c3c;
 }
 
+.notifications-panel {
+    max-width: 860px;
+    width: 100%;
+    margin: 3.5rem auto;
+    padding: 2.5rem 2.25rem;
+    background: linear-gradient(155deg, rgba(10, 25, 47, 0.96), rgba(6, 18, 36, 0.92));
+    border-radius: 22px;
+    box-shadow: 0 28px 60px rgba(2, 12, 27, 0.6);
+    border: 1px solid rgba(77, 163, 255, 0.28);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.notifications-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1.2rem;
+}
+
+.notifications-header-text {
+    flex: 1 1 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.notifications-title {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.6vw, 2rem);
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    color: #e6f2ff;
+}
+
+.notifications-description {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: rgba(214, 232, 255, 0.72);
+    max-width: 60ch;
+}
+
+.notifications-header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+}
+
+.notifications-panel .btn-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid rgba(77, 163, 255, 0.35);
+    background: rgba(77, 163, 255, 0.14);
+    color: #d6e8ff;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-decoration: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.notifications-panel .btn-back::before {
+    content: '\2190';
+    font-size: 1rem;
+}
+
+.notifications-panel .btn-back:hover {
+    background: rgba(77, 163, 255, 0.24);
+    border-color: rgba(77, 163, 255, 0.55);
+    transform: translateX(-2px);
+}
+
+.notifications-panel .btn-back:focus-visible {
+    outline: 2px solid rgba(99, 183, 255, 0.8);
+    outline-offset: 2px;
+}
+
+.notifications-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.notifications-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.notifications-empty {
+    margin: 0 auto;
+    padding: 1.2rem 1.5rem;
+    border-radius: 16px;
+    border: 1px dashed rgba(77, 163, 255, 0.45);
+    background: rgba(9, 22, 38, 0.85);
+    color: rgba(205, 224, 255, 0.85);
+    text-align: center;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    max-width: 30rem;
+}
+
+.notification-box {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1.5rem;
+    align-items: center;
+    padding: 1.25rem 1.6rem;
+    border-radius: 18px;
+    background: linear-gradient(145deg, rgba(12, 32, 56, 0.95), rgba(9, 24, 40, 0.9));
+    border: 1px solid rgba(77, 163, 255, 0.2);
+    border-left: 4px solid rgba(77, 163, 255, 0.5);
+    box-shadow: 0 18px 40px rgba(2, 12, 27, 0.55);
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    animation: notification-in 0.35s ease;
+}
+
+.notification-box:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 26px 50px rgba(31, 111, 235, 0.35);
+    border-color: rgba(77, 163, 255, 0.45);
+}
+
+.notification-icon {
+    width: 3.3rem;
+    height: 3.3rem;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    font-size: 1.45rem;
+    background: rgba(77, 163, 255, 0.18);
+    color: #cfe5ff;
+    box-shadow: 0 0 0 1px rgba(77, 163, 255, 0.35) inset;
+}
+
+.notification-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-width: 0;
+}
+
 .notification-box .device-identifiers {
+    margin: 0;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0 0 0.5rem;
+    gap: 0.55rem;
 }
 
 .notification-box .device-address {
     font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: 0.02em;
+    word-break: break-all;
 }
 
 .notification-box .device-type {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(77, 163, 255, 0.22);
+    color: #8ec8ff;
+    font-weight: 600;
+}
+
+.notifications-panel .time {
+    margin: 0;
     font-size: 0.85rem;
-    font-style: italic;
-    color: rgba(255, 255, 255, 0.75);
+    color: rgba(198, 216, 245, 0.75);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    letter-spacing: 0.03em;
+}
+
+.notifications-panel .time::before {
+    content: '\23F0';
+    font-size: 1rem;
+}
+
+.notification-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-end;
+}
+
+.notifications-panel .btn-add {
+    background: linear-gradient(135deg, #63b7ff, #1f6feb);
+    color: #ffffff;
+    padding: 0.65rem 1.4rem;
+    border-radius: 999px;
+    border: none;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    box-shadow: 0 14px 30px rgba(31, 111, 235, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+}
+
+.notifications-panel .btn-add::before {
+    content: '\2795';
+    font-size: 0.9rem;
+}
+
+.notifications-panel .btn-add:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 40px rgba(31, 111, 235, 0.45);
+    filter: brightness(1.05);
+}
+
+.notifications-panel .btn-add:focus-visible {
+    outline: 2px solid rgba(108, 191, 255, 0.8);
+    outline-offset: 3px;
+}
+
+@media (max-width: 900px) {
+    .notifications-panel {
+        margin: 3rem 1.5rem;
+        padding: 2rem 1.75rem;
+    }
+}
+
+@media (max-width: 720px) {
+    .notification-box {
+        grid-template-columns: auto 1fr;
+    }
+
+    .notification-actions {
+        grid-column: 1 / -1;
+        align-items: stretch;
+    }
+
+    .notifications-panel .btn-add {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 560px) {
+    .notifications-panel {
+        margin: 2.5rem 1rem;
+        padding: 1.75rem 1.25rem;
+    }
+
+    .notification-box {
+        grid-template-columns: 1fr;
+    }
+
+    .notification-icon {
+        width: 3rem;
+        height: 3rem;
+    }
+
+    .notifications-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .notifications-header-actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+}
+
+@keyframes notification-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -337,20 +337,292 @@ body {
         margin-top: 3px; /* piccolo offset per centrare meglio */
 }
 
+.notifications-panel {
+    max-width: 860px;
+    width: 100%;
+    margin: 3.5rem auto;
+    padding: 2.5rem 2.25rem;
+    background: linear-gradient(155deg, rgba(52, 26, 8, 0.96), rgba(32, 14, 4, 0.94));
+    border-radius: 22px;
+    box-shadow: 0 28px 60px rgba(0, 0, 0, 0.6);
+    border: 1px solid rgba(255, 157, 77, 0.32);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.notifications-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 1.2rem;
+}
+
+.notifications-header-text {
+    flex: 1 1 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.notifications-title {
+    margin: 0;
+    font-size: clamp(1.4rem, 2.6vw, 2rem);
+    font-weight: 700;
+    letter-spacing: 0.01em;
+    color: #ffe7d1;
+}
+
+.notifications-description {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    color: rgba(255, 226, 200, 0.78);
+    max-width: 60ch;
+}
+
+.notifications-header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+}
+
+.notifications-panel .btn-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 157, 77, 0.45);
+    background: rgba(255, 157, 77, 0.16);
+    color: #ffe3c6;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    text-decoration: none;
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.notifications-panel .btn-back::before {
+    content: '\2190';
+    font-size: 1rem;
+}
+
+.notifications-panel .btn-back:hover {
+    background: rgba(255, 157, 77, 0.26);
+    border-color: rgba(255, 157, 77, 0.6);
+    transform: translateX(-2px);
+}
+
+.notifications-panel .btn-back:focus-visible {
+    outline: 2px solid rgba(255, 188, 130, 0.85);
+    outline-offset: 2px;
+}
+
+.notifications-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.notifications-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2rem;
+}
+
+.notifications-empty {
+    margin: 0 auto;
+    padding: 1.2rem 1.5rem;
+    border-radius: 16px;
+    border: 1px dashed rgba(255, 157, 77, 0.45);
+    background: rgba(54, 25, 10, 0.85);
+    color: rgba(255, 224, 196, 0.88);
+    text-align: center;
+    font-size: 0.95rem;
+    line-height: 1.6;
+    max-width: 30rem;
+}
+
+.notification-box {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1.5rem;
+    align-items: center;
+    padding: 1.25rem 1.6rem;
+    border-radius: 18px;
+    background: linear-gradient(145deg, rgba(62, 26, 8, 0.96), rgba(44, 18, 6, 0.9));
+    border: 1px solid rgba(255, 157, 77, 0.24);
+    border-left: 4px solid rgba(255, 157, 77, 0.55);
+    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+    animation: notification-in 0.35s ease;
+}
+
+.notification-box:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 26px 52px rgba(255, 157, 77, 0.3);
+    border-color: rgba(255, 157, 77, 0.48);
+}
+
+.notification-icon {
+    width: 3.3rem;
+    height: 3.3rem;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    font-size: 1.45rem;
+    background: rgba(255, 157, 77, 0.18);
+    color: #ffe0c4;
+    box-shadow: 0 0 0 1px rgba(255, 157, 77, 0.35) inset;
+}
+
+.notification-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-width: 0;
+}
+
 .notification-box .device-identifiers {
+    margin: 0;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.5rem;
-    margin: 0 0 0.5rem;
+    gap: 0.55rem;
 }
 
 .notification-box .device-address {
     font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: 0.02em;
+    word-break: break-all;
 }
 
 .notification-box .device-type {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(255, 157, 77, 0.22);
+    color: #ffcba0;
+    font-weight: 600;
+}
+
+.notifications-panel .time {
+    margin: 0;
     font-size: 0.85rem;
-    font-style: italic;
-    color: rgba(255, 255, 255, 0.75);
+    color: rgba(255, 226, 200, 0.8);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    letter-spacing: 0.03em;
+}
+
+.notifications-panel .time::before {
+    content: '\23F0';
+    font-size: 1rem;
+}
+
+.notification-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-end;
+}
+
+.notifications-panel .btn-add {
+    background: linear-gradient(135deg, #ffb168, #ff7a18);
+    color: #ffffff;
+    padding: 0.65rem 1.4rem;
+    border-radius: 999px;
+    border: none;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    box-shadow: 0 14px 30px rgba(255, 138, 62, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+}
+
+.notifications-panel .btn-add::before {
+    content: '\2795';
+    font-size: 0.9rem;
+}
+
+.notifications-panel .btn-add:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 20px 40px rgba(255, 138, 62, 0.45);
+    filter: brightness(1.05);
+}
+
+.notifications-panel .btn-add:focus-visible {
+    outline: 2px solid rgba(255, 188, 130, 0.85);
+    outline-offset: 3px;
+}
+
+@media (max-width: 900px) {
+    .notifications-panel {
+        margin: 3rem 1.5rem;
+        padding: 2rem 1.75rem;
+    }
+}
+
+@media (max-width: 720px) {
+    .notification-box {
+        grid-template-columns: auto 1fr;
+    }
+
+    .notification-actions {
+        grid-column: 1 / -1;
+        align-items: stretch;
+    }
+
+    .notifications-panel .btn-add {
+        width: 100%;
+        justify-content: center;
+    }
+}
+
+@media (max-width: 560px) {
+    .notifications-panel {
+        margin: 2.5rem 1rem;
+        padding: 1.75rem 1.25rem;
+    }
+
+    .notification-box {
+        grid-template-columns: 1fr;
+    }
+
+    .notification-icon {
+        width: 3rem;
+        height: 3rem;
+    }
+
+    .notifications-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .notifications-header-actions {
+        width: 100%;
+        justify-content: flex-start;
+    }
+}
+
+@keyframes notification-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -37,18 +37,38 @@
         </a>
     </div>
 </header>
-<div class="form-container">
-    <div class="back-btn">
-        <a th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="btn-back" title="Back to Devices">⬅ Back</a>
+<section class="notifications-panel" aria-labelledby="notifications-title">
+    <header class="notifications-header">
+        <div class="notifications-header-text">
+            <h2 id="notifications-title" class="notifications-title"
+                th:text="'New device notifications · ' + ${project.name}">New device notifications</h2>
+            <p class="notifications-description">Live feed of devices waiting to be paired with the project.</p>
+        </div>
+        <div class="notifications-header-actions">
+            <a th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="btn-back" title="Back to Devices">Back to devices</a>
+        </div>
+    </header>
+    <div class="notifications-content">
+        <div id="notification-list" class="notifications-list" aria-live="polite" role="list"></div>
+        <p id="notifications-empty" class="notifications-empty">No new devices detected at the moment.</p>
     </div>
-    <div id="notification-list"></div>
-</div>
+</section>
 <script th:inline="javascript">
 /*<![CDATA[*/
     const projectId = [[${project.id}]];
 /*]]>*/
     const container = document.getElementById('notification-list');
+    const emptyState = document.getElementById('notifications-empty');
     const notifications = new Map();
+
+    function updateEmptyState() {
+        if (!emptyState || !container) {
+            return;
+        }
+        emptyState.hidden = container.childElementCount > 0 ? true : false;
+    }
+
+    updateEmptyState();
 
     function formatMac(mac) {
         if (!mac) {
@@ -69,9 +89,16 @@
             box = document.createElement('div');
             box.id = 'notif-' + n.key;
             box.className = 'notification-box';
-            box.innerHTML = `<p class="device-identifiers"><strong class="device-address">${identifierText}</strong> <span class="device-type">${typeLabel}</span></p>
-                             <p class="time"></p>
-                             <button class="btn-add" onclick="addDevice('${n.key}')">Add</button>`;
+            box.setAttribute('role', 'listitem');
+            box.innerHTML = `<div class="notification-icon" aria-hidden="true">📡</div>
+                             <div class="notification-main">
+                                 <p class="device-identifiers"><strong class="device-address">${identifierText}</strong>
+                                     <span class="device-type">${typeLabel}</span></p>
+                                 <p class="time"></p>
+                             </div>
+                             <div class="notification-actions">
+                                 <button type="button" class="btn-add" onclick="addDevice('${n.key}')">Add device</button>
+                             </div>`;
             container.appendChild(box);
         }
         const addressElement = box.querySelector('.device-address');
@@ -82,15 +109,38 @@
         if (typeElement) {
             typeElement.textContent = typeLabel;
         }
-        box.dataset.timestamp = Date.parse(n.timestamp);
+        const parsedTimestamp = Date.parse(n.timestamp);
+        box.dataset.timestamp = isNaN(parsedTimestamp) ? Date.now() : parsedTimestamp;
+        updateEmptyState();
+        updateTimes();
     }
 
     function updateTimes() {
         const now = Date.now();
         document.querySelectorAll('.notification-box').forEach(box => {
-            const ts = parseInt(box.dataset.timestamp);
-            const diff = Math.floor((now - ts) / 1000);
-            box.querySelector('.time').textContent = diff + 's ago';
+            const ts = parseInt(box.dataset.timestamp, 10);
+            const timeElement = box.querySelector('.time');
+            if (!timeElement || Number.isNaN(ts)) {
+                return;
+            }
+            const diffSeconds = Math.max(0, Math.floor((now - ts) / 1000));
+            let label;
+            if (diffSeconds < 5) {
+                label = 'Just now';
+            } else if (diffSeconds < 60) {
+                label = diffSeconds + 's ago';
+            } else if (diffSeconds < 3600) {
+                const minutes = Math.floor(diffSeconds / 60);
+                label = minutes === 1 ? '1 minute ago' : minutes + ' minutes ago';
+            } else {
+                const hours = Math.floor(diffSeconds / 3600);
+                label = hours === 1 ? '1 hour ago' : hours + ' hours ago';
+            }
+            timeElement.textContent = label;
+            const preciseDate = new Date(ts);
+            if (!Number.isNaN(preciseDate.getTime())) {
+                timeElement.setAttribute('title', preciseDate.toLocaleString());
+            }
         });
     }
     setInterval(updateTimes, 1000);


### PR DESCRIPTION
## Summary
- wrap the device notifications view in a semantic panel with header actions, descriptive text, and an empty-state message
- refresh the SSE renderer to build richer notification cards, manage the empty state, and show friendlier relative timestamps
- apply theme-specific styling for the notifications panel, cards, and controls across the L-TRAD, FIRE, and VOLCANO stylesheets

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to download Maven distribution in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce723f0328832787a9b8c1c98dfb98