### PR TITLE
Replace btn-add gradients with solid colors

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -540,7 +540,7 @@ body {
 }
 
 .notifications-panel .btn-add {
-    background: linear-gradient(135deg, #ff7b6b, #ff3b30);
+    background-color: #cc0000;
     color: #ffffff;
     padding: 0.65rem 1.4rem;
     border-radius: 999px;
@@ -552,8 +552,8 @@ body {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    box-shadow: 0 14px 30px rgba(255, 91, 77, 0.35);
-    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+    box-shadow: 0 14px 30px rgba(204, 0, 0, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
 }
 
 .notifications-panel .btn-add::before {
@@ -563,8 +563,8 @@ body {
 
 .notifications-panel .btn-add:hover {
     transform: translateY(-2px);
-    box-shadow: 0 20px 40px rgba(255, 91, 77, 0.45);
-    filter: brightness(1.05);
+    box-shadow: 0 20px 40px rgba(204, 0, 0, 0.45);
+    background-color: #a30000;
 }
 
 .notifications-panel .btn-add:focus-visible {

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -549,7 +549,7 @@ body {
 }
 
 .notifications-panel .btn-add {
-    background: linear-gradient(135deg, #63b7ff, #1f6feb);
+    background-color: #007bff;
     color: #ffffff;
     padding: 0.65rem 1.4rem;
     border-radius: 999px;
@@ -561,8 +561,8 @@ body {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    box-shadow: 0 14px 30px rgba(31, 111, 235, 0.35);
-    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+    box-shadow: 0 14px 30px rgba(0, 123, 255, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
 }
 
 .notifications-panel .btn-add::before {
@@ -572,8 +572,8 @@ body {
 
 .notifications-panel .btn-add:hover {
     transform: translateY(-2px);
-    box-shadow: 0 20px 40px rgba(31, 111, 235, 0.45);
-    filter: brightness(1.05);
+    box-shadow: 0 20px 40px rgba(0, 123, 255, 0.45);
+    background-color: #0069d9;
 }
 
 .notifications-panel .btn-add:focus-visible {

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -534,7 +534,7 @@ body {
 }
 
 .notifications-panel .btn-add {
-    background: linear-gradient(135deg, #ffb168, #ff7a18);
+    background-color: #e67e00;
     color: #ffffff;
     padding: 0.65rem 1.4rem;
     border-radius: 999px;
@@ -546,8 +546,8 @@ body {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    box-shadow: 0 14px 30px rgba(255, 138, 62, 0.35);
-    transition: transform 0.25s ease, box-shadow 0.25s ease, filter 0.25s ease;
+    box-shadow: 0 14px 30px rgba(230, 126, 0, 0.35);
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
 }
 
 .notifications-panel .btn-add::before {
@@ -557,8 +557,8 @@ body {
 
 .notifications-panel .btn-add:hover {
     transform: translateY(-2px);
-    box-shadow: 0 20px 40px rgba(255, 138, 62, 0.45);
-    filter: brightness(1.05);
+    box-shadow: 0 20px 40px rgba(230, 126, 0, 0.45);
+    background-color: #cc6e00;
 }
 
 .notifications-panel .btn-add:focus-visible {


### PR DESCRIPTION
## Summary
- replace the add button gradient in the Ltrad notification panel with a solid blue background
- update the Fire add button to use a consistent solid red fill and hover state
- align the Volcano add button styling with a flat orange background and matching hover effect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce854d35008327a327a201a6c5aa2d