### PR TITLE
Adjust notification panel themes

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -348,7 +348,7 @@ body {
     width: 100%;
     margin: 3.5rem auto;
     padding: 2.5rem 2.25rem;
-    background-color: #0d1b2a;
+    background: linear-gradient(135deg, #4c121c 0%, #8a2d3c 100%);
     border-radius: 22px;
     box-shadow: 0 28px 60px rgba(0, 0, 0, 0.6);
     border: 1px solid rgba(255, 107, 107, 0.28);

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -356,7 +356,7 @@ body {
     width: 100%;
     margin: 3.5rem auto;
     padding: 2.5rem 2.25rem;
-    background-color: #0d1b2a;
+    background: linear-gradient(135deg, #1a2f4a 0%, #254f7a 100%);
     border-radius: 22px;
     box-shadow: 0 28px 60px rgba(2, 12, 27, 0.6);
     border: 1px solid rgba(77, 163, 255, 0.28);

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -342,7 +342,7 @@ body {
     width: 100%;
     margin: 3.5rem auto;
     padding: 2.5rem 2.25rem;
-    background-color: #0d1b2a;
+    background: linear-gradient(135deg, #3d2012 0%, #c9662a 100%);
     border-radius: 22px;
     box-shadow: 0 28px 60px rgba(0, 0, 0, 0.6);
     border: 1px solid rgba(255, 157, 77, 0.32);


### PR DESCRIPTION
## Summary
- refresh the Ltrad notification panel background with a lighter blue gradient that matches the theme accents
- brighten the Fire notification panel using a softer bordeaux gradient while maintaining contrast for text and buttons
- enhance the Volcano notification panel with a warmer copper gradient that keeps existing shadows and highlights readable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ce7f4fc18c8327b9aa6b45560f1212