### PR TITLE
Add personal area dropdown navigation

### DIFF
--- a/src/main/resources/static/css/adminHome.css
+++ b/src/main/resources/static/css/adminHome.css
@@ -76,7 +76,87 @@ body {
 }
 
 .icon-button:hover {
-	color: #00BFFF;
+        color: #00BFFF;
+}
+
+/* Dropdown navigation */
+.dropdown {
+        position: relative;
+        display: inline-flex;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: #fff;
+        font-size: 0.95rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        cursor: pointer;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        width: 16px;
+        height: 16px;
+        transition: transform 0.3s ease;
+}
+
+.dropdown-toggle[aria-expanded="true"] .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: calc(100% + 0.75rem);
+        background-color: #0D1B2A;
+        border: 1px solid rgba(0, 191, 255, 0.5);
+        border-radius: 10px;
+        padding: 0.5rem;
+        min-width: 150px;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+        z-index: 10;
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        cursor: pointer;
+        transition: background-color 0.2s;
+}
+
+.dropdown-link {
+        display: block;
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        text-decoration: none;
+        cursor: pointer;
+        transition: background-color 0.2s;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(255, 255, 255, 0.12);
 }
 
 /* HERO */

--- a/src/main/resources/static/css/deviceDashboard.css
+++ b/src/main/resources/static/css/deviceDashboard.css
@@ -145,6 +145,26 @@
         transition: background-color 0.2s;
 }
 
