### PR TITLE
Adjust project users table heading markup

### DIFF
--- a/src/main/resources/static/css/personalArea.css
+++ b/src/main/resources/static/css/personalArea.css
@@ -360,6 +360,15 @@ body.theme-superadmin {
     background: var(--panel-background);
 }
 
+.table-title {
+    margin: 0;
+    text-align: left;
+    padding: 0.75rem 1rem;
+    font-weight: 600;
+    color: var(--primary-contrast);
+    background: rgba(var(--primary-rgb), 0.25);
+}
+
 .users-table {
     width: 100%;
     border-collapse: collapse;
@@ -367,14 +376,6 @@ body.theme-superadmin {
     overflow: hidden;
     background: transparent;
     color: var(--text-color);
-}
-
-.users-table caption {
-    text-align: left;
-    padding: 0.75rem 1rem;
-    font-weight: 600;
-    color: var(--primary-contrast);
-    background: rgba(var(--primary-rgb), 0.25);
 }
 
 .users-table th,

--- a/src/main/resources/templates/personalArea.html
+++ b/src/main/resources/templates/personalArea.html
@@ -150,8 +150,8 @@
                 <p class="table-placeholder" th:if="${selectedProjectId == null}">Seleziona un progetto per visualizzare gli utenti.</p>
 
                 <div class="table-wrapper" th:if="${selectedProjectId != null}">
+                    <h3 class="table-title" th:text="${activeProject != null ? 'Utenti del progetto ' + activeProject.name : 'Utenti del progetto'}">Utenti del progetto</h3>
                     <table class="users-table">
-                        <caption th:text="${activeProject != null ? 'Utenti del progetto ' + activeProject.name : 'Utenti del progetto'}">Utenti del progetto</caption>
                         <thead>
                             <tr>
                                 <th scope="col">Username</th>


### PR DESCRIPTION
## Summary
- replace the project users table caption with a themed heading above the table while preserving the Thymeleaf binding
- add styling for the new `.table-title` class so the heading retains the previous padding and background treatment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf15bc70e08327bb6789fefe162fd8