### PR TITLE
Fix project resolution exception handling multi-catch

### DIFF
--- a/src/main/java/it/sensorplatform/controller/PersonalAreaController.java
+++ b/src/main/java/it/sensorplatform/controller/PersonalAreaController.java
@@ -220,7 +220,9 @@ public class PersonalAreaController {
         }
         try {
             return projectService.getProjectById(projectId);
-        } catch (NoSuchElementException | RuntimeException ex) {
+        } catch (NoSuchElementException ex) {
+            return null;
+        } catch (RuntimeException ex) {
             return null;
         }
     }


### PR DESCRIPTION
## Summary
- split the resolveProject multi-catch clause into ordered catches to avoid subclass conflicts during compilation

## Testing
- ./mvnw -DskipTests compile *(fails: Maven wrapper cannot download Maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cf06c222648327a923146b7a7d7eb6