### PR TITLE
Restyle personal area with dark themes

### DIFF
--- a/src/main/resources/static/css/personalArea.css
+++ b/src/main/resources/static/css/personalArea.css
@@ -1,59 +1,66 @@
 :root {
     --font-family: 'Roboto', sans-serif;
-    --text-color: #1f2937;
-    --muted-text: #6b7280;
-    --background-color: #f6f7fb;
-    --card-background: #ffffff;
-    --border-color: rgba(148, 163, 184, 0.35);
+    --text-color: #e2e8f0;
+    --muted-text: #94a3b8;
+    --background-color: #1b263b;
+    --card-background: #243b53;
+    --surface-elevated: #2d3e5f;
+    --input-background: #1a2b44;
+    --border-color: rgba(148, 163, 184, 0.45);
     --border-radius-lg: 18px;
     --border-radius-sm: 12px;
-    --shadow-soft: 0 18px 32px rgba(15, 23, 42, 0.08);
-    --shadow-hover: 0 22px 42px rgba(15, 23, 42, 0.16);
+    --shadow-soft: 0 18px 32px rgba(8, 15, 32, 0.45);
+    --shadow-hover: 0 24px 46px rgba(8, 15, 32, 0.55);
     --transition-base: 0.25s ease;
-    --success-color: #16a34a;
-    --error-color: #dc2626;
-    --primary-color: #2563eb;
-    --primary-rgb: 37, 99, 235;
-    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --success-color: #22c55e;
+    --error-color: #f87171;
+    --primary-color: #007bff;
+    --primary-rgb: 0, 123, 255;
+    --primary-soft: rgba(var(--primary-rgb), 0.18);
     --primary-contrast: #ffffff;
+    --primary-border: #8ec4ff;
 }
 
 body.personal-area {
     font-family: var(--font-family);
     margin: 0;
     min-height: 100vh;
-    background: linear-gradient(145deg, var(--primary-soft), #eef2ff 60%, #ffffff 100%);
+    background-color: var(--background-color);
     color: var(--text-color);
     display: flex;
     flex-direction: column;
 }
 
 body.theme-ltrad {
-    --primary-color: #2563eb;
-    --primary-rgb: 37, 99, 235;
-    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --primary-color: #007bff;
+    --primary-rgb: 0, 123, 255;
+    --primary-soft: rgba(var(--primary-rgb), 0.18);
     --primary-contrast: #ffffff;
+    --primary-border: #8ec4ff;
 }
 
 body.theme-fire {
-    --primary-color: #ef4444;
-    --primary-rgb: 239, 68, 68;
-    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --primary-color: #cc0000;
+    --primary-rgb: 204, 0, 0;
+    --primary-soft: rgba(var(--primary-rgb), 0.18);
     --primary-contrast: #ffffff;
+    --primary-border: #ff8e8e;
 }
 
 body.theme-volcano {
-    --primary-color: #ea580c;
-    --primary-rgb: 234, 88, 12;
-    --primary-soft: rgba(var(--primary-rgb), 0.12);
+    --primary-color: #e67e00;
+    --primary-rgb: 230, 126, 0;
+    --primary-soft: rgba(var(--primary-rgb), 0.18);
     --primary-contrast: #ffffff;
+    --primary-border: #ffbf80;
 }
 
 body.theme-superadmin {
     --primary-color: #7c3aed;
     --primary-rgb: 124, 58, 237;
-    --primary-soft: rgba(var(--primary-rgb), 0.14);
+    --primary-soft: rgba(var(--primary-rgb), 0.2);
     --primary-contrast: #ffffff;
+    --primary-border: #c4b5fd;
 }
 
 .navbar {
@@ -67,7 +74,8 @@ body.theme-superadmin {
     position: sticky;
     top: 0;
     z-index: 20;
-    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.15);
+    box-shadow: 0 12px 28px rgba(8, 15, 32, 0.45);
+    border-bottom: 2px solid var(--primary-border);
 }
 
 .brand {
@@ -80,11 +88,13 @@ body.theme-superadmin {
 
 .project-name {
     margin-left: 1rem;
-    padding: 0.35rem 0.75rem;
+    padding: 0.4rem 0.9rem;
     border-radius: 999px;
-    background: rgba(255, 255, 255, 0.18);
+    background: rgba(var(--primary-rgb), 0.22);
+    border: 1px solid var(--primary-border);
     font-size: 0.9rem;
-    font-weight: 500;
+    font-weight: 600;
+    color: var(--primary-contrast);
 }
 
 .nav-right {
@@ -98,7 +108,7 @@ body.theme-superadmin {
     height: 42px;
     border-radius: 50%;
     border: 1px solid rgba(255, 255, 255, 0.35);
-    background: rgba(255, 255, 255, 0.12);
+    background: rgba(0, 0, 0, 0.18);
     color: var(--primary-contrast);
     display: grid;
     place-items: center;
@@ -121,16 +131,16 @@ body.theme-superadmin {
     gap: 0.5rem;
     padding: 0.65rem 0.9rem;
     border-radius: 999px;
-    border: none;
-    background: rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(var(--primary-rgb), 0.35);
+    background: rgba(var(--primary-rgb), 0.2);
     color: var(--primary-contrast);
-    font-weight: 500;
+    font-weight: 600;
     cursor: pointer;
     transition: background var(--transition-base), transform var(--transition-base);
 }
 
 .dropdown-toggle:hover {
-    background: rgba(255, 255, 255, 0.28);
+    background: rgba(var(--primary-rgb), 0.32);
     transform: translateY(-1px);
 }
 
@@ -145,12 +155,13 @@ body.theme-superadmin {
     display: none;
     flex-direction: column;
     gap: 0.4rem;
-    background: var(--card-background);
+    background: var(--surface-elevated);
     color: var(--text-color);
     border-radius: var(--border-radius-sm);
     min-width: 200px;
     padding: 0.75rem;
     box-shadow: var(--shadow-soft);
+    border: 1px solid rgba(var(--primary-rgb), 0.35);
 }
 
 .dropdown-menu.show {
@@ -173,7 +184,7 @@ body.theme-superadmin {
 
 .dropdown-link:hover,
 .dropdown-logout:hover {
-    background: rgba(var(--primary-rgb), 0.08);
+    background: rgba(var(--primary-rgb), 0.2);
 }
 
 .personal-area-content {
@@ -192,6 +203,7 @@ body.theme-superadmin {
 
 .card {
     background: var(--card-background);
+    border: 1px solid var(--border-color);
     border-radius: var(--border-radius-lg);
     padding: 1.8rem;
     box-shadow: var(--shadow-soft);
@@ -240,6 +252,7 @@ body.theme-superadmin {
 .form-group label {
     font-weight: 500;
     font-size: 0.95rem;
+    color: var(--muted-text);
 }
 
 .form-group input,
@@ -248,20 +261,22 @@ body.theme-superadmin {
     border: 1px solid var(--border-color);
     padding: 0.75rem 0.9rem;
     font-size: 1rem;
-    background: #f8fafc;
-    transition: border-color var(--transition-base), box-shadow var(--transition-base);
+    background: var(--input-background);
+    color: var(--text-color);
+    transition: border-color var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
 }
 
 .form-group input:focus,
 .project-selector select:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.2);
+    box-shadow: 0 0 0 3px rgba(var(--primary-rgb), 0.3);
+    background: var(--surface-elevated);
 }
 
 .form-group.has-error input {
     border-color: var(--error-color);
-    box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.18);
+    box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.28);
 }
 
 .error-message {
@@ -278,15 +293,15 @@ body.theme-superadmin {
 }
 
 .alert.success {
-    background: rgba(22, 163, 74, 0.1);
-    color: #15803d;
-    border: 1px solid rgba(22, 163, 74, 0.2);
+    background: rgba(34, 197, 94, 0.16);
+    color: #4ade80;
+    border: 1px solid rgba(34, 197, 94, 0.4);
 }
 
 .alert.error {
-    background: rgba(220, 38, 38, 0.1);
-    color: #b91c1c;
-    border: 1px solid rgba(220, 38, 38, 0.2);
+    background: rgba(248, 113, 113, 0.16);
+    color: #fca5a5;
+    border: 1px solid rgba(248, 113, 113, 0.4);
 }
 
 .form-actions {
@@ -296,18 +311,18 @@ body.theme-superadmin {
 
 .primary-button,
 .secondary-button {
-    border: none;
     border-radius: 999px;
     padding: 0.75rem 1.6rem;
     font-weight: 600;
     cursor: pointer;
-    transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base);
+    transition: transform var(--transition-base), box-shadow var(--transition-base), background var(--transition-base), color var(--transition-base);
 }
 
 .primary-button {
     background: var(--primary-color);
     color: var(--primary-contrast);
     box-shadow: 0 12px 22px rgba(var(--primary-rgb), 0.25);
+    border: 1px solid rgba(var(--primary-rgb), 0.45);
 }
 
 .primary-button:hover {
@@ -316,12 +331,14 @@ body.theme-superadmin {
 }
 
 .secondary-button {
-    background: rgba(var(--primary-rgb), 0.12);
-    color: var(--primary-color);
+    background: rgba(var(--primary-rgb), 0.18);
+    color: var(--primary-contrast);
+    border: 1px solid var(--primary-border);
 }
 
 .secondary-button:hover {
-    background: rgba(var(--primary-rgb), 0.18);
+    background: rgba(var(--primary-rgb), 0.3);
+    color: var(--primary-contrast);
 }
 
 .superadmin-panel {
@@ -354,6 +371,9 @@ body.theme-superadmin {
 
 .table-wrapper {
     overflow-x: auto;
+    border-radius: var(--border-radius-sm);
+    border: 1px solid var(--border-color);
+    background: rgba(15, 25, 43, 0.65);
 }
 
 .users-table {
@@ -361,15 +381,16 @@ body.theme-superadmin {
     border-collapse: collapse;
     border-radius: var(--border-radius-sm);
     overflow: hidden;
-    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+    background: transparent;
+    color: var(--text-color);
 }
 
 .users-table caption {
     text-align: left;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    color: var(--primary-color);
-    background: rgba(var(--primary-rgb), 0.08);
+    color: var(--primary-contrast);
+    background: rgba(var(--primary-rgb), 0.25);
 }
 
 .users-table th,
@@ -377,18 +398,19 @@ body.theme-superadmin {
     padding: 0.85rem 1rem;
     font-size: 0.95rem;
     text-align: left;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.15);
 }
 
 .users-table thead {
-    background: rgba(var(--primary-rgb), 0.12);
+    background: rgba(var(--primary-rgb), 0.22);
 }
 
 .users-table tbody tr:nth-child(even) {
-    background: rgba(148, 163, 184, 0.08);
+    background: rgba(15, 23, 42, 0.35);
 }
 
 .users-table tbody tr:hover {
-    background: rgba(var(--primary-rgb), 0.14);
+    background: rgba(var(--primary-rgb), 0.22);
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
## Summary
- switch the personal area layout to the shared dark background with updated surface, text and border colors
- align ltrad, fire, volcano and superadmin theme variables with the respective home pages and apply them to navigation and badges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf0c35c39c8327accab46fa718a124