+.dropdown-link {
+        display: block;
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        text-decoration: none;
+        cursor: pointer;
+        transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
         background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -132,6 +132,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/fireHome.css
+++ b/src/main/resources/static/css/fireHome.css
@@ -132,6 +132,26 @@ nav-left{
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/fireOperator.css
+++ b/src/main/resources/static/css/fireOperator.css
@@ -98,6 +98,27 @@ html, body {
   cursor: pointer;
   text-align: left;
 }
+
+.dropdown-link {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 0.95rem;
+  padding: 0.5rem;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+  background: rgba(255,255,255,.1);
+}
+
+
 .dropdown-logout:hover {
   background: rgba(255,255,255,.1);
 }

--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -127,6 +127,26 @@ body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -128,6 +128,26 @@ body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -124,6 +124,26 @@ body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/formRegisterOperatorFire.css
+++ b/src/main/resources/static/css/formRegisterOperatorFire.css
@@ -132,6 +132,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/formRegisterOperatorLtrad.css
+++ b/src/main/resources/static/css/formRegisterOperatorLtrad.css
@@ -49,6 +49,27 @@ html, body {
   width: 100%; background: none; border: none; color: white; font-size: 0.95rem;
   padding: 0.5rem; cursor: pointer; text-align: left; transition: background-color 0.2s;
 }
+
+.dropdown-link {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 0.95rem;
+  padding: 0.5rem;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+  background-color: rgba(255,255,255,0.1);
+}
+
+
 .dropdown-logout:hover { background-color: rgba(255,255,255,0.1); }
 
 /* ===== Layout pagina ===== */

--- a/src/main/resources/static/css/formRegisterOperatorVolcano.css
+++ b/src/main/resources/static/css/formRegisterOperatorVolcano.css
@@ -50,6 +50,27 @@ html, body {
   width: 100%; background: none; border: none; color: white; font-size: 0.95rem;
   padding: 0.5rem; cursor: pointer; text-align: left; transition: background-color 0.2s;
 }
+
+.dropdown-link {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 0.95rem;
+  padding: 0.5rem;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+  background-color: rgba(255,255,255,0.1);
+}
+
+
 .dropdown-logout:hover { background-color: rgba(255,255,255,0.1); }
 
 /* ===== Layout pagina ===== */

--- a/src/main/resources/static/css/home1.css
+++ b/src/main/resources/static/css/home1.css
@@ -69,7 +69,87 @@ body {
 }
 
 .icon-button:hover {
-	color: #00BFFF;
+        color: #00BFFF;
+}
+
+/* Dropdown navigation */
+.dropdown {
+        position: relative;
+        display: inline-flex;
+}
+
+.dropdown-toggle {
+        background: none;
+        border: none;
+        color: #fff;
+        font-size: 0.95rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        cursor: pointer;
+}
+
+.dropdown-toggle:focus {
+        outline: none;
+}
+
+.dropdown-icon {
+        width: 16px;
+        height: 16px;
+        transition: transform 0.3s ease;
+}
+
+.dropdown-toggle[aria-expanded="true"] .dropdown-icon {
+        transform: rotate(180deg);
+}
+
+.dropdown-menu {
+        display: none;
+        position: absolute;
+        right: 0;
+        top: calc(100% + 0.75rem);
+        background-color: #0D1B2A;
+        border: 1px solid rgba(0, 191, 255, 0.5);
+        border-radius: 10px;
+        padding: 0.5rem;
+        min-width: 150px;
+        box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+        z-index: 10;
+}
+
+.dropdown-menu.show {
+        display: block;
+}
+
+.dropdown-logout {
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        cursor: pointer;
+        transition: background-color 0.2s;
+}
+
+.dropdown-link {
+        display: block;
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        text-decoration: none;
+        cursor: pointer;
+        transition: background-color 0.2s;
+}
+
+.dropdown-link:hover,
+.dropdown-logout:hover {
+        background-color: rgba(255, 255, 255, 0.12);
 }
 
 /* HERO */

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -132,6 +132,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/ltradHome.css
+++ b/src/main/resources/static/css/ltradHome.css
@@ -132,6 +132,26 @@ nav-left{
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/ltradOperator.css
+++ b/src/main/resources/static/css/ltradOperator.css
@@ -131,6 +131,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/manageGroupsFire.css
+++ b/src/main/resources/static/css/manageGroupsFire.css
@@ -131,6 +131,26 @@ html, body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/manageGroupsLtrad.css
+++ b/src/main/resources/static/css/manageGroupsLtrad.css
@@ -131,6 +131,26 @@ html, body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/manageGroupsVolcano.css
+++ b/src/main/resources/static/css/manageGroupsVolcano.css
@@ -131,6 +131,26 @@ html, body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -134,6 +134,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -133,6 +133,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -128,6 +128,26 @@ html, body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
         background-color: rgba(255, 255, 255, 0.1);
 }
@@ -230,19 +250,37 @@ html, body {
 }
 
 .dropdown-logout {
-	width: 100%;
-	background: none;
-	border: none;
-	color: white;
-	font-size: 0.95rem;
-	padding: 0.5rem;
-	cursor: pointer;
-	text-align: left;
-	transition: background-color 0.2s;
+        width: 100%;
+        background: none;
+        border: none;
+        color: white;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        cursor: pointer;
+        text-align: left;
+        transition: background-color 0.2s;
+}
+
+.dropdown-link {
+        display: block;
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        font-size: 0.95rem;
+        padding: 0.5rem;
+        text-align: left;
+        text-decoration: none;
+        cursor: pointer;
+        transition: background-color 0.2s;
+}
+
+.dropdown-link:hover {
+        background-color: rgba(255, 255, 255, 0.1);
 }
 
 .dropdown-logout:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
 }
 
 .icon-user {

--- a/src/main/resources/static/css/updateDeviceFire.css
+++ b/src/main/resources/static/css/updateDeviceFire.css
@@ -131,6 +131,26 @@ html, body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/updateDeviceLtrad.css
+++ b/src/main/resources/static/css/updateDeviceLtrad.css
@@ -131,6 +131,26 @@ html, body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/updateDeviceVolcano.css
+++ b/src/main/resources/static/css/updateDeviceVolcano.css
@@ -131,6 +131,26 @@ html, body {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -132,6 +132,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/volcanoHome.css
+++ b/src/main/resources/static/css/volcanoHome.css
@@ -132,6 +132,26 @@ nav-left{
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/static/css/volcanoOperator.css
+++ b/src/main/resources/static/css/volcanoOperator.css
@@ -131,6 +131,26 @@ navbar h1 {
 	transition: background-color 0.2s;
 }
 
+.dropdown-link {
+	display: block;
+	width: 100%;
+	background: none;
+	border: none;
+	color: inherit;
+	font-size: 0.95rem;
+	padding: 0.5rem;
+	text-align: left;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background-color 0.2s;
+}
+
+
+.dropdown-link:hover {
+	background-color: rgba(255, 255, 255, 0.1);
+}
+
+
 .dropdown-logout:hover {
 	background-color: rgba(255, 255, 255, 0.1);
 }

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -20,16 +20,17 @@
                 </div>
                 <div class="nav-right">
                         <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-                                <button type="button" class="dropdown-toggle" id="userDropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
                                         Hi, <strong th:text="${user.visibleUsername}">utente</strong>
                                         <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16"
                                                 fill="white">
                                                 <path d="M7 10l5 5 5-5z" />
                                         </svg>
                                 </button>
-                                <div class="dropdown-menu" id="userDropdownMenu">
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
                                         <form th:action="@{/logout}" method="post" th:csrf="true">
-                                                <button type="submit" class="dropdown-logout">Logout</button>
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
                                         </form>
                                 </div>
                         </div>
@@ -156,13 +157,16 @@
                         if (!toggle || !menu) {
                                 return;
                         }
-                        toggle.addEventListener('click', function (e) {
-                                e.stopPropagation();
+                        toggle.addEventListener('click', function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                                toggle.setAttribute('aria-expanded', (!isExpanded).toString());
                                 menu.classList.toggle('show');
                         });
-                        document.addEventListener('click', function (e) {
-                                if (!toggle.contains(e.target)) {
+                        document.addEventListener('click', function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
                                         menu.classList.remove('show');
+                                        toggle.setAttribute('aria-expanded', 'false');
                                 }
                         });
                 }

--- a/src/main/resources/templates/admin/formRegisterOperator.html
+++ b/src/main/resources/templates/admin/formRegisterOperator.html
@@ -26,21 +26,22 @@
 					class="nav-title-link">VOLCANO</a></h1>
 
 		</div>
-		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                <div class="nav-right">
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 					<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -113,23 +114,30 @@
 			</section>
 	</main>
 
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			const toggle = document.getElementById("userDropdown");
-			const menu = document.getElementById("userDropdownMenu");
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
 
-			toggle.addEventListener("click", function (e) {
-				e.stopPropagation();
-				menu.classList.toggle("show");
-			});
+                        if (!toggle || !menu) {
+                                return;
+                        }
 
-			document.addEventListener("click", function (e) {
-				if (!toggle.contains(e.target)) {
-					menu.classList.remove("show");
-				}
-			});
-		});
-	</script>
+                        toggle.addEventListener("click", function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                menu.classList.toggle("show");
+                        });
+
+                        document.addEventListener("click", function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove("show");
+                                        toggle.setAttribute("aria-expanded", "false");
+                                }
+                        });
+                });
+        </script>
 </body>
 
 </html>

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -32,21 +32,22 @@
 					class="nav-title-link">VOLCANO</a></h1>
 
 		</div>
