### PR TITLE
Adjust new device forms background color

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -2,7 +2,7 @@ body {
     margin: 0;
     padding: 0;
     font-family: 'Roboto', sans-serif;
-    background-color: #1B263B;
+    background-color: #0d1b2a;
     color: white;
 }
 .navbar {
@@ -348,7 +348,7 @@ body {
     width: 100%;
     margin: 3.5rem auto;
     padding: 2.5rem 2.25rem;
-    background: linear-gradient(155deg, rgba(38, 11, 17, 0.95), rgba(24, 7, 12, 0.95));
+    background-color: #0d1b2a;
     border-radius: 22px;
     box-shadow: 0 28px 60px rgba(0, 0, 0, 0.6);
     border: 1px solid rgba(255, 107, 107, 0.28);

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -2,7 +2,7 @@ body {
     margin: 0;
     padding: 0;
     font-family: 'Roboto', sans-serif;
-    background-color: #1B263B;
+    background-color: #0d1b2a;
     color: white;
 }
 
@@ -356,7 +356,7 @@ body {
     width: 100%;
     margin: 3.5rem auto;
     padding: 2.5rem 2.25rem;
-    background: linear-gradient(155deg, rgba(10, 25, 47, 0.96), rgba(6, 18, 36, 0.92));
+    background-color: #0d1b2a;
     border-radius: 22px;
     box-shadow: 0 28px 60px rgba(2, 12, 27, 0.6);
     border: 1px solid rgba(77, 163, 255, 0.28);

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -2,7 +2,7 @@ body {
     margin: 0;
     padding: 0;
     font-family: 'Roboto', sans-serif;
-    background-color: #1B263B;
+    background-color: #0d1b2a;
     color: white;
 }
 
@@ -342,7 +342,7 @@ body {
     width: 100%;
     margin: 3.5rem auto;
     padding: 2.5rem 2.25rem;
-    background: linear-gradient(155deg, rgba(52, 26, 8, 0.96), rgba(32, 14, 4, 0.94));
+    background-color: #0d1b2a;
     border-radius: 22px;
     box-shadow: 0 28px 60px rgba(0, 0, 0, 0.6);
     border: 1px solid rgba(255, 157, 77, 0.32);


### PR DESCRIPTION
## Summary
- update the body background color for the new device forms (Ltrad, Fire, Volcano) to use the unified #0d1b2a shade
- replace the gradient backgrounds on the notifications panel with the same solid color while retaining layout styling

## Testing
- Manual verification using a temporary local static server and Playwright screenshots

------
https://chatgpt.com/codex/tasks/task_e_68ce7ba3486c83278d60f137ec9ffbe1