### PR TITLE
Add personal area management and update nav menus

### DIFF
--- a/src/main/java/it/sensorplatform/controller/UserProfileController.java
+++ b/src/main/java/it/sensorplatform/controller/UserProfileController.java
@@ -1,0 +1,236 @@
+package it.sensorplatform.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import it.sensorplatform.dto.CredentialsUpdateDTO;
+import it.sensorplatform.model.Credentials;
+import it.sensorplatform.model.Project;
+import it.sensorplatform.model.User;
+import it.sensorplatform.service.CredentialsService;
+import it.sensorplatform.service.ProjectService;
+import it.sensorplatform.service.UserService;
+import jakarta.validation.Valid;
+
+/**
+ * Controller responsible for handling the personal area where authenticated
+ * users can review and update their personal information and credentials.
+ */
+@Controller
+public class UserProfileController {
+
+    private static final String PERSONAL_AREA_VIEW = "personalArea";
+
+    @Autowired
+    private CredentialsService credentialsService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private ProjectService projectService;
+
+    @Autowired
+    private MessageSource messageSource;
+
+    @GetMapping("/personal-area")
+    public String personalArea(@RequestParam(value = "projectId", required = false) Long projectFilterId, Model model) {
+        Credentials credentials = getCurrentCredentials();
+        if (credentials == null) {
+            return "redirect:/login";
+        }
+
+        ensureUserForm(model, credentials);
+        ensureCredentialsDto(model, credentials);
+        populateCommon(model, credentials, projectFilterId);
+        return PERSONAL_AREA_VIEW;
+    }
+
+    @PostMapping("/personal-area/update-user")
+    public String updateUser(@Valid @ModelAttribute("userForm") User userForm, BindingResult bindingResult,
+            @RequestParam(value = "projectId", required = false) Long projectFilterId, RedirectAttributes redirectAttributes,
+            Model model) {
+
+        Credentials credentials = getCurrentCredentials();
+        if (credentials == null) {
+            return "redirect:/login";
+        }
+
+        if (bindingResult.hasErrors()) {
+            ensureCredentialsDto(model, credentials);
+            populateCommon(model, credentials, projectFilterId);
+            return PERSONAL_AREA_VIEW;
+        }
+
+        User existingUser = credentials.getUser();
+        if (existingUser != null && existingUser.getId() != null) {
+            userForm.setId(existingUser.getId());
+        }
+
+        User savedUser = userService.saveUser(userForm);
+        credentials.setUser(savedUser);
+        credentialsService.save(credentials);
+
+        String successMessage = resolveMessage("profile.update.success");
+        redirectAttributes.addFlashAttribute("userSuccessMessage", successMessage);
+        if (projectFilterId != null) {
+            redirectAttributes.addAttribute("projectId", projectFilterId);
+        }
+        return "redirect:/personal-area";
+    }
+
+    @PostMapping("/personal-area/update-credentials")
+    public String updateCredentials(@Valid @ModelAttribute("credentialsDto") CredentialsUpdateDTO credentialsDto,
+            BindingResult bindingResult, @RequestParam(value = "projectId", required = false) Long projectFilterId,
+            RedirectAttributes redirectAttributes, Model model) {
+
+        Credentials credentials = getCurrentCredentials();
+        if (credentials == null) {
+            return "redirect:/login";
+        }
+
+        validatePasswords(credentialsDto, bindingResult);
+
+        if (!bindingResult.hasErrors()) {
+            String candidatePersistedUsername = buildPersistedUsername(credentials, credentialsDto.getVisibleUsername());
+            credentialsService.findByUsernameAndIdNot(candidatePersistedUsername, credentials.getId())
+                    .ifPresent(existing -> bindingResult.rejectValue("visibleUsername",
+                            "credentials.visibleUsername.duplicate"));
+        }
+
+        if (bindingResult.hasErrors()) {
+            ensureUserForm(model, credentials);
+            populateCommon(model, credentials, projectFilterId);
+            return PERSONAL_AREA_VIEW;
+        }
+
+        credentialsService.updateCredentials(credentials, credentialsDto.getVisibleUsername(),
+                credentialsDto.getNewPassword());
+
+        String successMessage = resolveMessage("profile.credentials.success");
+        redirectAttributes.addFlashAttribute("credentialsSuccessMessage", successMessage);
+        if (projectFilterId != null) {
+            redirectAttributes.addAttribute("projectId", projectFilterId);
+        }
+        return "redirect:/personal-area";
+    }
+
+    private void populateCommon(Model model, Credentials credentials, Long projectFilterId) {
+        model.addAttribute("user", credentials);
+        boolean isSuperadmin = Credentials.SUPERADMIN_ROLE.equals(credentials.getRole());
+        Long currentProjectId = isSuperadmin ? null : credentials.getProjectId();
+        model.addAttribute("currentProjectId", currentProjectId);
+        model.addAttribute("isSuperadmin", isSuperadmin);
+        model.addAttribute("selectedProjectId", projectFilterId);
+
+        if (isSuperadmin) {
+            List<Project> projects = new ArrayList<>();
+            projectService.getAllProjects().forEach(projects::add);
+            model.addAttribute("projects", projects);
+            if (projectFilterId != null) {
+                model.addAttribute("projectUsers", credentialsService.findByProjectIdAndUserIsNotNull(projectFilterId));
+            } else {
+                model.addAttribute("projectUsers", new ArrayList<Credentials>());
+            }
+        }
+    }
+
+    private void ensureUserForm(Model model, Credentials credentials) {
+        if (!model.containsAttribute("userForm")) {
+            User user = credentials.getUser();
+            if (user == null) {
+                user = new User();
+            }
+            model.addAttribute("userForm", user);
+        }
+    }
+
+    private void ensureCredentialsDto(Model model, Credentials credentials) {
+        if (!model.containsAttribute("credentialsDto")) {
+            CredentialsUpdateDTO dto = new CredentialsUpdateDTO();
+            String visibleUsername = credentials.getVisibleUsername();
+            if (!StringUtils.hasText(visibleUsername)) {
+                visibleUsername = extractVisibleUsername(credentials.getUsername());
+            }
+            dto.setVisibleUsername(visibleUsername);
+            model.addAttribute("credentialsDto", dto);
+        }
+    }
+
+    private void validatePasswords(CredentialsUpdateDTO credentialsDto, BindingResult bindingResult) {
+        String newPassword = credentialsDto.getNewPassword();
+        String confirmPassword = credentialsDto.getConfirmPassword();
+
+        boolean hasNewPassword = StringUtils.hasText(newPassword);
+        boolean hasConfirmPassword = StringUtils.hasText(confirmPassword);
+
+        if (hasNewPassword || hasConfirmPassword) {
+            if (!hasNewPassword || !hasConfirmPassword || !newPassword.equals(confirmPassword)) {
+                bindingResult.rejectValue("confirmPassword", "credentials.password.mismatch");
+            }
+        }
+    }
+
+    private Credentials getCurrentCredentials() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        if (!(principal instanceof UserDetails userDetails)) {
+            return null;
+        }
+        return credentialsService.getCredentials(userDetails.getUsername());
+    }
+
+    private String buildPersistedUsername(Credentials credentials, String visibleUsername) {
+        if (!StringUtils.hasText(visibleUsername)) {
+            return visibleUsername;
+        }
+
+        String suffix = Credentials.SUPERADMIN_ROLE;
+        if (!Credentials.SUPERADMIN_ROLE.equals(credentials.getRole())) {
+            Long projectId = credentials.getProjectId();
+            if (projectId != null) {
+                Project project = projectService.getProjectById(projectId);
+                if (project != null && StringUtils.hasText(project.getName())) {
+                    suffix = project.getName();
+                } else {
+                    suffix = "";
+                }
+            } else {
+                suffix = "";
+            }
+        }
+
+        return StringUtils.hasText(suffix) ? visibleUsername + "|" + suffix : visibleUsername;
+    }
+
+    private String extractVisibleUsername(String persistedUsername) {
+        if (!StringUtils.hasText(persistedUsername)) {
+            return persistedUsername;
+        }
+        int separatorIndex = persistedUsername.indexOf('|');
+        if (separatorIndex >= 0) {
+            return persistedUsername.substring(0, separatorIndex);
+        }
+        return persistedUsername;
+    }
+
+    private String resolveMessage(String code) {
+        Locale locale = LocaleContextHolder.getLocale();
+        return messageSource.getMessage(code, null, locale);
+    }
+}