-		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                <div class="nav-right">
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 					<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -382,16 +383,21 @@
                                 renderPaginationControls();
                         }
 
-                        toggle.addEventListener("click", function (e) {
-                                e.stopPropagation();
-                                menu.classList.toggle("show");
-                        });
+                        if (toggle && menu) {
+                                toggle.addEventListener("click", function (event) {
+                                        event.stopPropagation();
+                                        const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                        toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                        menu.classList.toggle("show");
+                                });
 
-                        document.addEventListener("click", function (e) {
-                                if (!toggle.contains(e.target)) {
-                                        menu.classList.remove("show");
-                                }
-                        });
+                                document.addEventListener("click", function (event) {
+                                        if (!menu.contains(event.target) && event.target !== toggle) {
+                                                menu.classList.remove("show");
+                                                toggle.setAttribute("aria-expanded", "false");
+                                        }
+                                });
+                        }
 
                         initializeDevicesTablePagination();
                 });

--- a/src/main/resources/templates/admin/manageGroups.html
+++ b/src/main/resources/templates/admin/manageGroups.html
@@ -26,21 +26,22 @@
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 
 		</div>
-				<div class="nav-right">
-					<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-						<button type="button" class="dropdown-toggle" id="userDropdown">
-							Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-							<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-								height="16" fill="white">
-								<path d="M7 10l5 5 5-5z" />
-							</svg>
-						</button>
-						<div class="dropdown-menu" id="userDropdownMenu">
-							<form th:action="@{/logout}" method="post" th:csrf="true">
-								<button type="submit" class="dropdown-logout">Logout</button>
-							</form>
-						</div>
-					</div>
+                                <div class="nav-right">
+                                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                                height="16" fill="white">
+                                                                <path d="M7 10l5 5 5-5z" />
+                                                        </svg>
+                                                </button>
+                                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                                        </form>
+                                                </div>
+                                        </div>
 					<a href="/" class="home-button" title="Homepage">
 						<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 							<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -195,22 +196,29 @@ document.querySelectorAll('.toggle-add-list').forEach(button => {
 </script>
 
 <script>
-		document.addEventListener("DOMContentLoaded", function () {
-			const toggle = document.getElementById("userDropdown");
-			const menu = document.getElementById("userDropdownMenu");
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
 
-			toggle.addEventListener("click", function (e) {
-				e.stopPropagation();
-				menu.classList.toggle("show");
-			});
+                        if (!toggle || !menu) {
+                                return;
+                        }
 
-			document.addEventListener("click", function (e) {
-				if (!toggle.contains(e.target)) {
-					menu.classList.remove("show");
-				}
-			});
-		});
-	</script>
+                        toggle.addEventListener("click", function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                menu.classList.toggle("show");
+                        });
+
+                        document.addEventListener("click", function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove("show");
+                                        toggle.setAttribute("aria-expanded", "false");
+                                }
+                        });
+                });
+        </script>
 
 </body>
 </html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -15,23 +15,25 @@
 			<h1>AetherSense</h1>
 		</div>
 		<div class="nav-right">
