### PR TITLE
Implement personal area management

### DIFF
--- a/src/main/java/it/sensorplatform/controller/PersonalAreaController.java
+++ b/src/main/java/it/sensorplatform/controller/PersonalAreaController.java
@@ -1,0 +1,259 @@
+package it.sensorplatform.controller;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import it.sensorplatform.dto.CredentialsUpdateForm;
+import it.sensorplatform.dto.PersonalInfoForm;
+import it.sensorplatform.model.Credentials;
+import it.sensorplatform.model.Project;
+import it.sensorplatform.model.User;
+import it.sensorplatform.service.CredentialsService;
+import it.sensorplatform.service.ProjectService;
+import it.sensorplatform.service.UserService;
+import jakarta.validation.Valid;
+
+@Controller
+@RequestMapping("/personal-area")
+public class PersonalAreaController {
+
+    private static final String PERSONAL_AREA_VIEW = "personalArea";
+
+    @Autowired
+    private CredentialsService credentialsService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private ProjectService projectService;
+
+    @GetMapping
+    public String showPersonalArea(@RequestParam(value = "projectId", required = false) Long projectId,
+            Model model) {
+        Credentials credentials = getCurrentCredentials();
+        if (credentials == null) {
+            return "redirect:/login";
+        }
+
+        model.addAttribute("user", credentials);
+
+        if (!model.containsAttribute("personalInfoForm")) {
+            model.addAttribute("personalInfoForm", buildPersonalInfoForm(credentials.getUser()));
+        }
+        if (!model.containsAttribute("credentialsUpdateForm")) {
+            CredentialsUpdateForm credentialsForm = new CredentialsUpdateForm();
+            credentialsForm.setUsername(credentials.getVisibleUsername());
+            model.addAttribute("credentialsUpdateForm", credentialsForm);
+        }
+
+        boolean isSuperadmin = Credentials.SUPERADMIN_ROLE.equals(credentials.getRole());
+        model.addAttribute("isSuperadmin", isSuperadmin);
+
+        List<Project> projects = collectProjects();
+        model.addAttribute("projects", projects);
+
+        Long effectiveProjectId = determineProjectId(credentials, projectId, isSuperadmin);
+        Project activeProject = resolveProject(effectiveProjectId);
+
+        if (isSuperadmin) {
+            model.addAttribute("projectUsers", credentialsService.getProjectUsers(effectiveProjectId));
+        } else {
+            model.addAttribute("projectUsers", Collections.emptyList());
+        }
+
+        model.addAttribute("selectedProjectId", effectiveProjectId);
+        model.addAttribute("activeProject", activeProject);
+        model.addAttribute("projectKey", determineProjectKey(activeProject));
+
+        return PERSONAL_AREA_VIEW;
+    }
+
+    @PostMapping("/update-info")
+    public String updatePersonalInformation(
+            @RequestParam(value = "projectId", required = false) Long projectId,
+            @Valid @ModelAttribute("personalInfoForm") PersonalInfoForm form,
+            BindingResult bindingResult,
+            RedirectAttributes redirectAttributes) {
+        Credentials credentials = getCurrentCredentials();
+        if (credentials == null) {
+            return "redirect:/login";
+        }
+
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute(BindingResult.MODEL_KEY_PREFIX + "personalInfoForm", bindingResult);
+            redirectAttributes.addFlashAttribute("personalInfoForm", form);
+            redirectAttributes.addFlashAttribute("personalInfoErrorMessage", "Verifica i dati inseriti e riprova.");
+            if (projectId != null) {
+                redirectAttributes.addAttribute("projectId", projectId);
+            }
+            return "redirect:/personal-area";
+        }
+
+        userService.updatePersonalInfo(credentials, form);
+        credentialsService.updateCredentials(credentials, null);
+
+        redirectAttributes.addFlashAttribute("personalInfoSuccessMessage", "Dati anagrafici aggiornati con successo.");
+        if (projectId != null) {
+            redirectAttributes.addAttribute("projectId", projectId);
+        }
+        return "redirect:/personal-area";
+    }
+
+    @PostMapping("/update-credentials")
+    public String updateCredentials(
+            @RequestParam(value = "projectId", required = false) Long projectId,
+            @Valid @ModelAttribute("credentialsUpdateForm") CredentialsUpdateForm form,
+            BindingResult bindingResult,
+            RedirectAttributes redirectAttributes) {
+        Credentials credentials = getCurrentCredentials();
+        if (credentials == null) {
+            return "redirect:/login";
+        }
+
+        String normalizedUsername = form.getUsername() != null ? form.getUsername().trim() : "";
+        if (!normalizedUsername.equals(form.getUsername())) {
+            form.setUsername(normalizedUsername);
+        }
+
+        String suffix = resolveUsernameSuffix(credentials);
+        String rebuiltUsername = buildUsername(normalizedUsername, suffix);
+
+        if (!rebuiltUsername.equals(credentials.getUsername())
+                && credentialsService.existsByUsername(rebuiltUsername)) {
+            bindingResult.rejectValue("username", "username.alreadyInUse", "Username già in uso");
+        }
+
+        if (bindingResult.hasErrors()) {
+            redirectAttributes.addFlashAttribute(BindingResult.MODEL_KEY_PREFIX + "credentialsUpdateForm",
+                    bindingResult);
+            CredentialsUpdateForm safeForm = new CredentialsUpdateForm();
+            safeForm.setUsername(form.getUsername());
+            redirectAttributes.addFlashAttribute("credentialsUpdateForm", safeForm);
+            redirectAttributes.addFlashAttribute("credentialsErrorMessage", "Correggi gli errori segnalati e riprova.");
+            if (projectId != null) {
+                redirectAttributes.addAttribute("projectId", projectId);
+            }
+            return "redirect:/personal-area";
+        }
+
+        credentials.setVisibleUsername(normalizedUsername);
+        credentials.setUsername(rebuiltUsername);
+        String password = form.getPassword();
+        if (!StringUtils.hasText(password)) {
+            password = null;
+        }
+        credentialsService.updateCredentials(credentials, password);
+
+        redirectAttributes.addFlashAttribute("credentialsSuccessMessage", "Credenziali aggiornate con successo.");
+        if (projectId != null) {
+            redirectAttributes.addAttribute("projectId", projectId);
+        }
+        return "redirect:/personal-area";
+    }
+
+    private Credentials getCurrentCredentials() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetails userDetails) {
+            return credentialsService.getCredentials(userDetails.getUsername());
+        }
+        if (principal instanceof String username) {
+            return credentialsService.getCredentials(username);
+        }
+        return null;
+    }
+
+    private PersonalInfoForm buildPersonalInfoForm(User user) {
+        PersonalInfoForm form = new PersonalInfoForm();
+        if (user != null) {
+            form.setName(user.getName());
+            form.setSurname(user.getSurname());
+            form.setDateOfBirth(user.getDateOfBirth());
+            form.setPhoneNumber(user.getPhoneNumber());
+        }
+        return form;
+    }
+
+    private List<Project> collectProjects() {
+        List<Project> projects = new ArrayList<>();
+        projectService.getAllProjects().forEach(projects::add);
+        return projects;
+    }
+
+    private Long determineProjectId(Credentials credentials, Long requestedProjectId, boolean isSuperadmin) {
+        if (isSuperadmin) {
+            if (requestedProjectId != null) {
+                return requestedProjectId;
+            }
+        }
+        return credentials.getProjectId();
+    }
+
+    private Project resolveProject(Long projectId) {
+        if (projectId == null) {
+            return null;
+        }
+        try {
+            return projectService.getProjectById(projectId);
+        } catch (NoSuchElementException | RuntimeException ex) {
+            return null;
+        }
+    }
+
+    private String determineProjectKey(Project project) {
+        if (project != null && project.getName() != null) {
+            return project.getName().toLowerCase(Locale.ROOT);
+        }
+        return "default";
+    }
+
+    private String resolveUsernameSuffix(Credentials credentials) {
+        if (Credentials.SUPERADMIN_ROLE.equals(credentials.getRole())) {
+            return Credentials.SUPERADMIN_ROLE;
+        }
+        Project project = resolveProject(credentials.getProjectId());
+        if (project != null && StringUtils.hasText(project.getName())) {
+            return project.getName();
+        }
+        String username = credentials.getUsername();
+        if (username != null) {
+            int separatorIndex = username.indexOf('|');
+            if (separatorIndex >= 0 && separatorIndex < username.length() - 1) {
+                return username.substring(separatorIndex + 1);
+            }
+        }
+        return null;
+    }
+
+    private String buildUsername(String visibleUsername, String suffix) {
+        if (!StringUtils.hasText(suffix)) {
+            return visibleUsername;
+        }
+        return visibleUsername + "|" + suffix;
+    }
+}