--- a/src/main/java/it/sensorplatform/dto/CredentialsUpdateDTO.java
+++ b/src/main/java/it/sensorplatform/dto/CredentialsUpdateDTO.java
@@ -1,0 +1,41 @@
+package it.sensorplatform.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Data transfer object used to update credentials information from the personal
+ * area page.
+ */
+public class CredentialsUpdateDTO {
+
+    @NotBlank
+    private String visibleUsername;
+
+    private String newPassword;
+
+    private String confirmPassword;
+
+    public String getVisibleUsername() {
+        return visibleUsername;
+    }
+
+    public void setVisibleUsername(String visibleUsername) {
+        this.visibleUsername = visibleUsername;
+    }
+
+    public String getNewPassword() {
+        return newPassword;
+    }
+
+    public void setNewPassword(String newPassword) {
+        this.newPassword = newPassword;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+}

--- a/src/main/java/it/sensorplatform/repository/CredentialsRepository.java
+++ b/src/main/java/it/sensorplatform/repository/CredentialsRepository.java
@@ -10,17 +10,21 @@ import it.sensorplatform.model.Credentials;
 
 @Repository
 public interface CredentialsRepository extends CrudRepository<Credentials, Long>{
-	public Optional<Credentials> findByUsername(String username);
+        public Optional<Credentials> findByUsername(String username);
 
-	public Optional<Credentials> findByUsernameAndProjectId(String username, Long projectId);
+        public Optional<Credentials> findByUsernameAndProjectId(String username, Long projectId);
 
-	public boolean existsByUsername(String username);
+        public boolean existsByUsername(String username);
 
-	public boolean existsByEmailAndProjectId(String email, Long projectId);
-	
+        public boolean existsByEmailAndProjectId(String email, Long projectId);
+
     public List<Credentials> findByRoleAndUserIsNull(String role);
-    
+
     public Optional<Credentials>  findById(Long id);
-    
+
     List<Credentials> findByRoleAndProjectId(String role, Long projectId);
+
+    Optional<Credentials> findByUsernameAndIdNot(String username, Long id);
+
+    List<Credentials> findByProjectIdAndUserIsNotNull(Long projectId);
 }

--- a/src/main/java/it/sensorplatform/service/CredentialsService.java
+++ b/src/main/java/it/sensorplatform/service/CredentialsService.java
@@ -1,14 +1,16 @@
 package it.sensorplatform.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import it.sensorplatform.repository.CredentialsRepository;
-import jakarta.transaction.Transactional;
 import it.sensorplatform.model.Credentials;
 import it.sensorplatform.model.Project;
 
@@ -24,25 +26,25 @@ public class CredentialsService {
 	@Autowired
 	protected ProjectService projectService;
 
-	@Transactional
-	public Credentials getCredentials(Long id) {
-		Optional<Credentials> result = this.credentialsRepository.findById(id);
-		return result.orElse(null);
-	}
+        @Transactional
+        public Credentials getCredentials(Long id) {
+                Optional<Credentials> result = this.credentialsRepository.findById(id);
+                return result.orElse(null);
+        }
 
-	@Transactional
+        @Transactional
 	public Credentials getCredentials(String username) {
 		Optional<Credentials> result = this.credentialsRepository.findByUsername(username);
 		return result.orElse(null);
 	}
 	
-	@Transactional
-	public Credentials getCredentialsByUsernameAndProjectId(String username, Long projectId) {
-	    return credentialsRepository.findByUsernameAndProjectId(username, projectId).get();
-	}
+        @Transactional
+        public Credentials getCredentialsByUsernameAndProjectId(String username, Long projectId) {
+            return credentialsRepository.findByUsernameAndProjectId(username, projectId).get();
+        }
 
 
-	@Transactional
+        @Transactional
 	public Credentials saveCredentials(Credentials credentials) {
 		credentials.setPassword(this.passwordEncoder.encode(credentials.getPassword()));
 		return this.credentialsRepository.save(credentials);
@@ -74,13 +76,63 @@ public class CredentialsService {
 	    return credentialsRepository.findByRoleAndUserIsNull(role);
 	}*/
 	
-	public List<Credentials> findByRoleAndProjectId(String role, Long projectId) {
-	    return credentialsRepository.findByRoleAndProjectId(role, projectId);
-	}
-	
-	public Credentials findById(Long id) {
-		return credentialsRepository.findById(id).get();
-	}
+        public List<Credentials> findByRoleAndProjectId(String role, Long projectId) {
+            return credentialsRepository.findByRoleAndProjectId(role, projectId);
+        }
+
+        public Credentials findById(Long id) {
+                return credentialsRepository.findById(id).get();
+        }
+
+        @Transactional
+        public Credentials save(Credentials credentials) {
+                return credentialsRepository.save(credentials);
+        }
+
+        @Transactional
+        public Optional<Credentials> findByUsernameAndIdNot(String username, Long id) {
+                return credentialsRepository.findByUsernameAndIdNot(username, id);
+        }
+
+        @Transactional
+        public List<Credentials> findByProjectIdAndUserIsNotNull(Long projectId) {
+                if (projectId == null) {
+                        return new ArrayList<>();
+                }
+                return credentialsRepository.findByProjectIdAndUserIsNotNull(projectId);
+        }
+
+        @Transactional
+        public Credentials updateCredentials(Credentials credentials, String newVisibleUsername, String rawPassword) {
+                credentials.setVisibleUsername(newVisibleUsername);
+
+                String suffix = Credentials.SUPERADMIN_ROLE;
+                if (!Credentials.SUPERADMIN_ROLE.equals(credentials.getRole())) {
+                        Long projectId = credentials.getProjectId();
+                        if (projectId != null) {
+                                Project project = projectService.getProjectById(projectId);
+                                if (project != null && StringUtils.hasText(project.getName())) {
+                                        suffix = project.getName();
+                                } else {
+                                        suffix = "";
+                                }
+                        } else {
+                                suffix = "";
+                        }
+                }
+
+                String persistedUsername = newVisibleUsername;
+                if (StringUtils.hasText(suffix)) {
+                        persistedUsername = newVisibleUsername + "|" + suffix;
+                }
+                credentials.setUsername(persistedUsername);
+
+                if (StringUtils.hasText(rawPassword)) {
+                        credentials.setPassword(this.passwordEncoder.encode(rawPassword));
+                }
+
+                return credentialsRepository.save(credentials);
+        }
 
 
 }

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -1,3 +1,7 @@
 NotNull = This field is required.
 NotBlank = This field is required.
 Past = Invalid date.
+profile.update.success=Profile information updated successfully.
+profile.credentials.success=Credentials updated successfully.
+credentials.visibleUsername.duplicate=Visible username already in use.
+credentials.password.mismatch=The passwords do not match.

--- a/src/main/resources/static/css/adminHome.css
+++ b/src/main/resources/static/css/adminHome.css
@@ -47,14 +47,85 @@ body {
 }
 
 .nav-right {
-	margin-right: 3em;
+        margin-right: 3em;
+}
+
+.auth-user {
+        display: flex;
+        align-items: center;
+}
+
+.dropdown {
+        position: relative;
+        display: inline-block;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: #fff;
+        font-size: 1rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        transition: transform 0.3s;
+}
+
+.dropdown-toggle:hover .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 2.4rem;
+        background-color: #0D1B2A;
+        border: 1px solid rgba(0, 191, 255, 0.4);
+        border-radius: 8px;
+        padding: 0.5rem;
+        min-width: 150px;
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+        z-index: 5;
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-link,
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: #fff;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        text-decoration: none;
+        display: block;
+        border-radius: 4px;
+        cursor: pointer;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(0, 191, 255, 0.15);
 }
 
 .nav-button {
-	background: transparent;
-	border: 2px solid #fff;
-	color: #fff;
-	padding: 0.5rem 1rem;
+        background: transparent;
+        border: 2px solid #fff;
+        color: #fff;
+        padding: 0.5rem 1rem;
 	border-radius: 20px;
 	text-decoration: none;
 	font-size: 0.95rem;

--- a/src/main/resources/static/css/deviceDashboard.css
+++ b/src/main/resources/static/css/deviceDashboard.css
@@ -133,6 +133,9 @@
         display: block;
 }
 
+.dropdown-link,
+
+
 .dropdown-logout {
         background: none;
         border: none;
@@ -144,6 +147,9 @@
         padding: 0.4rem 0;
         transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
         background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -120,6 +120,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -131,6 +132,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/fireHome.css
+++ b/src/main/resources/static/css/fireHome.css
@@ -120,6 +120,7 @@ nav-left{
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -131,6 +132,9 @@ nav-left{
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/fireOperator.css
+++ b/src/main/resources/static/css/fireOperator.css
@@ -88,6 +88,7 @@ html, body {
 .dropdown:hover .dropdown-menu {
   display: block;
 }
+.dropdown-link,
 .dropdown-logout {
   width: 100%;
   background: none;
@@ -98,6 +99,7 @@ html, body {
   cursor: pointer;
   text-align: left;
 }
+.dropdown-link:hover,
 .dropdown-logout:hover {
   background: rgba(255,255,255,.1);
 }

--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -115,6 +115,7 @@ body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -126,6 +127,9 @@ body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -116,6 +116,7 @@ body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -127,6 +128,9 @@ body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -112,6 +112,9 @@ body {
 	display: block;
 }
 
+.dropdown-link,
+
+
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -123,6 +126,9 @@ body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/formRegisterOperatorFire.css
+++ b/src/main/resources/static/css/formRegisterOperatorFire.css
@@ -120,6 +120,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -131,6 +132,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/formRegisterOperatorLtrad.css
+++ b/src/main/resources/static/css/formRegisterOperatorLtrad.css
@@ -45,10 +45,12 @@ html, body {
   box-shadow: 0 0 10px rgba(0,0,0,0.3);
 }
 .dropdown-menu.show { display: block; }
+.dropdown-link,
 .dropdown-logout {
   width: 100%; background: none; border: none; color: white; font-size: 0.95rem;
   padding: 0.5rem; cursor: pointer; text-align: left; transition: background-color 0.2s;
 }
+.dropdown-link:hover,
 .dropdown-logout:hover { background-color: rgba(255,255,255,0.1); }
 
 /* ===== Layout pagina ===== */

--- a/src/main/resources/static/css/formRegisterOperatorVolcano.css
+++ b/src/main/resources/static/css/formRegisterOperatorVolcano.css
@@ -46,10 +46,12 @@ html, body {
   box-shadow: 0 0 10px rgba(0,0,0,0.3);
 }
 .dropdown-menu.show { display: block; }
+.dropdown-link,
 .dropdown-logout {
   width: 100%; background: none; border: none; color: white; font-size: 0.95rem;
   padding: 0.5rem; cursor: pointer; text-align: left; transition: background-color 0.2s;
 }
+.dropdown-link:hover,
 .dropdown-logout:hover { background-color: rgba(255,255,255,0.1); }
 
 /* ===== Layout pagina ===== */

--- a/src/main/resources/static/css/home1.css
+++ b/src/main/resources/static/css/home1.css
@@ -40,14 +40,85 @@ body {
 }
 
 .nav-right {
-	margin-right: 3em;
+        margin-right: 3em;
+}
+
+.auth-nav {
+        display: flex;
+        align-items: center;
+}
+
+.dropdown {
+        position: relative;
+        display: inline-block;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: #fff;
+        font-size: 1rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        transition: transform 0.3s;
+}
+
+.dropdown-toggle:hover .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 2.4rem;
+        background-color: #0D1B2A;
+        border: 1px solid rgba(0, 191, 255, 0.4);
+        border-radius: 8px;
+        padding: 0.5rem;
+        min-width: 150px;
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+        z-index: 5;
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-link,
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: #fff;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        text-decoration: none;
+        display: block;
+        border-radius: 4px;
+        cursor: pointer;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(0, 191, 255, 0.15);
 }
 
 .nav-button {
-	background: transparent;
-	border: 2px solid #fff;
-	color: #fff;
-	padding: 0.5rem 1rem;
+        background: transparent;
+        border: 2px solid #fff;
+        color: #fff;
+        padding: 0.5rem 1rem;
 	border-radius: 20px;
 	text-decoration: none;
 	font-size: 0.95rem;

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -120,6 +120,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -131,6 +132,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/ltradHome.css
+++ b/src/main/resources/static/css/ltradHome.css
@@ -120,6 +120,7 @@ nav-left{
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -131,6 +132,9 @@ nav-left{
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/ltradOperator.css
+++ b/src/main/resources/static/css/ltradOperator.css
@@ -119,6 +119,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/manageGroupsFire.css
+++ b/src/main/resources/static/css/manageGroupsFire.css
@@ -119,6 +119,7 @@ html, body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/manageGroupsLtrad.css
+++ b/src/main/resources/static/css/manageGroupsLtrad.css
@@ -119,6 +119,7 @@ html, body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/manageGroupsVolcano.css
+++ b/src/main/resources/static/css/manageGroupsVolcano.css
@@ -119,6 +119,7 @@ html, body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -122,6 +122,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -133,6 +134,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -121,6 +121,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -132,6 +133,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -116,6 +116,9 @@ html, body {
 	display: block;
 }
 
+.dropdown-link,
+
+
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -127,6 +130,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
         background-color: rgba(255, 255, 255, 0.1);
@@ -228,6 +234,9 @@ html, body {
 	display: block;
 }
 
+.dropdown-link,
+
+
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -239,6 +248,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/personalAreaFire.css
+++ b/src/main/resources/static/css/personalAreaFire.css
@@ -1,0 +1,304 @@
+body {
+        margin: 0;
+        font-family: 'Roboto', sans-serif;
+        background-color: #1b0e0e;
+        color: #ffffff;
+}
+
+.navbar {
+        border-bottom: 2px solid rgba(255, 142, 142, 0.6);
+        background-color: #cc0000;
+        color: white;
+        position: sticky;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 1.5rem;
+        z-index: 10;
+        height: 3em;
+}
+
+.nav-left h1 {
+        margin: 0;
+        font-size: 1.5rem;
+}
+
+.nav-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+}
+
+.home-button {
+        color: white;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+}
+
+.icon-home {
+        fill: currentColor;
+        width: 24px;
+        height: 24px;
+}
+
+.dropdown {
+        position: relative;
+        display: inline-block;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: white;
+        font-size: 1rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        transition: transform 0.3s;
+}
+
+.dropdown:hover .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 2.4rem;
+        background-color: #1f1212;
+        border: 1px solid rgba(255, 142, 142, 0.7);
+        border-radius: 8px;
+        padding: 0.5rem;
+        z-index: 999;
+        min-width: 140px;
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-link,
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: white;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        cursor: pointer;
+        text-align: left;
+        text-decoration: none;
+        display: block;
+        border-radius: 4px;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(255, 142, 142, 0.2);
+}
+
+.personal-area {
+        max-width: 1100px;
+        margin: 3rem auto;
+        padding: 0 1.5rem 3rem;
+}
+
+.flash-messages {
+        margin-bottom: 1.5rem;
+}
+
+.flash-message {
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        font-weight: 500;
+        margin-bottom: 0.75rem;
+}
+
+.flash-message.success {
+        background: rgba(204, 0, 0, 0.18);
+        border: 1px solid rgba(255, 142, 142, 0.5);
+        color: #ffb3b3;
+}
+
+.profile-section {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.profile-card {
+        background: rgba(30, 10, 10, 0.85);
+        border: 1px solid rgba(255, 142, 142, 0.3);
+        border-radius: 14px;
+        padding: 1.5rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+        backdrop-filter: blur(3px);
+}
+
+.profile-card h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        margin-bottom: 1rem;
+        color: #ffe0e0;
+}
+
+.profile-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+
+.form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+}
+
+label {
+        font-weight: 600;
+        color: #ffd6d6;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="password"],
+select {
+        background: rgba(39, 13, 13, 0.9);
+        border: 1px solid rgba(255, 142, 142, 0.4);
+        border-radius: 6px;
+        padding: 0.6rem 0.75rem;
+        color: white;
+        font-size: 0.95rem;
+}
+
+input[type="text"]:focus,
+input[type="date"]:focus,
+input[type="password"]:focus,
+select:focus {
+        outline: none;
+        border-color: rgba(255, 80, 80, 0.9);
+        box-shadow: 0 0 0 2px rgba(255, 80, 80, 0.25);
+}
+
+.primary-button,
+.secondary-button {
+        border: none;
+        border-radius: 6px;
+        padding: 0.6rem 1.2rem;
+        font-weight: 600;
+        cursor: pointer;
+        font-size: 0.95rem;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+        background: linear-gradient(135deg, #cc0000, #ff5f5f);
+        color: white;
+        box-shadow: 0 8px 18px rgba(204, 0, 0, 0.35);
+}
+
+.secondary-button {
+        background: rgba(255, 142, 142, 0.18);
+        color: #ffe0e0;
+        border: 1px solid rgba(255, 142, 142, 0.45);
+}
+
+.primary-button:hover,
+.secondary-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px rgba(204, 0, 0, 0.45);
+}
+
+.error {
+        color: #ff9f9f;
+        font-size: 0.85rem;
+}
+
+.superadmin-panel {
+        margin-top: 3rem;
+        background: rgba(30, 10, 10, 0.88);
+        border: 1px solid rgba(255, 142, 142, 0.3);
+        border-radius: 14px;
+        padding: 1.75rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+
+.superadmin-panel h2 {
+        margin-top: 0;
+        margin-bottom: 1.2rem;
+        color: #ffb3b3;
+}
+
+.filter-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        margin-bottom: 1.5rem;
+}
+
+.table-wrapper {
+        overflow-x: auto;
+}
+
+table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(39, 13, 13, 0.85);
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+
+th,
+td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+}
+
+th {
+        background: rgba(204, 0, 0, 0.35);
+        color: #ffe0e0;
+}
+
+tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.04);
+}
+
+tbody tr:nth-child(odd) {
+        background: rgba(0, 0, 0, 0.25);
+}
+
+.empty-state {
+        margin: 0;
+        color: #ffd6d6;
+        font-style: italic;
+}
+
+@media (max-width: 768px) {
+        .navbar {
+                padding: 0.75rem 1rem;
+        }
+
+        .personal-area {
+                margin-top: 2rem;
+        }
+
+        .profile-section {
+                grid-template-columns: 1fr;
+        }
+}

--- a/src/main/resources/static/css/personalAreaLtrad.css
+++ b/src/main/resources/static/css/personalAreaLtrad.css
@@ -1,0 +1,304 @@
+body {
+        margin: 0;
+        font-family: 'Roboto', sans-serif;
+        background-color: #0b1a2f;
+        color: #ffffff;
+}
+
+.navbar {
+        border-bottom: 2px solid rgba(142, 196, 255, 0.6);
+        background-color: #007bff;
+        color: white;
+        position: sticky;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 1.5rem;
+        z-index: 10;
+        height: 3em;
+}
+
+.nav-left h1 {
+        margin: 0;
+        font-size: 1.5rem;
+}
+
+.nav-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+}
+
+.home-button {
+        color: white;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+}
+
+.icon-home {
+        fill: currentColor;
+        width: 24px;
+        height: 24px;
+}
+
+.dropdown {
+        position: relative;
+        display: inline-block;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: white;
+        font-size: 1rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        transition: transform 0.3s;
+}
+
+.dropdown:hover .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 2.4rem;
+        background-color: #0d1b2a;
+        border: 1px solid rgba(142, 196, 255, 0.6);
+        border-radius: 8px;
+        padding: 0.5rem;
+        z-index: 999;
+        min-width: 140px;
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-link,
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: white;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        cursor: pointer;
+        text-align: left;
+        text-decoration: none;
+        display: block;
+        border-radius: 4px;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(142, 196, 255, 0.2);
+}
+
+.personal-area {
+        max-width: 1100px;
+        margin: 3rem auto;
+        padding: 0 1.5rem 3rem;
+}
+
+.flash-messages {
+        margin-bottom: 1.5rem;
+}
+
+.flash-message {
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        font-weight: 500;
+        margin-bottom: 0.75rem;
+}
+
+.flash-message.success {
+        background: rgba(0, 123, 255, 0.15);
+        border: 1px solid rgba(0, 123, 255, 0.4);
+        color: #9bd0ff;
+}
+
+.profile-section {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.profile-card {
+        background: rgba(13, 27, 42, 0.8);
+        border: 1px solid rgba(142, 196, 255, 0.3);
+        border-radius: 14px;
+        padding: 1.5rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(3px);
+}
+
+.profile-card h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        margin-bottom: 1rem;
+        color: #e1ecff;
+}
+
+.profile-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+
+.form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+}
+
+label {
+        font-weight: 600;
+        color: #d3e3ff;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="password"],
+select {
+        background: rgba(11, 26, 47, 0.9);
+        border: 1px solid rgba(142, 196, 255, 0.4);
+        border-radius: 6px;
+        padding: 0.6rem 0.75rem;
+        color: white;
+        font-size: 0.95rem;
+}
+
+input[type="text"]:focus,
+input[type="date"]:focus,
+input[type="password"]:focus,
+select:focus {
+        outline: none;
+        border-color: rgba(0, 191, 255, 0.8);
+        box-shadow: 0 0 0 2px rgba(0, 191, 255, 0.2);
+}
+
+.primary-button,
+.secondary-button {
+        border: none;
+        border-radius: 6px;
+        padding: 0.6rem 1.2rem;
+        font-weight: 600;
+        cursor: pointer;
+        font-size: 0.95rem;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+        background: linear-gradient(135deg, #007bff, #00bfff);
+        color: white;
+        box-shadow: 0 8px 18px rgba(0, 123, 255, 0.25);
+}
+
+.secondary-button {
+        background: rgba(142, 196, 255, 0.2);
+        color: #e1ecff;
+        border: 1px solid rgba(142, 196, 255, 0.5);
+}
+
+.primary-button:hover,
+.secondary-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 20px rgba(0, 123, 255, 0.35);
+}
+
+.error {
+        color: #ff8f8f;
+        font-size: 0.85rem;
+}
+
+.superadmin-panel {
+        margin-top: 3rem;
+        background: rgba(13, 27, 42, 0.85);
+        border: 1px solid rgba(142, 196, 255, 0.3);
+        border-radius: 14px;
+        padding: 1.75rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.superadmin-panel h2 {
+        margin-top: 0;
+        margin-bottom: 1.2rem;
+        color: #9bd0ff;
+}
+
+.filter-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        margin-bottom: 1.5rem;
+}
+
+.table-wrapper {
+        overflow-x: auto;
+}
+
+table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(11, 26, 47, 0.85);
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+}
+
+th,
+td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+}
+
+th {
+        background: rgba(0, 123, 255, 0.3);
+        color: #e1ecff;
+}
+
+tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.03);
+}
+
+tbody tr:nth-child(odd) {
+        background: rgba(0, 0, 0, 0.15);
+}
+
+.empty-state {
+        margin: 0;
+        color: #d3e3ff;
+        font-style: italic;
+}
+
+@media (max-width: 768px) {
+        .navbar {
+                padding: 0.75rem 1rem;
+        }
+
+        .personal-area {
+                margin-top: 2rem;
+        }
+
+        .profile-section {
+                grid-template-columns: 1fr;
+        }
+}