-			<div class="auth-nav">
-				<!-- Utente autenticato -->
-				<div sec:authorize="isAuthenticated()" class="auth-user">
-					<span class="username">Hi, <strong th:text="${user.visibleUsername}">utente</strong></span>
-					<form th:action="@{/logout}" method="post" th:csrf="true" class="logout-form">
-						<button type="submit" class="icon-button" title="Logout">
-							<svg xmlns="http://www.w3.org/2000/svg" class="icon-user" viewBox="0 0 24 24"
-								fill="currentColor" width="24" height="24">
-								<path
-									d="M16 13v-2H7v-3l-5 4 5 4v-3zM20 3h-8v2h8v14h-8v2h8c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
-							</svg>
-						</button>
-					</form>
-				</div>
-			</div>
-		</div>
-	</header>
+                        <div class="auth-nav">
+                                <!-- Utente autenticato -->
+                                <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                        <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                                Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                                <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+                                                        <path d="M7 10l5 5 5-5z" />
+                                                </svg>
+                                        </button>
+                                        <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                                <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                                <form th:action="@{/logout}" method="post" th:csrf="true" class="logout-form">
+                                                        <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                                </form>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </header>
 
 	<section class="hero">
 		<video class="hero_video" autoplay muted loop playsinline preload="auto">
@@ -114,9 +116,34 @@
 		<p>Interested in our projects? <a href="https://www.4spark.it/" target="_blank">Contact us</a>.</p>
 	</section>
 
-	<footer>
-		<p>&copy; 2025 - 4Spark Sensor Platform</p>
-	</footer>
+        <footer>
+                <p>&copy; 2025 - 4Spark Sensor Platform</p>
+        </footer>
+
+        <script>
+        document.addEventListener('DOMContentLoaded', function () {
+                const toggle = document.getElementById('userDropdown');
+                const menu = document.getElementById('userDropdownMenu');
+
+                if (!toggle || !menu) {
+                        return;
+                }
+
+                toggle.addEventListener('click', function (event) {
+                        event.stopPropagation();
+                        const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                        toggle.setAttribute('aria-expanded', (!isExpanded).toString());
+                        menu.classList.toggle('show');
+                });
+
+                document.addEventListener('click', function (event) {
+                        if (!menu.contains(event.target) && event.target !== toggle) {
+                                menu.classList.remove('show');
+                                toggle.setAttribute('aria-expanded', 'false');
+                        }
+                });
+        });
+</script>
 
 </body>
 

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -25,20 +25,21 @@
 			</h1>
 		</div>
 		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<!--a href="/" class="home-button" title="Homepage"-->
 			<form th:action="@{/logout}" method="post" th:csrf="true">
 				<button type="submit" class="home-button" title="Logout and back to home">
@@ -191,18 +192,30 @@
 		});
 	</script>
 
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			const toggle = document.getElementById("userDropdown");
-			const menu = document.getElementById("userDropdownMenu");
-			toggle.addEventListener("click", function (e) {
-				e.stopPropagation(); menu.classList.toggle("show");
-			});
-			document.addEventListener("click", function (e) {
-				if (!toggle.contains(e.target)) {menu.classList.remove("show");}
-			});
-		});
-	</script>
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
+
+                        if (!toggle || !menu) {
+                                return;
+                        }
+
+                        toggle.addEventListener("click", function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                menu.classList.toggle("show");
+                        });
+
+                        document.addEventListener("click", function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove("show");
+                                        toggle.setAttribute("aria-expanded", "false");
+                                }
+                        });
+                });
+        </script>
 
 </body>
 

--- a/src/main/resources/templates/personalArea.html
+++ b/src/main/resources/templates/personalArea.html
@@ -34,9 +34,9 @@
                     </svg>
                 </button>
                 <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
-                    <a class="dropdown-link" th:href="@{'/personal-area'(projectId=${selectedProjectId})}">Area personale</a>
+                    <a class="dropdown-link" th:href="@{/personal-area}" role="menuitem">Personal Area</a>
                     <form th:action="@{/logout}" method="post" th:csrf="true">
-                        <button type="submit" class="dropdown-logout">Logout</button>
+                        <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
                     </form>
                 </div>
             </div>

