### PR TITLE
Replace device status flag with activated boolean

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -259,11 +259,11 @@ public class DeviceController {
                 if (latitude != null && longitude != null) {
                         device.setLatitude(latitude);
                         device.setLongitude(longitude);
-                        device.setStatus("activated");
+                        device.setActivated(true);
                 } else {
                         device.setLatitude(null);
                         device.setLongitude(null);
-                        device.setStatus("deactivated");
+                        device.setActivated(false);
                 }
 
                 // Salvataggio
@@ -341,11 +341,11 @@ public class DeviceController {
                 if (latitude != null && longitude != null) {
                         device.setLatitude(latitude);
                         device.setLongitude(longitude);
-                        device.setStatus("activated");
+                        device.setActivated(true);
                 } else {
                         device.setLatitude(null);
                         device.setLongitude(null);
-                        device.setStatus("deactivated");
+                        device.setActivated(false);
                 }
 
                 // Salvataggio
@@ -468,7 +468,7 @@ public class DeviceController {
                 d.setOperator(null);
                 d.setLatitude(null);
                 d.setLongitude(null);
-                d.setStatus("deactivated");
+                d.setActivated(false);
                 deviceService.save(d);
                 ra.addFlashAttribute("successMessage", "Operator removed.");
                 return "redirect:/admin/group/"+projectId;
@@ -532,7 +532,7 @@ public class DeviceController {
         public void loadDeviceDTO(List<Device> devices, Model model) {
                 List<DeviceDTO> deviceDTOs = devices.stream().map(d -> new DeviceDTO(d.getId(), d.getName(),
                                 d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(),
-                                d.getTod() != null ? d.getTod().getName() : null, d.getVisibleUsername(), d.getStatus(),
+                                d.getTod() != null ? d.getTod().getName() : null, d.getVisibleUsername(), d.isActivated(),
                                 d.getGsheet()))
                                 .collect(Collectors.toList());
                 Comparator<DeviceDTO> cmp = Comparator.comparing(DeviceDTO::getEmailOwner,

--- a/src/main/java/it/sensorplatform/controller/GroupController.java
+++ b/src/main/java/it/sensorplatform/controller/GroupController.java
@@ -301,7 +301,7 @@ private AdminService adminService;
                 });
                 List<DeviceDTO> deviceDTOs = orderedDevices.stream().map(d -> new DeviceDTO(d.getId(), d.getName(),
                                 d.getMacAddress(), d.getEmailOwner(), d.getDevEui(), d.getLongitude(), d.getLatitude(),
-                                d.getTod() != null ? d.getTod().getName() : null, d.getVisibleUsername(), d.getStatus(),
+                                d.getTod() != null ? d.getTod().getName() : null, d.getVisibleUsername(), d.isActivated(),
                                 d.getGsheet()))
                                 .collect(Collectors.toList());
                 model.addAttribute("devices", deviceDTOs);

--- a/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/GroupControllerRest.java
@@ -43,7 +43,7 @@ public class GroupControllerRest {
                         d.getLatitude(),
                         d.getTod() != null ? d.getTod().getName() : null,
                         d.getVisibleUsername(),
-                        d.getStatus(),
+                        d.isActivated(),
                         d.getGsheet()))
                 .collect(Collectors.toList());
     }
@@ -64,7 +64,7 @@ public class GroupControllerRest {
                         d.getLatitude(),
                         d.getTod() != null ? d.getTod().getName() : null,
                         d.getVisibleUsername(),
-                        d.getStatus(),
+                        d.isActivated(),
                         d.getGsheet()))
                 .collect(Collectors.toList());
     }
@@ -86,7 +86,7 @@ public class GroupControllerRest {
                 device.getLatitude(),
                 device.getTod() != null ? device.getTod().getName() : null,
                 device.getVisibleUsername(),
-                device.getStatus(),
+                device.isActivated(),
                 device.getGsheet()
             ))
             .toList();