--- a/src/main/resources/static/css/personalAreaSuperadmin.css
+++ b/src/main/resources/static/css/personalAreaSuperadmin.css
@@ -1,0 +1,304 @@
+body {
+        margin: 0;
+        font-family: 'Roboto', sans-serif;
+        background-color: #0f1724;
+        color: #f2f4f8;
+}
+
+.navbar {
+        border-bottom: 2px solid rgba(0, 184, 212, 0.35);
+        background-color: #1c2a3a;
+        color: white;
+        position: sticky;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 1.5rem;
+        z-index: 10;
+        height: 3em;
+}
+
+.nav-left h1 {
+        margin: 0;
+        font-size: 1.5rem;
+}
+
+.nav-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+}
+
+.home-button {
+        color: white;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+}
+
+.icon-home {
+        fill: currentColor;
+        width: 24px;
+        height: 24px;
+}
+
+.dropdown {
+        position: relative;
+        display: inline-block;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: white;
+        font-size: 1rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        transition: transform 0.3s;
+}
+
+.dropdown:hover .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 2.4rem;
+        background-color: #152130;
+        border: 1px solid rgba(0, 184, 212, 0.4);
+        border-radius: 8px;
+        padding: 0.5rem;
+        z-index: 999;
+        min-width: 140px;
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-link,
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: white;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        cursor: pointer;
+        text-align: left;
+        text-decoration: none;
+        display: block;
+        border-radius: 4px;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(0, 184, 212, 0.22);
+}
+
+.personal-area {
+        max-width: 1100px;
+        margin: 3rem auto;
+        padding: 0 1.5rem 3rem;
+}
+
+.flash-messages {
+        margin-bottom: 1.5rem;
+}
+
+.flash-message {
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        font-weight: 500;
+        margin-bottom: 0.75rem;
+}
+
+.flash-message.success {
+        background: rgba(0, 184, 212, 0.18);
+        border: 1px solid rgba(0, 184, 212, 0.35);
+        color: #9de9f4;
+}
+
+.profile-section {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.profile-card {
+        background: rgba(21, 33, 48, 0.85);
+        border: 1px solid rgba(157, 233, 244, 0.25);
+        border-radius: 14px;
+        padding: 1.5rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(3px);
+}
+
+.profile-card h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        margin-bottom: 1rem;
+        color: #d7f4ff;
+}
+
+.profile-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+
+.form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+}
+
+label {
+        font-weight: 600;
+        color: #c8e0f2;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="password"],
+select {
+        background: rgba(17, 29, 44, 0.9);
+        border: 1px solid rgba(0, 184, 212, 0.35);
+        border-radius: 6px;
+        padding: 0.6rem 0.75rem;
+        color: white;
+        font-size: 0.95rem;
+}
+
+input[type="text"]:focus,
+input[type="date"]:focus,
+input[type="password"]:focus,
+select:focus {
+        outline: none;
+        border-color: rgba(0, 200, 255, 0.8);
+        box-shadow: 0 0 0 2px rgba(0, 200, 255, 0.25);
+}
+
+.primary-button,
+.secondary-button {
+        border: none;
+        border-radius: 6px;
+        padding: 0.6rem 1.2rem;
+        font-weight: 600;
+        cursor: pointer;
+        font-size: 0.95rem;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+        background: linear-gradient(135deg, #00bcd4, #007bff);
+        color: white;
+        box-shadow: 0 8px 18px rgba(0, 123, 255, 0.25);
+}
+
+.secondary-button {
+        background: rgba(157, 233, 244, 0.18);
+        color: #d7f4ff;
+        border: 1px solid rgba(157, 233, 244, 0.35);
+}
+
+.primary-button:hover,
+.secondary-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px rgba(0, 184, 212, 0.35);
+}
+
+.error {
+        color: #ff9f9f;
+        font-size: 0.85rem;
+}
+
+.superadmin-panel {
+        margin-top: 3rem;
+        background: rgba(21, 33, 48, 0.88);
+        border: 1px solid rgba(157, 233, 244, 0.25);
+        border-radius: 14px;
+        padding: 1.75rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.superadmin-panel h2 {
+        margin-top: 0;
+        margin-bottom: 1.2rem;
+        color: #9de9f4;
+}
+
+.filter-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        margin-bottom: 1.5rem;
+}
+
+.table-wrapper {
+        overflow-x: auto;
+}
+
+table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(17, 29, 44, 0.9);
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+}
+
+th,
+td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+}
+
+th {
+        background: rgba(0, 184, 212, 0.25);
+        color: #d7f4ff;
+}
+
+tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.04);
+}
+
+tbody tr:nth-child(odd) {
+        background: rgba(0, 0, 0, 0.2);
+}
+
+.empty-state {
+        margin: 0;
+        color: #c8e0f2;
+        font-style: italic;
+}
+
+@media (max-width: 768px) {
+        .navbar {
+                padding: 0.75rem 1rem;
+        }
+
+        .personal-area {
+                margin-top: 2rem;
+        }
+
+        .profile-section {
+                grid-template-columns: 1fr;
+        }
+}