--- a/src/main/resources/templates/project/fireHome.html
+++ b/src/main/resources/templates/project/fireHome.html
@@ -14,19 +14,20 @@
 		</div>
 		<div class="nav-right">
                         <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
                                         Hi, <strong th:text="${user != null ? user.visibleUsername : 'utente'}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 					<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -60,23 +61,30 @@
 		</section>
 	</main>
 
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			const toggle = document.getElementById("userDropdown");
-			const menu = document.getElementById("userDropdownMenu");
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
 
-			toggle.addEventListener("click", function (e) {
-				e.stopPropagation();
-				menu.classList.toggle("show");
-			});
+                        if (!toggle || !menu) {
+                                return;
+                        }
 
-			document.addEventListener("click", function (e) {
-				if (!toggle.contains(e.target)) {
-					menu.classList.remove("show");
-				}
-			});
-		});
-	</script>
+                        toggle.addEventListener("click", function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                menu.classList.toggle("show");
+                        });
+
+                        document.addEventListener("click", function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove("show");
+                                        toggle.setAttribute("aria-expanded", "false");
+                                }
+                        });
+                });
+        </script>
 </body>
 
 </html>

--- a/src/main/resources/templates/project/ltradHome.html
+++ b/src/main/resources/templates/project/ltradHome.html
@@ -14,19 +14,20 @@
 		</div>
 		<div class="nav-right">
                         <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
                                         Hi, <strong th:text="${user != null ? user.visibleUsername : 'utente'}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 					<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -73,24 +74,30 @@
 					drones</em> for rapid intervention.</p>
 		</section>
 	</main>
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			const toggle = document.getElementById("userDropdown");
-			const menu = document.getElementById("userDropdownMenu");
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
 
-			toggle.addEventListener("click", function (e) {
-				e.stopPropagation();
-				menu.classList.toggle("show");
-			});
+                        if (!toggle || !menu) {
+                                return;
+                        }
 
-			// Chiudi il menu cliccando altrove
-			document.addEventListener("click", function (e) {
-				if (!toggle.contains(e.target)) {
-					menu.classList.remove("show");
-				}
-			});
-		});
-	</script>
+                        toggle.addEventListener("click", function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                menu.classList.toggle("show");
+                        });
+
+                        document.addEventListener("click", function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove("show");
+                                        toggle.setAttribute("aria-expanded", "false");
+                                }
+                        });
+                });
+        </script>
 
 </body>
 

--- a/src/main/resources/templates/project/volcanoHome.html
+++ b/src/main/resources/templates/project/volcanoHome.html
@@ -16,19 +16,20 @@
 		</div>
 		<div class="nav-right">
                         <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
                                         Hi, <strong th:text="${user != null ? user.visibleUsername : 'utente'}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 					<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -57,23 +58,30 @@
 		</section>
 	</main>
 
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			const toggle = document.getElementById("userDropdown");
-			const menu = document.getElementById("userDropdownMenu");
+        <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                        const toggle = document.getElementById("userDropdown");
+                        const menu = document.getElementById("userDropdownMenu");
 
-			toggle.addEventListener("click", function (e) {
-				e.stopPropagation();
-				menu.classList.toggle("show");
-			});
+                        if (!toggle || !menu) {
+                                return;
+                        }
 
-			document.addEventListener("click", function (e) {
-				if (!toggle.contains(e.target)) {
-					menu.classList.remove("show");
-				}
-			});
-		});
-	</script>
+                        toggle.addEventListener("click", function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                menu.classList.toggle("show");
+                        });
+
+                        document.addEventListener("click", function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove("show");
+                                        toggle.setAttribute("aria-expanded", "false");
+                                }
+                        });
+                });
+        </script>
 </body>
 
 </html>

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -18,15 +18,16 @@
     </div>
     <div class="nav-right">
         <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-            <button type="button" class="dropdown-toggle" id="userDropdown">
+            <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
                 Hi, <strong th:text="${user.visibleUsername}">utente</strong>
                 <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="white">
                     <path d="M7 10l5 5 5-5z" />
                 </svg>
             </button>
-            <div class="dropdown-menu" id="userDropdownMenu">
+            <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
                 <form th:action="@{/logout}" method="post" th:csrf="true">
-                    <button type="submit" class="dropdown-logout">Logout</button>
+                    <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
                 </form>
             </div>
         </div>
