### PR TITLE
Use solid brand backgrounds for notification panels

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -456,7 +456,7 @@ body {
     align-items: center;
     padding: 1.25rem 1.6rem;
     border-radius: 18px;
-    background: linear-gradient(145deg, rgba(218, 82, 69, 0.96), rgba(187, 58, 52, 0.92));
+    background: #b30000;
     border: 1px solid rgba(255, 150, 130, 0.25);
     border-left: 4px solid rgba(255, 150, 130, 0.55);
     box-shadow: 0 16px 36px rgba(120, 32, 32, 0.4);

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -465,7 +465,7 @@ body {
     align-items: center;
     padding: 1.25rem 1.6rem;
     border-radius: 18px;
-    background: linear-gradient(145deg, rgba(78, 116, 158, 0.96), rgba(54, 85, 125, 0.92));
+    background: #0069d9;
     border: 1px solid rgba(142, 196, 255, 0.24);
     border-left: 4px solid rgba(142, 196, 255, 0.45);
     box-shadow: 0 16px 36px rgba(16, 32, 58, 0.4);

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -450,7 +450,7 @@ body {
     align-items: center;
     padding: 1.25rem 1.6rem;
     border-radius: 18px;
-    background: linear-gradient(145deg, rgba(190, 94, 38, 0.96), rgba(154, 72, 26, 0.9));
+    background: #cc6f00;
     border: 1px solid rgba(255, 189, 120, 0.26);
     border-left: 4px solid rgba(255, 189, 120, 0.58);
     box-shadow: 0 16px 36px rgba(92, 39, 16, 0.42);


### PR DESCRIPTION
## Summary
- replace notification box gradients in the ltrad, fire, and volcano forms with solid shades that are slightly darker than their respective navbar colors
- preserved existing borders, shadows, and hover treatments so contrast for text and badges remains intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce82cf2e908327b280a6752ca6e7a7