--- a/src/main/resources/static/css/personalAreaVolcano.css
+++ b/src/main/resources/static/css/personalAreaVolcano.css
@@ -1,0 +1,304 @@
+body {
+        margin: 0;
+        font-family: 'Roboto', sans-serif;
+        background-color: #1d1205;
+        color: #ffffff;
+}
+
+.navbar {
+        border-bottom: 2px solid rgba(255, 189, 113, 0.6);
+        background-color: #e67e00;
+        color: white;
+        position: sticky;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 0.75rem 1.5rem;
+        z-index: 10;
+        height: 3em;
+}
+
+.nav-left h1 {
+        margin: 0;
+        font-size: 1.5rem;
+}
+
+.nav-right {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+}
+
+.home-button {
+        color: white;
+        text-decoration: none;
+        display: flex;
+        align-items: center;
+}
+
+.icon-home {
+        fill: currentColor;
+        width: 24px;
+        height: 24px;
+}
+
+.dropdown {
+        position: relative;
+        display: inline-block;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: white;
+        font-size: 1rem;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        transition: transform 0.3s;
+}
+
+.dropdown:hover .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: 2.4rem;
+        background-color: #201107;
+        border: 1px solid rgba(255, 189, 113, 0.7);
+        border-radius: 8px;
+        padding: 0.5rem;
+        z-index: 999;
+        min-width: 140px;
+        box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-link,
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: white;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        cursor: pointer;
+        text-align: left;
+        text-decoration: none;
+        display: block;
+        border-radius: 4px;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(255, 189, 113, 0.22);
+}
+
+.personal-area {
+        max-width: 1100px;
+        margin: 3rem auto;
+        padding: 0 1.5rem 3rem;
+}
+
+.flash-messages {
+        margin-bottom: 1.5rem;
+}
+
+.flash-message {
+        padding: 0.75rem 1rem;
+        border-radius: 6px;
+        font-weight: 500;
+        margin-bottom: 0.75rem;
+}
+
+.flash-message.success {
+        background: rgba(230, 126, 0, 0.2);
+        border: 1px solid rgba(255, 189, 113, 0.55);
+        color: #ffd7aa;
+}
+
+.profile-section {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.profile-card {
+        background: rgba(32, 17, 7, 0.88);
+        border: 1px solid rgba(255, 189, 113, 0.35);
+        border-radius: 14px;
+        padding: 1.5rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+        backdrop-filter: blur(3px);
+}
+
+.profile-card h2 {
+        margin-top: 0;
+        font-size: 1.4rem;
+        margin-bottom: 1rem;
+        color: #ffe6cc;
+}
+
+.profile-form {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+}
+
+.form-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+}
+
+label {
+        font-weight: 600;
+        color: #ffe0c2;
+}
+
+input[type="text"],
+input[type="date"],
+input[type="password"],
+select {
+        background: rgba(42, 20, 6, 0.9);
+        border: 1px solid rgba(255, 189, 113, 0.45);
+        border-radius: 6px;
+        padding: 0.6rem 0.75rem;
+        color: white;
+        font-size: 0.95rem;
+}
+
+input[type="text"]:focus,
+input[type="date"]:focus,
+input[type="password"]:focus,
+select:focus {
+        outline: none;
+        border-color: rgba(255, 153, 51, 0.9);
+        box-shadow: 0 0 0 2px rgba(255, 153, 51, 0.25);
+}
+
+.primary-button,
+.secondary-button {
+        border: none;
+        border-radius: 6px;
+        padding: 0.6rem 1.2rem;
+        font-weight: 600;
+        cursor: pointer;
+        font-size: 0.95rem;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button {
+        background: linear-gradient(135deg, #e67e00, #ff9f43);
+        color: white;
+        box-shadow: 0 8px 18px rgba(230, 126, 0, 0.35);
+}
+
+.secondary-button {
+        background: rgba(255, 189, 113, 0.2);
+        color: #ffe6cc;
+        border: 1px solid rgba(255, 189, 113, 0.45);
+}
+
+.primary-button:hover,
+.secondary-button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 22px rgba(230, 126, 0, 0.45);
+}
+
+.error {
+        color: #ffc6a1;
+        font-size: 0.85rem;
+}
+
+.superadmin-panel {
+        margin-top: 3rem;
+        background: rgba(32, 17, 7, 0.9);
+        border: 1px solid rgba(255, 189, 113, 0.35);
+        border-radius: 14px;
+        padding: 1.75rem;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+
+.superadmin-panel h2 {
+        margin-top: 0;
+        margin-bottom: 1.2rem;
+        color: #ffd7aa;
+}
+
+.filter-form {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        margin-bottom: 1.5rem;
+}
+
+.table-wrapper {
+        overflow-x: auto;
+}
+
+table {
+        width: 100%;
+        border-collapse: collapse;
+        background: rgba(42, 20, 6, 0.88);
+        border-radius: 10px;
+        overflow: hidden;
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.45);
+}
+
+th,
+td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+}
+
+th {
+        background: rgba(230, 126, 0, 0.38);
+        color: #ffe6cc;
+}
+
+tbody tr:nth-child(even) {
+        background: rgba(255, 255, 255, 0.05);
+}
+
+tbody tr:nth-child(odd) {
+        background: rgba(0, 0, 0, 0.25);
+}
+
+.empty-state {
+        margin: 0;
+        color: #ffe0c2;
+        font-style: italic;
+}
+
+@media (max-width: 768px) {
+        .navbar {
+                padding: 0.75rem 1rem;
+        }
+
+        .personal-area {
+                margin-top: 2rem;
+        }
+
+        .profile-section {
+                grid-template-columns: 1fr;
+        }
+}