--- a/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
+++ b/src/main/java/it/sensorplatform/controller/rest/NotificationControllerRest.java
@@ -99,10 +99,10 @@ public class NotificationControllerRest {
         device.setDevEui(normalizedDevEui);
         device.setProject(project);
         device.setTod(tod);
-        device.setStatus("deactivated");
+        device.setActivated(false);
         try {
             Device savedDevice = deviceRepository.save(device);
-            logger.info("Persisted device with id {} and status {}", savedDevice.getId(), savedDevice.getStatus());
+            logger.info("Persisted device with id {} and activated {}", savedDevice.getId(), savedDevice.isActivated());
             return ResponseEntity.ok().build();
         } catch (DataIntegrityViolationException e) {
             logger.warn("Conflict saving device with MAC {} and DevEUI {}", macAddress, notif.getDevEui(), e);

--- a/src/main/java/it/sensorplatform/dto/DeviceDTO.java
+++ b/src/main/java/it/sensorplatform/dto/DeviceDTO.java
@@ -14,10 +14,10 @@ public class DeviceDTO {
         private String devEui;
         private String tod;
         private String operator;
-        private String status;
+        private boolean activated;
         private String gsheet;
 
-        public DeviceDTO(Long id, String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator, String status, String gsheet) {
+        public DeviceDTO(Long id, String name, String macAddress, String emailOwner, String devEui, Double longitude, Double latitude, String tod, String operator, boolean activated, String gsheet) {
                 this.id = id;
                 this.name = name;
                 this.macAddress = macAddress;
@@ -27,7 +27,7 @@ public class DeviceDTO {
                 this.latitude = latitude;
                 this.tod=tod;
                 this.operator=operator;
-                this.status = status;
+                this.activated = activated;
                 this.gsheet = gsheet;
         }
 
@@ -114,12 +114,12 @@ public class DeviceDTO {
                 this.operator = operator;
         }
 
-        public String getStatus() {
-                return status;
+        public boolean isActivated() {
+                return activated;
         }
 
-        public void setStatus(String status) {
-                this.status = status;
+        public void setActivated(boolean activated) {
+                this.activated = activated;
         }
 
         public String getGsheet() {

--- a/src/main/java/it/sensorplatform/dto/PacketDTO.java
+++ b/src/main/java/it/sensorplatform/dto/PacketDTO.java
@@ -17,7 +17,6 @@ public class PacketDTO {
     private String devEui;
     private String typeOfDevice;
     private Long projectId;
-    private boolean activation;
     private Double latitude;
     private Double longitude;
     private Map<String, Object> payload;
@@ -54,14 +53,6 @@ public class PacketDTO {
 
     public void setProjectId(Long projectId) {
         this.projectId = projectId;
-    }
-
-    public boolean isActivation() {
-        return activation;
-    }
-
-    public void setActivation(boolean activation) {
-        this.activation = activation;
     }
 
     public Double getLatitude() {

--- a/src/main/java/it/sensorplatform/model/Device.java
+++ b/src/main/java/it/sensorplatform/model/Device.java
@@ -40,8 +40,8 @@ public class Device {
         @Column(nullable = true)
         private String gsheet;
 
-        @Column(name="status")
-        private String status = "deactivated";
+        @Column(name = "activated", nullable = false)
+        private boolean activated = false;
 	
 	@ManyToOne
 	private Project project;
@@ -155,12 +155,12 @@ public class Device {
                 this.gsheet = normalizeBlank(gsheet);
         }
 
-        public String getStatus() {
-                return status;
+        public boolean isActivated() {
+                return activated;
         }
 
-        public void setStatus(String status) {
-                this.status = status;
+        public void setActivated(boolean activated) {
+                this.activated = activated;
         }
 
 

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -13,9 +13,9 @@ import java.util.Optional;
 /**
  * Service that applies the device/project filter logic described in the
  * specification. It handles three cases:
- *  1. unknown device -> register it with activation=false
- *  2. known device with activation flag -> update device activation and location
- *  3. known device without activation flag -> forward data to IngestService
+ *  1. unknown device -> notify the unknown device service
+ *  2. known device not yet activated -> perform the activation flow
+ *  3. activated device -> forward data to IngestService
  */
 @Service
 public class PacketService {
@@ -61,18 +61,18 @@ public class PacketService {
 
         Device device = existing.get();
 
-        if (packet.isActivation()) {
+        if (!device.isActivated()) {
             System.out.println("PacketService.handlePacket - activation packet for device: " + device.getId());
-            // Case 3: activation packet -> update flags and location
-            device.setStatus("activated");
+            // Case 2: activation packet -> update flags and location
             if (packet.getLatitude() != null) device.setLatitude(packet.getLatitude());
             if (packet.getLongitude() != null) device.setLongitude(packet.getLongitude());
+            device.setActivated(true);
             deviceRepository.save(device);
             return Result.ACTIVATION;
         }
 
         System.out.println("PacketService.handlePacket - forwarding data to IngestService for device: " + device.getMacAddress());
-        // Case 2: normal data packet -> forward metrics to ingest service
+        // Case 3: normal data packet -> forward metrics to ingest service
         Map<String, Object> payload = packet.getPayload();
         ingestService.process(
                 device,

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -60,51 +60,51 @@ insert into project_tods(project_id, tods_id)values(101, 3)
 -- 5. Dispositivi (devono esistere i gruppi e i progetti)
 
 /* MIMI - Roma, gruppo compatto */
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850001, 12.460101, 1, 1, 1, 'flamy003@gmail.com', '21:06:1C:EC:E7:20', 'Blue1', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850302, 12.460402, 1, 2, 1, 'flamy003@gmail.com', '34:09:1C:EC:E7:21', 'Blue2', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850503, 12.460703, 1, 3, 1, 'flamy003@gmail.com', '56:08:1C:EC:E7:22', 'Blue3', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.850804, 12.461004, 1, 4, 1, 'flamy003@gmail.com', '15:05:1B:EC:E7:23', 'Blue4', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.851005, 12.461305, 1, 5, 1, 'flamy003@gmail.com', '17:04:1C:EC:E7:24', 'Blue5', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, status)values(41.851206, 12.461606, 1, 6, 1, 'flamy003@gmail.com', '18:03:1C:EC:E7:25', 'Blue6', 1, 'deactivated');
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850001, 12.460101, 1, 1, 1, 'flamy003@gmail.com', '21:06:1C:EC:E7:20', 'Blue1', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850302, 12.460402, 1, 2, 1, 'flamy003@gmail.com', '34:09:1C:EC:E7:21', 'Blue2', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850503, 12.460703, 1, 3, 1, 'flamy003@gmail.com', '56:08:1C:EC:E7:22', 'Blue3', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850804, 12.461004, 1, 4, 1, 'flamy003@gmail.com', '15:05:1B:EC:E7:23', 'Blue4', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.851005, 12.461305, 1, 5, 1, 'flamy003@gmail.com', '17:04:1C:EC:E7:24', 'Blue5', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, activated)values(41.851206, 12.461606, 1, 6, 1, 'flamy003@gmail.com', '18:03:1C:EC:E7:25', 'Blue6', 1, false);
 
 /* Dispositivi aggiuntivi MIMI */
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.851407, 12.461907, 1, 24, 1, 'flamy003@gmail.com', 'E3:06:1C:EC:E7:3D', 'Blue7', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.851608, 12.462208, 1, 25, 1, 'flamy003@gmail.com', 'F4:06:1C:EC:E7:3E', 'Blue8', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.851809, 12.462509, 1, 26, 1, 'flamy003@gmail.com', '10:07:1C:EC:E7:3F', 'Blue9', 1, 5, 'activated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.852010, 12.462810, 1, 27, 1, 'flamy003@gmail.com', '21:07:1C:EC:E7:40', 'Blue10', 1, 5, 'deactivated');
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.852211, 12.463111, 1, 28, 1, 'flamy003@gmail.com', '32:07:1C:EC:E7:41', 'Blue11', 1, 5, 'activated');
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.851407, 12.461907, 1, 24, 1, 'flamy003@gmail.com', 'E3:06:1C:EC:E7:3D', 'Blue7', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.851608, 12.462208, 1, 25, 1, 'flamy003@gmail.com', 'F4:06:1C:EC:E7:3E', 'Blue8', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.851809, 12.462509, 1, 26, 1, 'flamy003@gmail.com', '10:07:1C:EC:E7:3F', 'Blue9', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.852010, 12.462810, 1, 27, 1, 'flamy003@gmail.com', '21:07:1C:EC:E7:40', 'Blue10', 1, 5, false);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.852211, 12.463111, 1, 28, 1, 'flamy003@gmail.com', '32:07:1C:EC:E7:41', 'Blue11', 1, 5, true);
 
 
 /* KUCA - sparsi nel nord Italia */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.440001, 10.995001, 7, 51, 'luca.bussi@outlook.it','11:06:1C:EC:E8:26', 'Red1', 2, 6, 'activated');  -- Verona
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(44.494889, 11.342616, 8, 51, 'luca.bussi@outlook.it','14:06:1C:EC:E8:27', 'Red2', 2, 6, 'activated');  -- Bologna
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.070339, 7.686864, 9, 51, 'luca.bussi@outlook.it','15:06:1C:EC:E8:28', 'Red3', 2, 6, 'activated');   -- Torino
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(46.062008, 11.121083, 10, 51, 'luca.bussi@outlook.it', '23:06:1C:EC:E8:29', 'Red4', 2, 6, 'activated'); -- Trento
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.649526, 13.776818, 11, 51, 'luca.bussi@outlook.it', '39:06:1C:EC:E8:30', 'Red5', 2, 6, 'activated'); -- Trieste
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(44.801485, 10.327903, 12, 51, 'luca.bussi@outlook.it', '4A:06:1C:EC:E8:31', 'Red6', 2, 6, 'deactivated'); -- Parma
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.440001, 10.995001, 7, 51, 'luca.bussi@outlook.it','11:06:1C:EC:E8:26', 'Red1', 2, 6, true);  -- Verona
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(44.494889, 11.342616, 8, 51, 'luca.bussi@outlook.it','14:06:1C:EC:E8:27', 'Red2', 2, 6, true);  -- Bologna
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.070339, 7.686864, 9, 51, 'luca.bussi@outlook.it','15:06:1C:EC:E8:28', 'Red3', 2, 6, true);   -- Torino
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(46.062008, 11.121083, 10, 51, 'luca.bussi@outlook.it', '23:06:1C:EC:E8:29', 'Red4', 2, 6, true); -- Trento
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.649526, 13.776818, 11, 51, 'luca.bussi@outlook.it', '39:06:1C:EC:E8:30', 'Red5', 2, 6, true); -- Trieste
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(44.801485, 10.327903, 12, 51, 'luca.bussi@outlook.it', '4A:06:1C:EC:E8:31', 'Red6', 2, 6, false); -- Parma
 
 /* Dispositivi aggiuntivi KUCA */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.184724, 9.158207, 29, 51, 'luca.bussi@outlook.it', '43:07:1C:EC:E8:42', 'Red7', 2, 6, 'activated'); -- Pavia
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(44.405650, 8.946256, 30, 51, 'luca.bussi@outlook.it', '54:07:1C:EC:E8:43', 'Red8', 2, 6, 'activated'); -- Genova
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.465422, 9.185924, 31, 51, 'luca.bussi@outlook.it', '65:07:1C:EC:E8:44', 'Red9', 2, 6, 'activated'); -- Milano
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(45.327064, 8.419981, 32, 51, 'luca.bussi@outlook.it', '76:07:1C:EC:E8:45', 'Red10', 2, 6, 'deactivated'); -- Novara
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(46.498295, 11.354758, 33, 51, 'luca.bussi@outlook.it', '87:07:1C:EC:E8:46', 'Red11', 2, 6, 'activated'); -- Bolzano
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.184724, 9.158207, 29, 51, 'luca.bussi@outlook.it', '43:07:1C:EC:E8:42', 'Red7', 2, 6, true); -- Pavia
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(44.405650, 8.946256, 30, 51, 'luca.bussi@outlook.it', '54:07:1C:EC:E8:43', 'Red8', 2, 6, true); -- Genova
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.465422, 9.185924, 31, 51, 'luca.bussi@outlook.it', '65:07:1C:EC:E8:44', 'Red9', 2, 6, true); -- Milano
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.327064, 8.419981, 32, 51, 'luca.bussi@outlook.it', '76:07:1C:EC:E8:45', 'Red10', 2, 6, false); -- Novara
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(46.498295, 11.354758, 33, 51, 'luca.bussi@outlook.it', '87:07:1C:EC:E8:46', 'Red11', 2, 6, true); -- Bolzano
 
 
 /* JEM - sud e isole */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(40.851775, 14.268124, 13, 101, 'jhon30.herrera@gmail.com', '26:06:1C:EC:E7:32', 'Amber1', 3, 7, 'activated'); -- Napoli
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(38.115688, 13.361267, 14, 101, 'jhon30.herrera@gmail.com', '37:06:1C:EC:E7:33', 'Amber2', 3, 7, 'activated'); -- Palermo
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(37.507877, 15.083030, 15, 101, 'jhon30.herrera@gmail.com', '58:06:1C:EC:E7:34', 'Amber3', 3, 7, 'activated'); -- Catania
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(39.223841, 9.121661, 16, 101, 'jhon30.herrera@gmail.com', '6B:06:1C:EC:E7:35', 'Amber4', 3, 7, 'activated');  -- Cagliari
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(40.639470, 17.694360, 17, 101, 'jhon30.herrera@gmail.com', '7C:06:1C:EC:E7:36', 'Amber5', 3, 7, 'activated'); -- Lecce
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(38.193791, 15.554045, 18, 101, 'jhon30.herrera@gmail.com', '8D:06:1C:EC:E7:37', 'Amber6', 3, 7, 'deactivated'); -- Messina
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.851775, 14.268124, 13, 101, 'jhon30.herrera@gmail.com', '26:06:1C:EC:E7:32', 'Amber1', 3, 7, true); -- Napoli
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.115688, 13.361267, 14, 101, 'jhon30.herrera@gmail.com', '37:06:1C:EC:E7:33', 'Amber2', 3, 7, true); -- Palermo
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(37.507877, 15.083030, 15, 101, 'jhon30.herrera@gmail.com', '58:06:1C:EC:E7:34', 'Amber3', 3, 7, true); -- Catania
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(39.223841, 9.121661, 16, 101, 'jhon30.herrera@gmail.com', '6B:06:1C:EC:E7:35', 'Amber4', 3, 7, true);  -- Cagliari
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.639470, 17.694360, 17, 101, 'jhon30.herrera@gmail.com', '7C:06:1C:EC:E7:36', 'Amber5', 3, 7, true); -- Lecce
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.193791, 15.554045, 18, 101, 'jhon30.herrera@gmail.com', '8D:06:1C:EC:E7:37', 'Amber6', 3, 7, false); -- Messina
 
 /* Dispositivi aggiuntivi VOLCANO */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(37.502328, 14.165223, 19, 101, 'jhon30.herrera@gmail.com', '9E:06:1C:EC:E7:38', 'Amber7', 3, 7, 'activated'); -- Enna
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(41.125667, 16.869817, 20, 101, 'jhon30.herrera@gmail.com', 'AF:06:1C:EC:E7:39', 'Amber8', 3, 7, 'activated'); -- Bari
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(40.728333, 8.560833, 21, 101, 'jhon30.herrera@gmail.com', 'B0:06:1C:EC:E7:3A', 'Amber9', 3, 7, 'activated'); -- Sassari
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(38.910986, 16.587678, 22, 101, 'jhon30.herrera@gmail.com', 'C1:06:1C:EC:E7:3B', 'Amber10', 3, 7, 'deactivated'); -- Catanzaro
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, status)values(36.921984, 14.730344, 23, 101, 'jhon30.herrera@gmail.com', 'D2:06:1C:EC:E7:3C', 'Amber11', 3, 7, 'activated'); -- Ragusa
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(37.502328, 14.165223, 19, 101, 'jhon30.herrera@gmail.com', '9E:06:1C:EC:E7:38', 'Amber7', 3, 7, true); -- Enna
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.125667, 16.869817, 20, 101, 'jhon30.herrera@gmail.com', 'AF:06:1C:EC:E7:39', 'Amber8', 3, 7, true); -- Bari
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.728333, 8.560833, 21, 101, 'jhon30.herrera@gmail.com', 'B0:06:1C:EC:E7:3A', 'Amber9', 3, 7, true); -- Sassari
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.910986, 16.587678, 22, 101, 'jhon30.herrera@gmail.com', 'C1:06:1C:EC:E7:3B', 'Amber10', 3, 7, false); -- Catanzaro
+insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(36.921984, 14.730344, 23, 101, 'jhon30.herrera@gmail.com', 'D2:06:1C:EC:E7:3C', 'Amber11', 3, 7, true); -- Ragusa
 
 insert into spec(id, measurement, unit_of_measurement, component)values(1, 'Temperature', '°C' ,'Sen5x')
 insert into spec(id, measurement, unit_of_measurement, component)values(2, 'Relative Humidity', '%RH' ,'Sen5x')

