### PR TITLE
Align personal area navbar with project headers

### DIFF
--- a/src/main/resources/static/css/personalArea.css
+++ b/src/main/resources/static/css/personalArea.css
@@ -76,28 +76,20 @@ body.theme-superadmin {
     display: flex;
     align-items: center;
     gap: 1.5rem;
-    margin-left: 3rem;
-}
-
-.brand {
-    color: var(--primary-contrast);
-    font-weight: 700;
-    font-size: 1.6rem;
-    text-decoration: none;
-    letter-spacing: 0.02em;
-}
-
-.project-name {
-    font-size: 2rem;
-    font-weight: 600;
-    color: var(--primary-contrast);
 }
 
 .nav-right {
     display: flex;
     align-items: center;
     gap: 1rem;
-    margin-right: 3rem;
+}
+
+#navbar h1 {
+    margin: 0;
+    margin-left: 3rem;
+    font-size: 2rem;
+    font-weight: 600;
+    color: var(--primary-contrast);
 }
 
 .home-button {
@@ -110,6 +102,12 @@ body.theme-superadmin {
 
 .home-button:hover {
     color: rgba(255, 255, 255, 0.85);
+}
+
+.icon-home {
+    fill: currentColor;
+    width: 24px;
+    height: 24px;
 }
 
 .dropdown {

--- a/src/main/resources/templates/personalArea.html
+++ b/src/main/resources/templates/personalArea.html
@@ -14,18 +14,11 @@
                     (selectedProjectId == 51 ? 'theme-fire' :
                     (selectedProjectId == 101 ? 'theme-volcano' : 'theme-superadmin'))}"
       th:classappend="' ' + ${theme}">
-    <header class="navbar">
+    <header id="navbar" class="navbar">
         <div class="nav-left">
-            <a class="brand" th:href="@{/}">AetherSense</a>
-            <span class="project-name" th:if="${activeProject != null}" th:text="${activeProject.name}">Project</span>
-            <span class="project-name" th:if="${activeProject == null}">Nessun progetto selezionato</span>
+            <h1 th:text="${activeProject != null ? activeProject.name : (isSuperadmin ? 'AetherSense' : 'Area Personale')}">AetherSense</h1>
         </div>
         <div class="nav-right">
-            <a class="home-button" th:href="@{/}" title="Torna alla home">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" aria-hidden="true">
-                    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" fill="currentColor" />
-                </svg>
-            </a>
             <div class="auth-user dropdown" sec:authorize="isAuthenticated()">
                 <button type="button" class="dropdown-toggle" id="userDropdown" aria-haspopup="true" aria-expanded="false">
                     Hi, <strong th:text="${user.visibleUsername}">utente</strong>
@@ -40,6 +33,11 @@
                     </form>
                 </div>
             </div>
+            <a class="home-button" th:href="@{/}" title="Torna alla home">
+                <svg xmlns="http://www.w3.org/2000/svg" class="icon-home" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" fill="currentColor" />
+                </svg>
+            </a>
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- update the personal area navbar markup to match the project home layout and show a single project title heading with a superadmin fallback
- reorder the action buttons so the home shortcut mirrors the project home pages and reuse the shared icon styling
- refresh the personal area header styles to rely on the shared #navbar h1 rules and align spacing, colors, and typography with the homes

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cf13d4c7b88327985c5b1d02fbbb94