### PR TITLE
Adjust notification gradients for new device forms

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -456,10 +456,10 @@ body {
     align-items: center;
     padding: 1.25rem 1.6rem;
     border-radius: 18px;
-    background: linear-gradient(145deg, rgba(53, 12, 17, 0.96), rgba(38, 9, 14, 0.92));
-    border: 1px solid rgba(255, 107, 107, 0.22);
-    border-left: 4px solid rgba(255, 107, 107, 0.6);
-    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+    background: linear-gradient(145deg, rgba(218, 82, 69, 0.96), rgba(187, 58, 52, 0.92));
+    border: 1px solid rgba(255, 150, 130, 0.25);
+    border-left: 4px solid rgba(255, 150, 130, 0.55);
+    box-shadow: 0 16px 36px rgba(120, 32, 32, 0.4);
     position: relative;
     overflow: hidden;
     transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
@@ -468,8 +468,8 @@ body {
 
 .notification-box:hover {
     transform: translateY(-4px);
-    box-shadow: 0 26px 52px rgba(255, 96, 86, 0.32);
-    border-color: rgba(255, 107, 107, 0.5);
+    box-shadow: 0 24px 48px rgba(255, 142, 120, 0.34);
+    border-color: rgba(255, 150, 130, 0.5);
 }
 
 .notification-icon {
@@ -479,9 +479,9 @@ body {
     display: grid;
     place-items: center;
     font-size: 1.45rem;
-    background: rgba(255, 107, 107, 0.15);
-    color: #ffd9d9;
-    box-shadow: 0 0 0 1px rgba(255, 107, 107, 0.32) inset;
+    background: rgba(255, 150, 130, 0.2);
+    color: #fff1ee;
+    box-shadow: 0 0 0 1px rgba(255, 150, 130, 0.32) inset;
 }
 
 .notification-main {
@@ -512,15 +512,15 @@ body {
     letter-spacing: 0.1em;
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
-    background: rgba(255, 107, 107, 0.22);
-    color: #ffb4b4;
+    background: rgba(255, 150, 130, 0.28);
+    color: #fff5f3;
     font-weight: 600;
 }
 
 .notifications-panel .time {
     margin: 0;
     font-size: 0.85rem;
-    color: rgba(255, 214, 214, 0.78);
+    color: rgba(255, 235, 232, 0.86);
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -457,6 +457,7 @@ body {
     max-width: 30rem;
 }
 
+
 .notification-box {
     display: grid;
     grid-template-columns: auto 1fr auto;
@@ -464,10 +465,10 @@ body {
     align-items: center;
     padding: 1.25rem 1.6rem;
     border-radius: 18px;
-    background: linear-gradient(145deg, rgba(12, 32, 56, 0.95), rgba(9, 24, 40, 0.9));
-    border: 1px solid rgba(77, 163, 255, 0.2);
-    border-left: 4px solid rgba(77, 163, 255, 0.5);
-    box-shadow: 0 18px 40px rgba(2, 12, 27, 0.55);
+    background: linear-gradient(145deg, rgba(78, 116, 158, 0.96), rgba(54, 85, 125, 0.92));
+    border: 1px solid rgba(142, 196, 255, 0.24);
+    border-left: 4px solid rgba(142, 196, 255, 0.45);
+    box-shadow: 0 16px 36px rgba(16, 32, 58, 0.4);
     position: relative;
     overflow: hidden;
     transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
@@ -476,8 +477,8 @@ body {
 
 .notification-box:hover {
     transform: translateY(-4px);
-    box-shadow: 0 26px 50px rgba(31, 111, 235, 0.35);
-    border-color: rgba(77, 163, 255, 0.45);
+    box-shadow: 0 24px 48px rgba(73, 137, 210, 0.32);
+    border-color: rgba(142, 196, 255, 0.42);
 }
 
 .notification-icon {
@@ -487,9 +488,9 @@ body {
     display: grid;
     place-items: center;
     font-size: 1.45rem;
-    background: rgba(77, 163, 255, 0.18);
-    color: #cfe5ff;
-    box-shadow: 0 0 0 1px rgba(77, 163, 255, 0.35) inset;
+    background: rgba(142, 196, 255, 0.22);
+    color: #f1f7ff;
+    box-shadow: 0 0 0 1px rgba(142, 196, 255, 0.35) inset;
 }
 
 .notification-main {
@@ -520,15 +521,15 @@ body {
     letter-spacing: 0.1em;
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
-    background: rgba(77, 163, 255, 0.22);
-    color: #8ec8ff;
+    background: rgba(142, 196, 255, 0.28);
+    color: #f4faff;
     font-weight: 600;
 }
 
 .notifications-panel .time {
     margin: 0;
     font-size: 0.85rem;
-    color: rgba(198, 216, 245, 0.75);
+    color: rgba(228, 238, 255, 0.86);
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -450,10 +450,10 @@ body {
     align-items: center;
     padding: 1.25rem 1.6rem;
     border-radius: 18px;
-    background: linear-gradient(145deg, rgba(62, 26, 8, 0.96), rgba(44, 18, 6, 0.9));
-    border: 1px solid rgba(255, 157, 77, 0.24);
-    border-left: 4px solid rgba(255, 157, 77, 0.55);
-    box-shadow: 0 18px 40px rgba(0, 0, 0, 0.55);
+    background: linear-gradient(145deg, rgba(190, 94, 38, 0.96), rgba(154, 72, 26, 0.9));
+    border: 1px solid rgba(255, 189, 120, 0.26);
+    border-left: 4px solid rgba(255, 189, 120, 0.58);
+    box-shadow: 0 16px 36px rgba(92, 39, 16, 0.42);
     position: relative;
     overflow: hidden;
     transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
@@ -462,8 +462,8 @@ body {
 
 .notification-box:hover {
     transform: translateY(-4px);
-    box-shadow: 0 26px 52px rgba(255, 157, 77, 0.3);
-    border-color: rgba(255, 157, 77, 0.48);
+    box-shadow: 0 24px 48px rgba(255, 189, 120, 0.32);
+    border-color: rgba(255, 189, 120, 0.5);
 }
 
 .notification-icon {
@@ -473,9 +473,9 @@ body {
     display: grid;
     place-items: center;
     font-size: 1.45rem;
-    background: rgba(255, 157, 77, 0.18);
-    color: #ffe0c4;
-    box-shadow: 0 0 0 1px rgba(255, 157, 77, 0.35) inset;
+    background: rgba(255, 189, 120, 0.22);
+    color: #fff2e2;
+    box-shadow: 0 0 0 1px rgba(255, 189, 120, 0.35) inset;
 }
 
 .notification-main {
@@ -506,15 +506,15 @@ body {
     letter-spacing: 0.1em;
     padding: 0.25rem 0.75rem;
     border-radius: 999px;
-    background: rgba(255, 157, 77, 0.22);
-    color: #ffcba0;
+    background: rgba(255, 189, 120, 0.26);
+    color: #fff6e8;
     font-weight: 600;
 }
 
 .notifications-panel .time {
     margin: 0;
     font-size: 0.85rem;
-    color: rgba(255, 226, 200, 0.8);
+    color: rgba(255, 236, 218, 0.86);
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;


### PR DESCRIPTION
## Summary
- refresh the Ltrad new device notification card with a lighter blue-gray gradient and matching accent colors for icons, tags, and timestamps
- update the Fire variant to a brighter red-orange palette while keeping supporting text legible
- retune the Volcano styling with lighter burnt tones and adjusted highlights for contrast

## Testing
- not run (css changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ce7ba441ec8327a6a8b7077b09afda