--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -52,7 +52,7 @@
                                         <span th:if="${device.macAddress != null}">MAC: <strong th:text="${T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)}">--</strong></span>
                                         <span th:if="${device.macAddress == null}">DevEUI: <strong th:text="${device.devEui != null ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui) : '--'}">--</strong></span>
                                         <span th:if="${device.tod != null}">Type: <strong th:text="${device.tod.name}">Type</strong></span>
-                                        <span>Status: <strong th:text="${device.status}">--</strong></span>
+                                        <span>Status: <strong th:text="${device.activated} ? 'activated' : 'deactivated'">--</strong></span>
                                 </p>
                         </div>
                         <div class="device-actions">

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -151,7 +151,7 @@
                                                           <td>
                                                                   <span th:if="${device.operator != null}" th:text="${device.operator}">Operator</span>
                                                           </td>
-                                                          <td th:text="${device.status}"></td>
+                                                          <td th:text="${device.activated} ? 'activated' : 'deactivated'"></td>
                                                           <td>
                                                                   <!-- Edit (icona a matita) -->
                                                                   <a th:href="@{'/device/' + ${project.id} + '/' + ${device.deviceKey}}"

--- a/src/test/java/it/sensorplatform/test/PacketServiceTests.java
+++ b/src/test/java/it/sensorplatform/test/PacketServiceTests.java
@@ -46,7 +46,7 @@ class PacketServiceTests {
 
         assertEquals(PacketService.Result.NEW_DEVICE, res);
         Device saved = deviceRepository.findByMacAddress(MacAddressUtils.normalize("AA:BB:CC")).orElseThrow();
-        assertEquals("deactivated", saved.getStatus());
+        assertFalse(saved.isActivated());
         assertEquals(project.getId(), saved.getProject().getId());
     }
 