--- a/src/main/java/it/sensorplatform/dto/CredentialsUpdateForm.java
+++ b/src/main/java/it/sensorplatform/dto/CredentialsUpdateForm.java
@@ -1,0 +1,50 @@
+package it.sensorplatform.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class CredentialsUpdateForm {
+
+    @NotBlank
+    @Size(min = 3, max = 50)
+    private String username;
+
+    @Pattern(regexp = "^$|.{8,255}$", message = "La password deve contenere almeno 8 caratteri")
+    private String password;
+
+    private String confirmPassword;
+
+    @AssertTrue(message = "Le password non coincidono")
+    public boolean isPasswordConfirmed() {
+        if (password == null || password.isBlank()) {
+            return confirmPassword == null || confirmPassword.isBlank();
+        }
+        return password.equals(confirmPassword);
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public void setConfirmPassword(String confirmPassword) {
+        this.confirmPassword = confirmPassword;
+    }
+}

--- a/src/main/java/it/sensorplatform/dto/PersonalInfoForm.java
+++ b/src/main/java/it/sensorplatform/dto/PersonalInfoForm.java
@@ -1,0 +1,63 @@
+package it.sensorplatform.dto;
+
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class PersonalInfoForm {
+
+    @NotBlank
+    @Size(max = 100)
+    private String name;
+
+    @NotBlank
+    @Size(max = 100)
+    private String surname;
+
+    @NotNull
+    @Past
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate dateOfBirth;
+
+    @NotBlank
+    @Pattern(regexp = "^\\+?[0-9\\s]{6,20}$", message = "Invalid phone number")
+    private String phoneNumber;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public void setSurname(String surname) {
+        this.surname = surname;
+    }
+
+    public LocalDate getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(LocalDate dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/it/sensorplatform/repository/CredentialsRepository.java
+++ b/src/main/java/it/sensorplatform/repository/CredentialsRepository.java
@@ -23,4 +23,6 @@ public interface CredentialsRepository extends CrudRepository<Credentials, Long>
     public Optional<Credentials>  findById(Long id);
     
     List<Credentials> findByRoleAndProjectId(String role, Long projectId);
+
+    List<Credentials> findByProjectId(Long projectId);
 }

--- a/src/main/java/it/sensorplatform/service/CredentialsService.java
+++ b/src/main/java/it/sensorplatform/service/CredentialsService.java
@@ -1,16 +1,17 @@
 package it.sensorplatform.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import it.sensorplatform.repository.CredentialsRepository;
 import jakarta.transaction.Transactional;
 import it.sensorplatform.model.Credentials;
-import it.sensorplatform.model.Project;
 
 @Service
 public class CredentialsService {
@@ -43,10 +44,18 @@ public class CredentialsService {
 
 
 	@Transactional
-	public Credentials saveCredentials(Credentials credentials) {
-		credentials.setPassword(this.passwordEncoder.encode(credentials.getPassword()));
-		return this.credentialsRepository.save(credentials);
-	}
+        public Credentials saveCredentials(Credentials credentials) {
+                credentials.setPassword(this.passwordEncoder.encode(credentials.getPassword()));
+                return this.credentialsRepository.save(credentials);
+        }
+
+        @Transactional
+        public Credentials updateCredentials(Credentials credentials, String rawPassword) {
+                if (StringUtils.hasText(rawPassword)) {
+                        credentials.setPassword(this.passwordEncoder.encode(rawPassword));
+                }
+                return this.credentialsRepository.save(credentials);
+        }
 	
 	public boolean existsByUsernameAndProjectId(String username, Long projectId) {
 	    return credentialsRepository.findByUsernameAndProjectId(username, projectId).isPresent();
@@ -74,13 +83,20 @@ public class CredentialsService {
 	    return credentialsRepository.findByRoleAndUserIsNull(role);
 	}*/
 	
-	public List<Credentials> findByRoleAndProjectId(String role, Long projectId) {
-	    return credentialsRepository.findByRoleAndProjectId(role, projectId);
-	}
-	
-	public Credentials findById(Long id) {
-		return credentialsRepository.findById(id).get();
-	}
+        public List<Credentials> findByRoleAndProjectId(String role, Long projectId) {
+            return credentialsRepository.findByRoleAndProjectId(role, projectId);
+        }
+
+        public List<Credentials> getProjectUsers(Long projectId) {
+                if (projectId == null) {
+                        return Collections.emptyList();
+                }
+                return credentialsRepository.findByProjectId(projectId);
+        }
+
+        public Credentials findById(Long id) {
+                return credentialsRepository.findById(id).get();
+        }
 
 
 }

--- a/src/main/java/it/sensorplatform/service/UserService.java
+++ b/src/main/java/it/sensorplatform/service/UserService.java
@@ -3,6 +3,8 @@ package it.sensorplatform.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import it.sensorplatform.dto.PersonalInfoForm;
+import it.sensorplatform.model.Credentials;
 import it.sensorplatform.model.User;
 import it.sensorplatform.repository.UserRepository;
 
@@ -19,9 +21,29 @@ public class UserService {
 		return userRepository.findAll();
 	}
 	
-	public User saveUser(User u) {
-		return userRepository.save(u);
-	}
+        public User saveUser(User u) {
+                return userRepository.save(u);
+        }
+
+        public User updatePersonalInfo(Credentials credentials, PersonalInfoForm form) {
+                if (credentials == null || form == null) {
+                        throw new IllegalArgumentException("Credentials and form must not be null");
+                }
+
+                User user = credentials.getUser();
+                if (user == null) {
+                        user = new User();
+                }
+
+                user.setName(form.getName());
+                user.setSurname(form.getSurname());
+                user.setDateOfBirth(form.getDateOfBirth());
+                user.setPhoneNumber(form.getPhoneNumber());
+
+                User savedUser = this.saveUser(user);
+                credentials.setUser(savedUser);
+                return savedUser;
+        }
 	
 	public void deleteUserById(Long id) {
 		userRepository.deleteById(id);


### PR DESCRIPTION
## Summary
- add PersonalInfoForm and CredentialsUpdateForm DTOs with validation rules for profile updates
- extend credentials repository and service with project-aware helpers and optional password encoding on updates
- introduce PersonalAreaController and UserService helper to manage personal data, username visibility, and project-scoped listings

## Testing
- ./mvnw -q test *(fails: unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cef9c927488327a78327bfe44f6e95