@@ -172,13 +173,22 @@
     document.addEventListener("DOMContentLoaded", function () {
         const toggle = document.getElementById("userDropdown");
         const menu = document.getElementById("userDropdownMenu");
-        toggle.addEventListener("click", function (e) {
-            e.stopPropagation();
+
+        if (!toggle || !menu) {
+            return;
+        }
+
+        toggle.addEventListener("click", function (event) {
+            event.stopPropagation();
+            const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+            toggle.setAttribute("aria-expanded", (!isExpanded).toString());
             menu.classList.toggle("show");
         });
-        document.addEventListener("click", function (e) {
-            if (!toggle.contains(e.target)) {
+
+        document.addEventListener("click", function (event) {
+            if (!menu.contains(event.target) && event.target !== toggle) {
                 menu.classList.remove("show");
+                toggle.setAttribute("aria-expanded", "false");
             }
         });
     });

--- a/src/main/resources/templates/superadmin/formNewSpec.html
+++ b/src/main/resources/templates/superadmin/formNewSpec.html
@@ -28,21 +28,22 @@
 			<h1><a th:if="${project.id == 101}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"
 					class="nav-title-link"> VOLCANO</a></h1>
 		</div>
-		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                <div class="nav-right">
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 					<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -85,6 +86,30 @@
 		</form>
 	</div>
 
+        <script>
+                document.addEventListener('DOMContentLoaded', function () {
+                        const toggle = document.getElementById('userDropdown');
+                        const menu = document.getElementById('userDropdownMenu');
+
+                        if (!toggle || !menu) {
+                                return;
+                        }
+
+                        toggle.addEventListener('click', function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                                toggle.setAttribute('aria-expanded', (!isExpanded).toString());
+                                menu.classList.toggle('show');
+                        });
+
+                        document.addEventListener('click', function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove('show');
+                                        toggle.setAttribute('aria-expanded', 'false');
+                                }
+                        });
+                });
+        </script>
 </body>
 
 </html>

--- a/src/main/resources/templates/superadmin/formNewTod.html
+++ b/src/main/resources/templates/superadmin/formNewTod.html
@@ -27,21 +27,22 @@
 			<h1><a th:if="${project.id == 101}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"
 					class="nav-title-link"> VOLCANO</a></h1>
 		</div>
-		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-				<button type="button" class="dropdown-toggle" id="userDropdown">
-					Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-					<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-						height="16" fill="white">
-						<path d="M7 10l5 5 5-5z" />
-					</svg>
-				</button>
-				<div class="dropdown-menu" id="userDropdownMenu">
-					<form th:action="@{/logout}" method="post" th:csrf="true">
-						<button type="submit" class="dropdown-logout">Logout</button>
-					</form>
-				</div>
-			</div>
+                <div class="nav-right">
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                height="16" fill="white">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
 			<a href="/" class="home-button" title="Homepage">
 				<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 					<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -92,6 +93,30 @@
 		</form>
 	</div>
 
+        <script>
+                document.addEventListener('DOMContentLoaded', function () {
+                        const toggle = document.getElementById('userDropdown');
+                        const menu = document.getElementById('userDropdownMenu');
+
+                        if (!toggle || !menu) {
+                                return;
+                        }
+
+                        toggle.addEventListener('click', function (event) {
+                                event.stopPropagation();
+                                const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                                toggle.setAttribute('aria-expanded', (!isExpanded).toString());
+                                menu.classList.toggle('show');
+                        });
+
+                        document.addEventListener('click', function (event) {
+                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                        menu.classList.remove('show');
+                                        toggle.setAttribute('aria-expanded', 'false');
+                                }
+                        });
+                });
+        </script>
 </body>
 
 </html>

--- a/src/main/resources/templates/superadmin/formUpdateDevice.html
+++ b/src/main/resources/templates/superadmin/formUpdateDevice.html
@@ -23,20 +23,21 @@
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 		</div>
 			<div class="nav-right">
-				<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-					<button type="button" class="dropdown-toggle" id="userDropdown">
-						Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-						<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-							height="16" fill="white">
-							<path d="M7 10l5 5 5-5z" />
-						</svg>
-					</button>
-					<div class="dropdown-menu" id="userDropdownMenu">
-						<form th:action="@{/logout}" method="post" th:csrf="true">
-							<button type="submit" class="dropdown-logout">Logout</button>
-						</form>
-					</div>
-				</div>
+                                <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                        <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                                Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                                <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                        height="16" fill="white">
+                                                        <path d="M7 10l5 5 5-5z" />
+                                                </svg>
+                                        </button>
+                                        <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                                <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                                <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                        <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                                </form>
+                                        </div>
+                                </div>
 				<a href="/" class="home-button" title="Homepage">
 					<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 						<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -116,21 +117,26 @@
 			</div>
         </div>
     </div>
-	<script>
+        <script>
                                 document.addEventListener("DOMContentLoaded", function () {
                                         const toggle = document.getElementById("userDropdown");
                                         const menu = document.getElementById("userDropdownMenu");
 
-                                        toggle.addEventListener("click", function (e) {
-                                                e.stopPropagation();
-                                                menu.classList.toggle("show");
-                                        });
+                                        if (toggle && menu) {
+                                                toggle.addEventListener("click", function (event) {
+                                                        event.stopPropagation();
+                                                        const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                                        toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                                        menu.classList.toggle("show");
+                                                });
 
-                                        document.addEventListener("click", function (e) {
-                                                if (!toggle.contains(e.target)) {
-                                                        menu.classList.remove("show");
-                                                }
-                                        });
+                                                document.addEventListener("click", function (event) {
+                                                        if (!menu.contains(event.target) && event.target !== toggle) {
+                                                                menu.classList.remove("show");
+                                                                toggle.setAttribute("aria-expanded", "false");
+                                                        }
+                                                });
+                                        }
 
                                         const escapeRegExp = function (str) {
                                                 return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -29,21 +29,22 @@
 					<h1><a th:if="${project.id == 51}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link">FIRE</a></h1>
 					<h1><a th:if="${project.id == 101}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link"> VOLCANO</a></h1>
 				</div>
-				<div class="nav-right">
-					<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-						<button type="button" class="dropdown-toggle" id="userDropdown">
-							Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-							<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-								height="16" fill="white">
-								<path d="M7 10l5 5 5-5z" />
-							</svg>
-						</button>
-						<div class="dropdown-menu" id="userDropdownMenu">
-							<form th:action="@{/logout}" method="post" th:csrf="true">
-								<button type="submit" class="dropdown-logout">Logout</button>
-							</form>
-						</div>
-					</div>
+                                <div class="nav-right">
+                                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                                height="16" fill="white">
+                                                                <path d="M7 10l5 5 5-5z" />
+                                                        </svg>
+                                                </button>
+                                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                                        <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                                        </form>
+                                                </div>
+                                        </div>
 					<a href="/" class="home-button" title="Homepage">
 						<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 							<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -237,7 +238,6 @@
                 </div>
         </form>
 </div>
-</body>
 
 <script th:inline="javascript">
         /*<![CDATA[*/
@@ -444,15 +444,18 @@
                         }
 
                         if (toggle && menu) {
-                                toggle.addEventListener("click", function (e) {
-                                        e.stopPropagation();
+                                toggle.addEventListener("click", function (event) {
+                                        event.stopPropagation();
+                                        const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                        toggle.setAttribute("aria-expanded", (!isExpanded).toString());
                                         menu.classList.toggle("show");
                                 });
                         }
 
-                        document.addEventListener("click", function (e) {
-                                if (toggle && menu && !toggle.contains(e.target)) {
+                        document.addEventListener("click", function (event) {
+                                if (toggle && menu && !menu.contains(event.target) && event.target !== toggle) {
                                         menu.classList.remove("show");
+                                        toggle.setAttribute("aria-expanded", "false");
                                 }
                         });
 
@@ -591,4 +594,6 @@
                         initializeDevicesTablePagination();
                 });
         </script>
+
+</body>
 </html>

--- a/src/main/resources/templates/superadmin/superadminHome.html
+++ b/src/main/resources/templates/superadmin/superadminHome.html
@@ -16,20 +16,22 @@
 		<div class="nav-left">
 			<h1>AetherSense <span class="admin-label">SuperAdmin</span></h1>
 		</div>
-		<div class="nav-right">
-			<div sec:authorize="isAuthenticated()" class="auth-user">
-				<span class="username">Hi, <strong th:text="${user.visibleUsername}">utente</strong></span>
-				<form th:action="@{/logout}" method="post" th:csrf="true" class="logout-form">
-					<button type="submit" class="icon-button" title="Logout">
-						<svg xmlns="http://www.w3.org/2000/svg" class="icon-user" viewBox="0 0 24 24"
-							fill="currentColor" width="24" height="24">
-							<path
-								d="M16 13v-2H7v-3l-5 4 5 4v-3zM20 3h-8v2h8v14h-8v2h8c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z" />
-						</svg>
-					</button>
-				</form>
-			</div>
-		</div>
+                <div class="nav-right">
+                        <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                        Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                        <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
+                                                <path d="M7 10l5 5 5-5z" />
+                                        </svg>
+                                </button>
+                                <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                        <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                        <form th:action="@{/logout}" method="post" th:csrf="true" class="logout-form">
+                                                <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                        </form>
+                                </div>
+                        </div>
+                </div>
 	</header>
 	<section class="hero">
 		<video class="hero_video" autoplay muted loop playsinline preload="auto">
@@ -108,9 +110,34 @@
 		<p>Interested in our projects? <a href="https://www.4spark.it/" target="_blank">Contact us</a>.</p>
 	</section>
 
-	<footer>
-		<p>&copy; 2025 - 4Spark Sensor Platform</p>
-	</footer>
+        <footer>
+                <p>&copy; 2025 - 4Spark Sensor Platform</p>
+        </footer>
+
+        <script>
+        document.addEventListener('DOMContentLoaded', function () {
+                const toggle = document.getElementById('userDropdown');
+                const menu = document.getElementById('userDropdownMenu');
+
+                if (!toggle || !menu) {
+                        return;
+                }
+
+                toggle.addEventListener('click', function (event) {
+                        event.stopPropagation();
+                        const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+                        toggle.setAttribute('aria-expanded', (!isExpanded).toString());
+                        menu.classList.toggle('show');
+                });
+
+                document.addEventListener('click', function (event) {
+                        if (!menu.contains(event.target) && event.target !== toggle) {
+                                menu.classList.remove('show');
+                                toggle.setAttribute('aria-expanded', 'false');
+                        }
+                });
+        });
+</script>
 
 </body>
 

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -24,21 +24,22 @@
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 
 		</div>
-			<div class="nav-right">
-				<div sec:authorize="isAuthenticated()" class="auth-user dropdown">
-					<button type="button" class="dropdown-toggle" id="userDropdown">
-						Hi, <strong th:text="${user.visibleUsername}">utente</strong>
-						<svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
-							height="16" fill="white">
-							<path d="M7 10l5 5 5-5z" />
-						</svg>
-					</button>
-					<div class="dropdown-menu" id="userDropdownMenu">
-						<form th:action="@{/logout}" method="post" th:csrf="true">
-							<button type="submit" class="dropdown-logout">Logout</button>
-						</form>
-					</div>
-				</div>
+                        <div class="nav-right">
+                                <div sec:authorize="isAuthenticated()" class="auth-user dropdown">
+                                        <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
+                                                Hi, <strong th:text="${user.visibleUsername}">utente</strong>
+                                                <svg class="dropdown-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16"
+                                                        height="16" fill="white">
+                                                        <path d="M7 10l5 5 5-5z" />
+                                                </svg>
+                                        </button>
+                                        <div class="dropdown-menu" id="userDropdownMenu" role="menu" aria-labelledby="userDropdown">
+                                                <a th:href="@{/personal-area}" class="dropdown-link" role="menuitem">Personal Area</a>
+                                                <form th:action="@{/logout}" method="post" th:csrf="true">
+                                                        <button type="submit" class="dropdown-logout" role="menuitem">Logout</button>
+                                                </form>
+                                        </div>
+                                </div>
 				<a href="/" class="home-button" title="Homepage">
 					<svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24">
 						<path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
@@ -119,21 +120,26 @@
         </div>
     </div>
 	
-	<script>
+        <script>
                         document.addEventListener("DOMContentLoaded", function () {
                                 const toggle = document.getElementById("userDropdown");
                                 const menu = document.getElementById("userDropdownMenu");
 
-                                toggle.addEventListener("click", function (e) {
-                                        e.stopPropagation();
-                                        menu.classList.toggle("show");
-                                });
+                                if (toggle && menu) {
+                                        toggle.addEventListener("click", function (event) {
+                                                event.stopPropagation();
+                                                const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+                                                toggle.setAttribute("aria-expanded", (!isExpanded).toString());
+                                                menu.classList.toggle("show");
+                                        });
 
-                                document.addEventListener("click", function (e) {
-                                        if (!toggle.contains(e.target)) {
-                                                menu.classList.remove("show");
-                                        }
-                                });
+                                        document.addEventListener("click", function (event) {
+                                                if (!menu.contains(event.target) && event.target !== toggle) {
+                                                        menu.classList.remove("show");
+                                                        toggle.setAttribute("aria-expanded", "false");
+                                                }
+                                        });
+                                }
 
                                 const escapeRegExp = function (str) {
                                         return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
## Summary
- replace the home and superadmin headers with a shared dropdown that exposes the Personal Area link before logout
- inject the same Personal Area entry and accessible toggle script in every template that renders a dropdown menu
- extend each themed stylesheet with the new `.dropdown-link` rules and add dropdown styling for the public and admin home pages

## Testing
- ./mvnw -q -DskipTests compile *(fails: network access to Maven Central is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cefeb91f208327b2b63dea031b9347