--- a/src/main/resources/static/css/updateDeviceFire.css
+++ b/src/main/resources/static/css/updateDeviceFire.css
@@ -119,6 +119,7 @@ html, body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/updateDeviceLtrad.css
+++ b/src/main/resources/static/css/updateDeviceLtrad.css
@@ -119,6 +119,7 @@ html, body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/updateDeviceVolcano.css
+++ b/src/main/resources/static/css/updateDeviceVolcano.css
@@ -119,6 +119,7 @@ html, body {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ html, body {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -120,6 +120,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -131,6 +132,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/volcanoHome.css
+++ b/src/main/resources/static/css/volcanoHome.css
@@ -120,6 +120,7 @@ nav-left{
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -131,6 +132,9 @@ nav-left{
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/static/css/volcanoOperator.css
+++ b/src/main/resources/static/css/volcanoOperator.css
@@ -119,6 +119,7 @@ navbar h1 {
 }
 
 /* Pulsante logout nel menu */
+.dropdown-link,
 .dropdown-logout {
 	width: 100%;
 	background: none;
@@ -130,6 +131,9 @@ navbar h1 {
 	text-align: left;
 	transition: background-color 0.2s;
 }
+
+.dropdown-link:hover,
+
 
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -28,6 +28,7 @@
                                         </svg>
                                 </button>
                                 <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
                                         <form th:action="@{/logout}" method="post" th:csrf="true">
                                                 <button type="submit" class="dropdown-logout">Logout</button>
                                         </form>

--- a/src/main/resources/templates/admin/formRegisterOperator.html
+++ b/src/main/resources/templates/admin/formRegisterOperator.html
@@ -35,11 +35,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -41,11 +41,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/admin/manageGroups.html
+++ b/src/main/resources/templates/admin/manageGroups.html
@@ -35,11 +35,12 @@
 								<path d="M7 10l5 5 5-5z" />
 							</svg>
 						</button>
-						<div class="dropdown-menu" id="userDropdownMenu">
-							<form th:action="@{/logout}" method="post" th:csrf="true">
-								<button type="submit" class="dropdown-logout">Logout</button>
-							</form>
-						</div>
+                                                <div class="dropdown-menu" id="userDropdownMenu">
+                                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                                        </form>
+                                                </div>
 					</div>
 					<a href="/" class="home-button" title="Homepage">
 						<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -14,23 +14,24 @@
 		<div class="nav-left">
 			<h1>AetherSense</h1>
 		</div>
-		<div class="nav-right">
-			<div class="auth-nav">
-				<!-- Utente autenticato -->
-				<div sec:authorize="isAuthenticated()" class="auth-user">
-					<span class="username">Hi, <strong th:text="${user.visibleUsername}">utente</strong></span>
-					<form th:action="@{/logout}" method="post" th:csrf="true" class="logout-form">
-						<button type="submit" class="icon-button" title="Logout">
-							<svg xmlns="http://www.w3.org/2000/svg" class="icon-user" viewBox="0 0 24 24"
-								fill="currentColor" width="24" height="24">
-								<path
-									d="M16 13v-2H7v-3l-5 4 5 4v-3zM20 3h-8v2h8v14h-8v2h8c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
-							</svg>
-						</button>
-					</form>
-				</div>
-			</div>
-		</div>
+                <div class="nav-right">
+                        <div class="auth-nav">
+                                <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                        <button type="button" class="dropdown-toggle" id="userDropdown">
+                                                Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                                <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="white">
+                                                        <path d="M7 10l5 5 5-5z" />
+                                                </svg>
+                                        </button>
+                                        <div class="dropdown-menu" id="userDropdownMenu">
+                                                <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                                <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                        <button type="submit" class="dropdown-logout">Logout</button>
+                                                </form>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
 	</header>
 
 	<section class="hero">
@@ -114,9 +115,29 @@
 		<p>Interested in our projects? <a href="https://www.4spark.it/" target="_blank">Contact us</a>.</p>
 	</section>
 
-	<footer>
-		<p>&copy; 2025 - 4Spark Sensor Platform</p>
-	</footer>
+        <footer>
+                <p>&copy; 2025 - 4Spark Sensor Platform</p>
+        </footer>
+
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
+
+                        if (toggle && menu) {
+                                toggle.addEventListener("click", function (event) {
+                                        event.stopPropagation();
+                                        menu.classList.toggle("show");
+                                });
+
+                                document.addEventListener("click", function (event) {
+                                        if (!toggle.contains(event.target)) {
+                                                menu.classList.remove("show");
+                                        }
+                                });
+                        }
+                });
+        </script>
 
 </body>
 

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -33,11 +33,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<!--a href="/" class="home-button" title="Homepage"-->
 			<form th:action="@{/logout}" method="post" th:csrf="true">

--- a/src/main/resources/templates/personalArea.html
+++ b/src/main/resources/templates/personalArea.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Personal Area</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
+    <link rel="stylesheet" th:if="${currentProjectId == 1}" th:href="@{/css/personalAreaLtrad.css}" />
+    <link rel="stylesheet" th:if="${currentProjectId == 51}" th:href="@{/css/personalAreaFire.css}" />
+    <link rel="stylesheet" th:if="${currentProjectId == 101}" th:href="@{/css/personalAreaVolcano.css}" />
+    <link rel="stylesheet" th:if="${currentProjectId == null}" th:href="@{/css/personalAreaSuperadmin.css}" />
+    <link rel="stylesheet" th:if="${currentProjectId != null and currentProjectId != 1 and currentProjectId != 51 and currentProjectId != 101}" th:href="@{/css/personalAreaSuperadmin.css}" />
+</head>
+
+<body>
+    <header id="navbar" class="navbar">
+        <div class="nav-left">
+            <h1>Personal Area</h1>
+        </div>
+        <div class="nav-right">
+            <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
+                <button type="button" class="dropdown-toggle" id="userDropdown">
+                    Hi, <strong th:text="${user.visibleUsername}">user</strong>
+                    <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="white">
+                        <path d="M7 10l5 5 5-5z" />
+                    </svg>
+                </button>
+                <div class="dropdown-menu" id="userDropdownMenu">
+                    <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                    <form th:action="@{/logout}" method="post" th:csrf="true">
+                        <button type="submit" class="dropdown-logout">Logout</button>
+                    </form>
+                </div>
+            </div>
+            <a href="/" class="home-button" title="Homepage">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
+                    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+                </svg>
+            </a>
+        </div>
+    </header>
+
+    <main class="personal-area">
+        <section class="flash-messages">
+            <div class="flash-message success" th:if="${userSuccessMessage != null}" th:text="${userSuccessMessage}"></div>
+            <div class="flash-message success" th:if="${credentialsSuccessMessage != null}" th:text="${credentialsSuccessMessage}"></div>
+        </section>
+
+        <section class="profile-section">
+            <div class="profile-card">
+                <h2>Personal Information</h2>
+                <form th:action="@{/personal-area/update-user}" th:object="${userForm}" method="post" class="profile-form">
+                    <input type="hidden" th:field="*{id}" />
+                    <input type="hidden" th:if="${selectedProjectId != null}" name="projectId" th:value="${selectedProjectId}" />
+                    <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+
+                    <div class="form-group">
+                        <label for="name">Name</label>
+                        <input type="text" id="name" th:field="*{name}" />
+                        <div class="error" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="surname">Surname</label>
+                        <input type="text" id="surname" th:field="*{surname}" />
+                        <div class="error" th:if="${#fields.hasErrors('surname')}" th:errors="*{surname}"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="dateOfBirth">Date of Birth</label>
+                        <input type="date" id="dateOfBirth" th:field="*{dateOfBirth}" />
+                        <div class="error" th:if="${#fields.hasErrors('dateOfBirth')}" th:errors="*{dateOfBirth}"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="phoneNumber">Phone Number</label>
+                        <input type="text" id="phoneNumber" th:field="*{phoneNumber}" />
+                        <div class="error" th:if="${#fields.hasErrors('phoneNumber')}" th:errors="*{phoneNumber}"></div>
+                    </div>
+
+                    <button type="submit" class="primary-button">Update Information</button>
+                </form>
+            </div>
+
+            <div class="profile-card">
+                <h2>Credentials</h2>
+                <form th:action="@{/personal-area/update-credentials}" th:object="${credentialsDto}" method="post" class="profile-form">
+                    <input type="hidden" th:if="${selectedProjectId != null}" name="projectId" th:value="${selectedProjectId}" />
+                    <input type="hidden" th:if="${_csrf != null}" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+
+                    <div class="form-group">
+                        <label for="visibleUsername">Visible Username</label>
+                        <input type="text" id="visibleUsername" th:field="*{visibleUsername}" />
+                        <div class="error" th:if="${#fields.hasErrors('visibleUsername')}" th:errors="*{visibleUsername}"></div>
+                    </div>
+
+                    <div class="form-group">
+                        <label for="newPassword">New Password</label>
+                        <input type="password" id="newPassword" th:field="*{newPassword}" placeholder="Leave blank to keep current password" />
+                    </div>
+
+                    <div class="form-group">
+                        <label for="confirmPassword">Confirm Password</label>
+                        <input type="password" id="confirmPassword" th:field="*{confirmPassword}" placeholder="Repeat new password" />
+                        <div class="error" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></div>
+                    </div>
+
+                    <button type="submit" class="primary-button">Update Credentials</button>
+                </form>
+            </div>
+        </section>
+
+        <section class="superadmin-panel" th:if="${isSuperadmin}">
+            <h2>Project Users Overview</h2>
+            <form method="get" th:action="@{/personal-area}" class="filter-form">
+                <label for="projectFilter">Select project</label>
+                <select id="projectFilter" name="projectId">
+                    <option th:value="" th:text="'All projects'" th:selected="${selectedProjectId == null}"></option>
+                    <option th:each="project : ${projects}" th:value="${project.id}" th:text="${project.name}"
+                        th:selected="${project.id == selectedProjectId}"></option>
+                </select>
+                <button type="submit" class="secondary-button">Filter</button>
+            </form>
+
+            <div class="table-wrapper">
+                <table th:if="${projectUsers != null && !projectUsers.isEmpty()}">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Surname</th>
+                            <th>Date of Birth</th>
+                            <th>Phone</th>
+                            <th>Email</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr th:each="credential : ${projectUsers}">
+                            <td th:text="${credential.user.name}">Name</td>
+                            <td th:text="${credential.user.surname}">Surname</td>
+                            <td th:text="${#temporals.format(credential.user.dateOfBirth, 'dd/MM/yyyy')}">01/01/2024</td>
+                            <td th:text="${credential.user.phoneNumber}">Phone</td>
+                            <td th:text="${credential.email}">email@example.com</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p th:if="${projectUsers == null || projectUsers.isEmpty()}" class="empty-state">No users available for the selected project.</p>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        document.addEventListener("DOMContentLoaded", function () {
+            const toggle = document.getElementById("userDropdown");
+            const menu = document.getElementById("userDropdownMenu");
+
+            if (toggle && menu) {
+                toggle.addEventListener("click", function (event) {
+                    event.stopPropagation();
+                    menu.classList.toggle("show");
+                });
+
+                document.addEventListener("click", function (event) {
+                    if (!toggle.contains(event.target)) {
+                        menu.classList.remove("show");
+                    }
+                });
+            }
+        });
+    </script>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/project/fireHome.html
+++ b/src/main/resources/templates/project/fireHome.html
@@ -21,11 +21,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/project/ltradHome.html
+++ b/src/main/resources/templates/project/ltradHome.html
@@ -21,11 +21,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/project/volcanoHome.html
+++ b/src/main/resources/templates/project/volcanoHome.html
@@ -23,11 +23,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -25,6 +25,7 @@
                 </svg>
             </button>
             <div class="dropdown-menu" id="userDropdownMenu">
+                <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
                 <form th:action="@{/logout}" method="post" th:csrf="true">
                     <button type="submit" class="dropdown-logout">Logout</button>
                 </form>

--- a/src/main/resources/templates/superadmin/formNewSpec.html
+++ b/src/main/resources/templates/superadmin/formNewSpec.html
@@ -37,11 +37,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/superadmin/formNewTod.html
+++ b/src/main/resources/templates/superadmin/formNewTod.html
@@ -36,11 +36,12 @@
 						<path d="M7 10l5 5 5-5z" />
 					</svg>
 				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
 			</div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/superadmin/formUpdateDevice.html
+++ b/src/main/resources/templates/superadmin/formUpdateDevice.html
@@ -31,11 +31,12 @@
 							<path d="M7 10l5 5 5-5z" />
 						</svg>
 					</button>
-					<div class="dropdown-menu" id="userDropdownMenu">
-						<form th:action="@{/logout}" method="post" th:csrf="true">
-							<button type="submit" class="dropdown-logout">Logout</button>
-						</form>
-					</div>
+                                        <div class="dropdown-menu" id="userDropdownMenu">
+                                                <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                                <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                        <button type="submit" class="dropdown-logout">Logout</button>
+                                                </form>
+                                        </div>
 				</div>
 				<a href="/" class="home-button" title="Homepage">
 					<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -38,11 +38,12 @@
 								<path d="M7 10l5 5 5-5z" />
 							</svg>
 						</button>
-						<div class="dropdown-menu" id="userDropdownMenu">
-							<form th:action="@{/logout}" method="post" th:csrf="true">
-								<button type="submit" class="dropdown-logout">Logout</button>
-							</form>
-						</div>
+                                                <div class="dropdown-menu" id="userDropdownMenu">
+                                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                                        </form>
+                                                </div>
 					</div>
 					<a href="/" class="home-button" title="Homepage">
 						<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">

--- a/src/main/resources/templates/superadmin/superadminHome.html
+++ b/src/main/resources/templates/superadmin/superadminHome.html
@@ -16,20 +16,22 @@
 		<div class="nav-left">
 			<h1>AetherSense <span class="admin-label">SuperAdmin</span></h1>
 		</div>
-		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user">
-				<span class="username">Hi, <strong th:text="${user.visibleUsername}">utente</strong></span>
-				<form th:action="@{/logout}" method="post" th:csrf="true" class="logout-form">
-					<button type="submit" class="icon-button" title="Logout">
-						<svg xmlns="http://www.w3.org/2000/svg" class="icon-user" viewBox="0 0 24 24"
-							fill="currentColor" width="24" height="24">
-							<path
-								d="M16 13v-2H7v-3l-5 4 5 4v-3zM20 3h-8v2h8v14h-8v2h8c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
-						</svg>
-					</button>
-				</form>
-			</div>
-		</div>
+                <div class="nav-right">
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu">
+                                        <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true" class="logout-form">
+                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
+                </div>
 	</header>
 	<section class="hero">
 		<video class="hero_video" autoplay muted loop playsinline preload="auto">
@@ -108,9 +110,29 @@
 		<p>Interested in our projects? <a href="https://www.4spark.it/" target="_blank">Contact us</a>.</p>
 	</section>
 
-	<footer>
-		<p>&copy; 2025 - 4Spark Sensor Platform</p>
-	</footer>
+        <footer>
+                <p>&copy; 2025 - 4Spark Sensor Platform</p>
+        </footer>
+
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
+
+                        if (toggle && menu) {
+                                toggle.addEventListener("click", function (event) {
+                                        event.stopPropagation();
+                                        menu.classList.toggle("show");
+                                });
+
+                                document.addEventListener("click", function (event) {
+                                        if (!toggle.contains(event.target)) {
+                                                menu.classList.remove("show");
+                                        }
+                                });
+                        }
+                });
+        </script>
 
 </body>
 

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -33,11 +33,12 @@
 							<path d="M7 10l5 5 5-5z" />
 						</svg>
 					</button>
-					<div class="dropdown-menu" id="userDropdownMenu">
-						<form th:action="@{/logout}" method="post" th:csrf="true">
-							<button type="submit" class="dropdown-logout">Logout</button>
-						</form>
-					</div>
+                                        <div class="dropdown-menu" id="userDropdownMenu">
+                                                <a th:href="@{/personal-area}" class="dropdown-link">Personal Area</a>
+                                                <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                        <button type="submit" class="dropdown-logout">Logout</button>
+                                                </form>
+                                        </div>
 				</div>
 				<a href="/" class="home-button" title="Homepage">
 					<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- implement `UserProfileController` and supporting DTO/service updates to manage personal data and credentials
- create the personal area template with themed styles plus superadmin filtering UI
- refresh navigation dropdowns and styling across templates while wiring the new personal area link

## Testing
- `mvn test` *(fails: unable to resolve parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cd64bbb1648327bac6285fb8fe7d35