### PR TITLE
Add personal area template and styles

### DIFF
--- a/src/main/resources/static/css/personalArea.css
+++ b/src/main/resources/static/css/personalArea.css
@@ -1,0 +1,440 @@
+:root {
+    --font-family: 'Roboto', sans-serif;
+    --text-color: #1f2937;
+    --muted-text: #6b7280;
+    --background-color: #f6f7fb;
+    --card-background: #ffffff;
+    --border-color: rgba(148, 163, 184, 0.35);
+    --border-radius-lg: 18px;
+    --border-radius-sm: 12px;
+    --shadow-soft: 0 18px 32px rgba(15, 23, 42, 0.08);
+    --shadow-hover: 0 22px 42px rgba(15, 23, 42, 0.16);
+    --transition-base: 0.25s ease;
+    --success-color: #16a34a;
+    --error-color: #dc2626;
+    --primary-color: #2563eb;
+    --primary-rgb: 37, 99, 235;
+    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --primary-contrast: #ffffff;
+}
+
+body.personal-area {
+    font-family: var(--font-family);
+    margin: 0;
+    min-height: 100vh;
+    background: linear-gradient(145deg, var(--primary-soft), #eef2ff 60%, #ffffff 100%);
+    color: var(--text-color);
+    display: flex;
+    flex-direction: column;
+}
+
+body.theme-ltrad {
+    --primary-color: #2563eb;
+    --primary-rgb: 37, 99, 235;
+    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --primary-contrast: #ffffff;
+}
+
+body.theme-fire {
+    --primary-color: #ef4444;
+    --primary-rgb: 239, 68, 68;
+    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --primary-contrast: #ffffff;
+}
+
+body.theme-volcano {
+    --primary-color: #ea580c;
+    --primary-rgb: 234, 88, 12;
+    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --primary-contrast: #ffffff;
+}
+
+body.theme-superadmin {
+    --primary-color: #7c3aed;
+    --primary-rgb: 124, 58, 237;
+    --primary-soft: rgba(var(--primary-rgb), 0.14);
+    --primary-contrast: #ffffff;
+}
+
+.navbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1.2rem 2.5rem;
+    background: var(--primary-color);
+    color: var(--primary-contrast);
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.15);
+}
+
+.brand {
+    color: var(--primary-contrast);
+    font-weight: 700;
+    font-size: 1.3rem;
+    text-decoration: none;
+    letter-spacing: 0.02em;
+}
+
+.project-name {
+    margin-left: 1rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.18);
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.nav-right {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.home-button {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--primary-contrast);
+    display: grid;
+    place-items: center;
+    transition: background var(--transition-base), transform var(--transition-base);
+    text-decoration: none;
+}
+
+.home-button:hover {
+    background: rgba(255, 255, 255, 0.22);
+    transform: translateY(-1px);
+}
+
+.dropdown {
+    position: relative;
+}
+
+.dropdown-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 0.9rem;
+    border-radius: 999px;
+    border: none;
+    background: rgba(255, 255, 255, 0.16);
+    color: var(--primary-contrast);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background var(--transition-base), transform var(--transition-base);
+}
+
+.dropdown-toggle:hover {
+    background: rgba(255, 255, 255, 0.28);
+    transform: translateY(-1px);
+}
+
+.dropdown-icon {
+    pointer-events: none;
+}
+
+.dropdown-menu {
+    position: absolute;
+    right: 0;
+    top: calc(100% + 0.5rem);
+    display: none;
+    flex-direction: column;
+    gap: 0.4rem;
+    background: var(--card-background);
+    color: var(--text-color);
+    border-radius: var(--border-radius-sm);
+    min-width: 200px;
+    padding: 0.75rem;
+    box-shadow: var(--shadow-soft);
+}
+
+.dropdown-menu.show {
+    display: flex;
+}
+
+.dropdown-link,
+.dropdown-logout {
+    padding: 0.65rem 0.85rem;
+    border-radius: 10px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 0.95rem;
+    text-align: left;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background var(--transition-base);
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+    background: rgba(var(--primary-rgb), 0.08);
+}
+
+.personal-area-content {
+    width: min(1100px, 95%);
+    margin: 2.5rem auto 3rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.forms-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.75rem;
+}
+
+.card {
+    background: var(--card-background);
+    border-radius: var(--border-radius-lg);
+    padding: 1.8rem;
+    box-shadow: var(--shadow-soft);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.card:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-hover);
+}
+
+.card-header h2 {
+    margin: 0;
+    font-size: 1.35rem;
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
+.card-header p {
+    margin: 0.5rem 0 0;
+    color: var(--muted-text);
+    line-height: 1.5;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.form-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.25rem;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.form-group label {
+    font-weight: 500;
+    font-size: 0.95rem;
+}
+
+.form-group input,
+.project-selector select {
+    border-radius: var(--border-radius-sm);
+    border: 1px solid var(--border-color);
+    padding: 0.75rem 0.9rem;
+    font-size: 1rem;
+    background: #f8fafc;
+    transition: border-color var(--transition-base), box-shadow var(--transition-base);
+}
+
+.form-group input:focus,
+.project-selector select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.2);
+}
+
+.form-group.has-error input {
+    border-color: var(--error-color);
+    box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.18);
+}
+
+.error-message {
+    margin: 0;
+    color: var(--error-color);
+    font-size: 0.85rem;
+}
+
+.alert {
+    padding: 0.85rem 1rem;
+    border-radius: var(--border-radius-sm);
+    font-weight: 500;
+    font-size: 0.95rem;
+}
+
+.alert.success {
+    background: rgba(22, 163, 74, 0.1);
+    color: #15803d;
+    border: 1px solid rgba(22, 163, 74, 0.2);
+}
+
+.alert.error {
+    background: rgba(220, 38, 38, 0.1);
+    color: #b91c1c;
+    border: 1px solid rgba(220, 38, 38, 0.2);
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.primary-button,
+.secondary-button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.75rem 1.6rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
+}
+
+.primary-button {
+    background: var(--primary-color);
+    color: var(--primary-contrast);
+    box-shadow: 0 12px 22px rgba(var(--primary-rgb), 0.25);
+}
+
+.primary-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 28px rgba(var(--primary-rgb), 0.3);
+}
+
+.secondary-button {
+    background: rgba(var(--primary-rgb), 0.12);
+    color: var(--primary-color);
+}
+
+.secondary-button:hover {
+    background: rgba(var(--primary-rgb), 0.18);
+}
+
+.superadmin-panel {
+    display: grid;
+    grid-template-columns: 1fr;
+}
+
+.project-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+}
+
+.project-selector-controls {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.project-selector select {
+    flex: 1;
+    min-width: 210px;
+}
+
+.table-placeholder {
+    margin: 0;
+    color: var(--muted-text);
+    font-size: 0.95rem;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+.users-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-radius: var(--border-radius-sm);
+    overflow: hidden;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.users-table caption {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    color: var(--primary-color);
+    background: rgba(var(--primary-rgb), 0.08);
+}
+
+.users-table th,
+.users-table td {
+    padding: 0.85rem 1rem;
+    font-size: 0.95rem;
+    text-align: left;
+}
+
+.users-table thead {
+    background: rgba(var(--primary-rgb), 0.12);
+}
+
+.users-table tbody tr:nth-child(even) {
+    background: rgba(148, 163, 184, 0.08);
+}
+
+.users-table tbody tr:hover {
+    background: rgba(var(--primary-rgb), 0.14);
+}
+
+@media (max-width: 900px) {
+    .navbar {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+        padding: 1rem 1.5rem;
+    }
+
+    .nav-right {
+        align-self: stretch;
+        justify-content: space-between;
+        width: 100%;
+    }
+
+    .forms-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .personal-area-content {
+        margin: 1.5rem auto 2rem;
+        width: min(95%, 600px);
+    }
+
+    .card {
+        padding: 1.4rem;
+    }
+
+    .form-actions {
+        justify-content: stretch;
+    }
+
+    .primary-button,
+    .secondary-button {
+        width: 100%;
+    }
+
+    .project-selector-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .table-wrapper {
+        margin-top: 1rem;
+    }
+}

--- a/src/main/resources/templates/personalArea.html
+++ b/src/main/resources/templates/personalArea.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${activeProject != null ? activeProject.name + ' – Area Personale' : 'Area Personale'}">Area Personale</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/css/personalArea.css}">
+</head>
+
+<body class="personal-area"
+      th:with="theme=${selectedProjectId} == 1 ? 'theme-ltrad' :
+                    (${selectedProjectId} == 51 ? 'theme-fire' :
+                    (${selectedProjectId} == 101 ? 'theme-volcano' : 'theme-superadmin'))}"
+      th:classappend="' ' + ${theme}">
+    <header class="navbar">
+        <div class="nav-left">
+            <a class="brand" th:href="@{/}">AetherSense</a>
+            <span class="project-name" th:if="${activeProject != null}" th:text="${activeProject.name}">Project</span>
+            <span class="project-name" th:if="${activeProject == null}">Nessun progetto selezionato</span>
+        </div>
+        <div class="nav-right">
+            <a class="home-button" th:href="@{/}" title="Torna alla home">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
+                    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" fill="currentColor" />
+                </svg>
+            </a>
+            <div class="auth-user dropdown" sec:authorize="isAuthenticated()">
+                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                    Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                    <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                        <path d="M7 10l5 5 5-5z" fill="currentColor" />
+                    </svg>
+                </button>
+                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                    <a class="dropdown-link" th:href="@{'/personal-area'(projectId=${selectedProjectId})}">Area personale</a>
+                    <form th:action="@{/logout}" method="post" th:csrf="true">
+                        <button type="submit" class="dropdown-logout">Logout</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main class="personal-area-content">
+        <section class="forms-grid">
+            <article class="card">
+                <header class="card-header">
+                    <h2>Informazioni personali</h2>
+                    <p>Aggiorna i tuoi dati anagrafici per tenere l'account sempre allineato.</p>
+                </header>
+
+                <div th:if="${personalInfoSuccessMessage}" class="alert success" th:text="${personalInfoSuccessMessage}"></div>
+                <div th:if="${personalInfoErrorMessage}" class="alert error" th:text="${personalInfoErrorMessage}"></div>
+
+                <form th:action="@{/personal-area/update-info}" th:object="${personalInfoForm}" method="post" th:csrf="true" class="form">
+                    <input type="hidden" name="projectId" th:value="${selectedProjectId}" th:if="${isSuperadmin}" />
+
+                    <div class="form-row">
+                        <div class="form-group" th:classappend="${#fields.hasErrors('name')} ? ' has-error'">
+                            <label for="name">Nome</label>
+                            <input type="text" id="name" th:field="*{name}" maxlength="100" autocomplete="given-name" required />
+                            <p class="error-message" th:if="${#fields.hasErrors('name')}" th:errors="*{name}"></p>
+                        </div>
+                        <div class="form-group" th:classappend="${#fields.hasErrors('surname')} ? ' has-error'">
+                            <label for="surname">Cognome</label>
+                            <input type="text" id="surname" th:field="*{surname}" maxlength="100" autocomplete="family-name" required />
+                            <p class="error-message" th:if="${#fields.hasErrors('surname')}" th:errors="*{surname}"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group" th:classappend="${#fields.hasErrors('dateOfBirth')} ? ' has-error'">
+                            <label for="dateOfBirth">Data di nascita</label>
+                            <input type="date" id="dateOfBirth" th:field="*{dateOfBirth}" required
+                                   th:attr="max=${#temporals.format(#temporals.createNow(), 'yyyy-MM-dd')}" />
+                            <p class="error-message" th:if="${#fields.hasErrors('dateOfBirth')}" th:errors="*{dateOfBirth}"></p>
+                        </div>
+                        <div class="form-group" th:classappend="${#fields.hasErrors('phoneNumber')} ? ' has-error'">
+                            <label for="phoneNumber">Telefono</label>
+                            <input type="tel" id="phoneNumber" th:field="*{phoneNumber}" required inputmode="tel"
+                                   pattern="^\+?[0-9\s]{6,20}$" placeholder="+39 123 456 789" />
+                            <p class="error-message" th:if="${#fields.hasErrors('phoneNumber')}" th:errors="*{phoneNumber}"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="primary-button">Salva modifiche</button>
+                    </div>
+                </form>
+            </article>
+
+            <article class="card">
+                <header class="card-header">
+                    <h2>Credenziali di accesso</h2>
+                    <p>Gestisci username e password per proteggere il tuo account.</p>
+                </header>
+
+                <div th:if="${credentialsSuccessMessage}" class="alert success" th:text="${credentialsSuccessMessage}"></div>
+                <div th:if="${credentialsErrorMessage}" class="alert error" th:text="${credentialsErrorMessage}"></div>
+
+                <form th:action="@{/personal-area/update-credentials}" th:object="${credentialsUpdateForm}" method="post" th:csrf="true" class="form">
+                    <input type="hidden" name="projectId" th:value="${selectedProjectId}" th:if="${isSuperadmin}" />
+
+                    <div class="form-group" th:classappend="${#fields.hasErrors('username')} ? ' has-error'">
+                        <label for="username">Username visibile</label>
+                        <input type="text" id="username" th:field="*{username}" minlength="3" maxlength="50" autocomplete="username" required />
+                        <p class="error-message" th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></p>
+                    </div>
+
+                    <div class="form-row">
+                        <div class="form-group" th:classappend="${#fields.hasErrors('password')} ? ' has-error'">
+                            <label for="password">Nuova password</label>
+                            <input type="password" id="password" th:field="*{password}" autocomplete="new-password"
+                                   placeholder="Minimo 8 caratteri" />
+                            <p class="error-message" th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></p>
+                        </div>
+                        <div class="form-group" th:classappend="${#fields.hasErrors('confirmPassword')} ? ' has-error'">
+                            <label for="confirmPassword">Conferma password</label>
+                            <input type="password" id="confirmPassword" th:field="*{confirmPassword}" autocomplete="new-password" />
+                            <p class="error-message" th:if="${#fields.hasErrors('confirmPassword')}" th:errors="*{confirmPassword}"></p>
+                        </div>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="primary-button">Aggiorna credenziali</button>
+                    </div>
+                </form>
+            </article>
+        </section>
+
+        <section class="superadmin-panel" th:if="${isSuperadmin}">
+            <article class="card">
+                <header class="card-header">
+                    <h2>Gestione utenti progetto</h2>
+                    <p>Seleziona un progetto per visualizzare gli utenti associati.</p>
+                </header>
+
+                <form class="project-selector" th:action="@{/personal-area}" method="get">
+                    <label for="projectId">Progetto</label>
+                    <div class="project-selector-controls">
+                        <select id="projectId" name="projectId">
+                            <option value="" th:selected="${selectedProjectId} == null">Seleziona un progetto</option>
+                            <option th:each="project : ${projects}" th:value="${project.id}" th:text="${project.name}"
+                                    th:selected="${project.id} == ${selectedProjectId}"></option>
+                        </select>
+                        <button type="submit" class="secondary-button">Carica</button>
+                    </div>
+                </form>
+
+                <p class="table-placeholder" th:if="${selectedProjectId == null}">Seleziona un progetto per visualizzare gli utenti.</p>
+
+                <div class="table-wrapper" th:if="${selectedProjectId != null}">
+                    <table class="users-table">
+                        <caption th:text="${activeProject != null ? 'Utenti del progetto ' + activeProject.name : 'Utenti del progetto'}">Utenti del progetto</caption>
+                        <thead>
+                            <tr>
+                                <th scope="col">Username</th>
+                                <th scope="col">Email</th>
+                                <th scope="col">Ruolo</th>
+                                <th scope="col">Nome</th>
+                                <th scope="col">Cognome</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr th:if="${#lists.isEmpty(projectUsers)}">
+                                <td colspan="5">Nessun utente trovato per il progetto selezionato.</td>
+                            </tr>
+                            <tr th:each="projUser : ${projectUsers}">
+                                <td th:text="${projUser.visibleUsername != null ? projUser.visibleUsername : projUser.username}">username</td>
+                                <td th:text="${projUser.email}">email@example.com</td>
+                                <td th:text="${projUser.role}">Ruolo</td>
+                                <td th:text="${projUser.user != null ? projUser.user.name : '-'}">Nome</td>
+                                <td th:text="${projUser.user != null ? projUser.user.surname : '-'}">Cognome</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </article>
+        </section>
+    </main>
+
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const toggle = document.getElementById('userDropdown');
+            const menu = document.getElementById('userDropdownMenu');
+            if (!toggle || !menu) {
+                return;
+            }
+            toggle.addEventListener('click', function (event) {
+                event.stopPropagation();
+                const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                toggle.setAttribute('aria-expanded', (!isExpanded).toString());
+                menu.classList.toggle('show');
+            });
+            document.addEventListener('click', function (event) {
+                if (!menu.contains(event.target) && event.target !== toggle) {
+                    menu.classList.remove('show');
+                    toggle.setAttribute('aria-expanded', 'false');
+                }
+            });
+        });
+    </script>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary
- add a new personal area template with navbar, personal data and credentials forms, and superadmin project management tools
- create the dedicated stylesheet with responsive layout, cards, themed colour variables, and user table styling

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to download Maven binaries in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cefc8302d8832794095ed9bf29e4de