### PR TITLE
Lighten device form backgrounds for themed pages

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -160,7 +160,7 @@ body {
     width: 100%;
     max-width: 600px;
     margin: 2rem auto;
-    background-color: #324a5f;
+    background-color: #3a5870;
     padding: 2rem;
     border-radius: 10px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.3);

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -164,7 +164,7 @@ body {
     width: 100%;
     max-width: 600px;
     margin: 2rem auto;
-    background-color: #0d1b2a;
+    background-color: #1d3557;
     padding: 2rem;
     border-radius: 10px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.3);

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -155,7 +155,7 @@ body {
     width: 100%;
     max-width: 600px;
     margin: 2rem auto;
-    background-color: #324a5f;
+    background-color: #3a5366;
     padding: 2rem;
     border-radius: 10px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.3);


### PR DESCRIPTION
## Summary
- lightened the L-TRAD device form background to a brighter navy while preserving contrast for controls
- refreshed the Fire and Volcano form backgrounds with lighter slate tones that complement their accent colors

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ce76ce98548327a77e1fcc7870a800