@@ -60,7 +60,7 @@ class PacketServiceTests {
         device.setName("d1");
         device.setMacAddress("AA:DD:EE");
         device.setEmailOwner("");
-        device.setStatus("deactivated");
+        device.setActivated(true);
         device.setLatitude(0d);
         device.setLongitude(0d);
         device.setProject(project);
@@ -76,7 +76,7 @@ class PacketServiceTests {
     }
 
     @Test
-    void activatesDeviceWhenFlagPresent() {
+    void activatesDeviceWhenNotYetActivated() {
         Project project = new Project();
         project.setName("demo");
         projectRepository.save(project);
@@ -85,7 +85,7 @@ class PacketServiceTests {
         device.setName("d1");
         device.setMacAddress("AA:FF:00");
         device.setEmailOwner("");
-        device.setStatus("deactivated");
+        device.setActivated(false);
         device.setLatitude(0d);
         device.setLongitude(0d);
         device.setProject(project);
@@ -93,7 +93,6 @@ class PacketServiceTests {
 
         PacketDTO dto = new PacketDTO();
         dto.setMacAddress("AA:FF:00");
-        dto.setActivation(true);
         dto.setLatitude(45.0);
         dto.setLongitude(7.0);
 
@@ -101,7 +100,7 @@ class PacketServiceTests {
         assertEquals(PacketService.Result.ACTIVATION, res);
 
         Device updated = deviceRepository.findByMacAddress(MacAddressUtils.normalize("AA:FF:00")).orElseThrow();
-        assertEquals("activated", updated.getStatus());
+        assertTrue(updated.isActivated());
         assertEquals(45.0, updated.getLatitude());
         assertEquals(7.0, updated.getLongitude());
     }


### PR DESCRIPTION
## Summary
- persist the device activation state with a boolean flag and propagate the change through DTOs, controllers, templates, and seed data
- remove the activation attribute from PacketDTO and drive PacketService logic via Device.isActivated(), updating unit tests accordingly

## Testing
- `mvn test` *(fails: cannot download Spring Boot parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a19d6e08832e90614b87ea974fd5