### PR TITLE
Add operator activation notifications with SSE

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/OperatorActivationController.java
+++ b/src/main/java/it/sensorplatform/controller/rest/OperatorActivationController.java
@@ -1,0 +1,78 @@
+package it.sensorplatform.controller.rest;
+
+import it.sensorplatform.dto.OperatorActivationNotification;
+import it.sensorplatform.model.Credentials;
+import it.sensorplatform.service.CredentialsService;
+import it.sensorplatform.service.OperatorActivationService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.security.Principal;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/operators/activations")
+public class OperatorActivationController {
+
+    private final OperatorActivationService operatorActivationService;
+    private final CredentialsService credentialsService;
+
+    public OperatorActivationController(OperatorActivationService operatorActivationService,
+                                        CredentialsService credentialsService) {
+        this.operatorActivationService = operatorActivationService;
+        this.credentialsService = credentialsService;
+    }
+
+    @GetMapping("/stream/{projectId}")
+    public SseEmitter stream(@PathVariable Long projectId, Principal principal) {
+        Credentials operator = requireOperator(principal);
+        validateProjectAccess(operator, projectId);
+        return operatorActivationService.subscribe(operator.getId(), projectId);
+    }
+
+    @GetMapping("/{projectId}")
+    public List<OperatorActivationNotification> pending(@PathVariable Long projectId, Principal principal) {
+        Credentials operator = requireOperator(principal);
+        validateProjectAccess(operator, projectId);
+        return operatorActivationService.listForOperator(projectId, operator.getId());
+    }
+
+    @PostMapping("/{projectId}/{deviceId}/consume")
+    public ResponseEntity<OperatorActivationNotification> consume(@PathVariable Long projectId,
+                                                                  @PathVariable Long deviceId,
+                                                                  Principal principal) {
+        Credentials operator = requireOperator(principal);
+        validateProjectAccess(operator, projectId);
+        OperatorActivationNotification notification =
+                operatorActivationService.consume(projectId, deviceId, operator.getId());
+        if (notification == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(notification);
+    }
+
+    private Credentials requireOperator(Principal principal) {
+        if (principal == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Operator not authenticated");
+        }
+        Credentials credentials = credentialsService.getCredentials(principal.getName());
+        if (credentials == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Operator not authenticated");
+        }
+        return credentials;
+    }
+
+    private void validateProjectAccess(Credentials operator, Long projectId) {
+        if (operator.getProjectId() != null && projectId != null
+                && !operator.getProjectId().equals(projectId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Operator cannot access this project");
+        }
+    }
+}

--- a/src/main/java/it/sensorplatform/dto/OperatorActivationNotification.java
+++ b/src/main/java/it/sensorplatform/dto/OperatorActivationNotification.java
@@ -1,0 +1,127 @@
+package it.sensorplatform.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Notification emitted when a device that is not yet activated sends
+ * a packet and requires an operator intervention.
+ */
+public class OperatorActivationNotification {
+
+    private final Long deviceId;
+    private final String deviceName;
+    private final String macAddress;
+    private final String devEui;
+    private final Long projectId;
+    private final String projectName;
+    private final Long adminId;
+    private final String adminEmail;
+    private final Double latitude;
+    private final Double longitude;
+    private final Instant timestamp;
+    private final Set<Long> authorizedOperatorIds;
+
+    public OperatorActivationNotification(Long deviceId,
+                                          String deviceName,
+                                          String macAddress,
+                                          String devEui,
+                                          Long projectId,
+                                          String projectName,
+                                          Long adminId,
+                                          String adminEmail,
+                                          Double latitude,
+                                          Double longitude,
+                                          Instant timestamp,
+                                          Set<Long> authorizedOperatorIds) {
+        this.deviceId = deviceId;
+        this.deviceName = deviceName;
+        this.macAddress = macAddress;
+        this.devEui = devEui;
+        this.projectId = projectId;
+        this.projectName = projectName;
+        this.adminId = adminId;
+        this.adminEmail = adminEmail;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.timestamp = timestamp != null ? timestamp : Instant.now();
+        this.authorizedOperatorIds = authorizedOperatorIds != null
+                ? Collections.unmodifiableSet(authorizedOperatorIds)
+                : Set.of();
+    }
+
+    public Long getDeviceId() {
+        return deviceId;
+    }
+
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public String getDevEui() {
+        return devEui;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public Long getAdminId() {
+        return adminId;
+    }
+
+    public String getAdminEmail() {
+        return adminEmail;
+    }
+
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    @JsonIgnore
+    public Set<Long> getAuthorizedOperatorIds() {
+        return authorizedOperatorIds;
+    }
+
+    public boolean isVisibleTo(Long operatorId) {
+        if (operatorId == null) {
+            return false;
+        }
+        return authorizedOperatorIds.contains(operatorId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OperatorActivationNotification that = (OperatorActivationNotification) o;
+        return Objects.equals(deviceId, that.deviceId)
+                && Objects.equals(projectId, that.projectId)
+                && Objects.equals(timestamp, that.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(deviceId, projectId, timestamp);
+    }
+}

--- a/src/main/java/it/sensorplatform/repository/CredentialsRepository.java
+++ b/src/main/java/it/sensorplatform/repository/CredentialsRepository.java
@@ -24,5 +24,7 @@ public interface CredentialsRepository extends CrudRepository<Credentials, Long>
     
     List<Credentials> findByRoleAndProjectId(String role, Long projectId);
 
+    Optional<Credentials> findByEmailAndProjectId(String email, Long projectId);
+
     List<Credentials> findByProjectId(Long projectId);
 }

--- a/src/main/java/it/sensorplatform/service/CredentialsService.java
+++ b/src/main/java/it/sensorplatform/service/CredentialsService.java
@@ -68,6 +68,13 @@ public class CredentialsService {
 	public boolean existsByEmailAndProjectId(String email, Long projectId) {
 		return this.credentialsRepository.existsByEmailAndProjectId(email, projectId);
 	}
+
+	public Optional<Credentials> findByEmailAndProjectId(String email, Long projectId) {
+		if (!StringUtils.hasText(email) || projectId == null) {
+		return Optional.empty();
+		}
+		return credentialsRepository.findByEmailAndProjectId(email.trim(), projectId);
+	}
 	
 	/*public List<Credentials> findOperatorsByProject(Project project) {
 	    String role = "OPERATOR";

--- a/src/main/java/it/sensorplatform/service/OperatorActivationService.java
+++ b/src/main/java/it/sensorplatform/service/OperatorActivationService.java
@@ -1,0 +1,210 @@
+package it.sensorplatform.service;
+
+import it.sensorplatform.dto.OperatorActivationNotification;
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Admin;
+import it.sensorplatform.model.Credentials;
+import it.sensorplatform.model.Device;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+@Service
+public class OperatorActivationService {
+
+    private static final String EVENT_NAME = "activation-request";
+
+    private final Map<Long, Map<Long, OperatorActivationNotification>> notificationsByProject =
+            new ConcurrentHashMap<>();
+    private final Map<Long, List<SseEmitter>> emittersByOperator = new ConcurrentHashMap<>();
+
+    public void notifyActivation(Device device,
+                                 PacketDTO packet,
+                                 Admin admin,
+                                 List<Credentials> authorizedOperators) {
+        if (device == null) {
+            return;
+        }
+        Long deviceId = device.getId();
+        if (deviceId == null) {
+            return;
+        }
+        Long projectId = resolveProjectId(device, packet);
+        if (projectId == null) {
+            return;
+        }
+
+        Set<Long> operatorIds = toOperatorIds(authorizedOperators);
+        OperatorActivationNotification notification = new OperatorActivationNotification(
+                deviceId,
+                device.getName(),
+                device.getMacAddress(),
+                device.getDevEui(),
+                projectId,
+                device.getProject() != null ? device.getProject().getName() : null,
+                admin != null ? admin.getId() : null,
+                resolveAdminEmail(admin, device),
+                resolveLatitude(device, packet),
+                resolveLongitude(device, packet),
+                Instant.now(),
+                operatorIds
+        );
+
+        notificationsByProject
+                .computeIfAbsent(projectId, id -> new ConcurrentHashMap<>())
+                .put(deviceId, notification);
+
+        if (operatorIds.isEmpty()) {
+            return;
+        }
+
+        for (Long operatorId : operatorIds) {
+            emitToOperator(operatorId, notification);
+        }
+    }
+
+    public List<OperatorActivationNotification> listForOperator(Long projectId, Long operatorId) {
+        if (projectId == null || operatorId == null) {
+            return List.of();
+        }
+        Map<Long, OperatorActivationNotification> map = notificationsByProject.get(projectId);
+        if (map == null || map.isEmpty()) {
+            return List.of();
+        }
+        return map.values().stream()
+                .filter(notification -> notification.isVisibleTo(operatorId))
+                .sorted(java.util.Comparator.comparing(OperatorActivationNotification::getTimestamp))
+                .toList();
+    }
+
+    public OperatorActivationNotification consume(Long projectId, Long deviceId, Long operatorId) {
+        if (projectId == null || deviceId == null || operatorId == null) {
+            return null;
+        }
+        Map<Long, OperatorActivationNotification> map = notificationsByProject.get(projectId);
+        if (map == null) {
+            return null;
+        }
+        OperatorActivationNotification notification = map.get(deviceId);
+        if (notification == null || !notification.isVisibleTo(operatorId)) {
+            return null;
+        }
+        map.remove(deviceId);
+        if (map.isEmpty()) {
+            notificationsByProject.remove(projectId);
+        }
+        return notification;
+    }
+
+    public SseEmitter subscribe(Long operatorId, Long projectId) {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        emittersByOperator
+                .computeIfAbsent(operatorId, id -> new CopyOnWriteArrayList<>())
+                .add(emitter);
+
+        emitter.onCompletion(() -> removeEmitter(operatorId, emitter));
+        emitter.onTimeout(() -> removeEmitter(operatorId, emitter));
+
+        replayExisting(operatorId, projectId, emitter);
+        return emitter;
+    }
+
+    private void emitToOperator(Long operatorId, OperatorActivationNotification notification) {
+        List<SseEmitter> emitters = emittersByOperator.getOrDefault(operatorId, Collections.emptyList());
+        for (SseEmitter emitter : new ArrayList<>(emitters)) {
+            try {
+                emitter.send(SseEmitter.event().name(EVENT_NAME).data(notification));
+            } catch (Exception e) {
+                emitter.complete();
+                removeEmitter(operatorId, emitter);
+            }
+        }
+    }
+
+    private void replayExisting(Long operatorId, Long projectId, SseEmitter emitter) {
+        if (operatorId == null || projectId == null) {
+            return;
+        }
+        Map<Long, OperatorActivationNotification> map = notificationsByProject.get(projectId);
+        if (map == null || map.isEmpty()) {
+            return;
+        }
+        for (OperatorActivationNotification notification : map.values()) {
+            if (!notification.isVisibleTo(operatorId)) {
+                continue;
+            }
+            try {
+                emitter.send(SseEmitter.event().name(EVENT_NAME).data(notification));
+            } catch (Exception e) {
+                emitter.complete();
+                removeEmitter(operatorId, emitter);
+                break;
+            }
+        }
+    }
+
+    private void removeEmitter(Long operatorId, SseEmitter emitter) {
+        if (operatorId == null || emitter == null) {
+            return;
+        }
+        List<SseEmitter> emitters = emittersByOperator.get(operatorId);
+        if (emitters == null) {
+            return;
+        }
+        emitters.remove(emitter);
+        if (emitters.isEmpty()) {
+            emittersByOperator.remove(operatorId);
+        }
+    }
+
+    private Long resolveProjectId(Device device, PacketDTO packet) {
+        if (device.getProject() != null) {
+            return device.getProject().getId();
+        }
+        return packet != null ? packet.getProjectId() : null;
+    }
+
+    private String resolveAdminEmail(Admin admin, Device device) {
+        if (admin != null && admin.getCredentials() != null
+                && StringUtils.hasText(admin.getCredentials().getEmail())) {
+            return admin.getCredentials().getEmail();
+        }
+        return device.getEmailOwner();
+    }
+
+    private Double resolveLatitude(Device device, PacketDTO packet) {
+        if (packet != null && packet.getLatitude() != null) {
+            return packet.getLatitude();
+        }
+        return device.getLatitude();
+    }
+
+    private Double resolveLongitude(Device device, PacketDTO packet) {
+        if (packet != null && packet.getLongitude() != null) {
+            return packet.getLongitude();
+        }
+        return device.getLongitude();
+    }
+
+    private Set<Long> toOperatorIds(List<Credentials> operators) {
+        if (operators == null || operators.isEmpty()) {
+            return Set.of();
+        }
+        return operators.stream()
+                .filter(Objects::nonNull)
+                .map(Credentials::getId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -1,14 +1,18 @@
 package it.sensorplatform.service;
 
 import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Admin;
+import it.sensorplatform.model.Credentials;
 import it.sensorplatform.model.Device;
 import it.sensorplatform.repository.DeviceRepository;
 import it.sensorplatform.util.MacAddressUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.List;
 
 /**
  * Service that applies the device/project filter logic described in the
@@ -23,13 +27,22 @@ public class PacketService {
     private final DeviceRepository deviceRepository;
     private final IngestService ingestService;
     private final UnknownDeviceService unknownDeviceService;
+    private final OperatorActivationService operatorActivationService;
+    private final AdminService adminService;
+    private final CredentialsService credentialsService;
 
     public PacketService(DeviceRepository deviceRepository,
                          IngestService ingestService,
-                         UnknownDeviceService unknownDeviceService) {
+                         UnknownDeviceService unknownDeviceService,
+                         OperatorActivationService operatorActivationService,
+                         AdminService adminService,
+                         CredentialsService credentialsService) {
         this.deviceRepository = deviceRepository;
         this.ingestService = ingestService;
         this.unknownDeviceService = unknownDeviceService;
+        this.operatorActivationService = operatorActivationService;
+        this.adminService = adminService;
+        this.credentialsService = credentialsService;
     }
 
     public enum Result { NEW_DEVICE, ACTIVATION, DATA }
@@ -63,6 +76,7 @@ public class PacketService {
 
         if (!device.isActivated()) {
             System.out.println("PacketService.handlePacket - activation packet for device: " + device.getId());
+            notifyOperators(device, packet);
             // Case 2: activation packet -> update flags and location
             if (packet.getLatitude() != null) device.setLatitude(packet.getLatitude());
             if (packet.getLongitude() != null) device.setLongitude(packet.getLongitude());
@@ -82,6 +96,32 @@ public class PacketService {
                 packet.getIndicator()
         );
         return Result.DATA;
+    }
+
+    private void notifyOperators(Device device, PacketDTO packet) {
+        String emailOwner = device.getEmailOwner();
+        Long projectId = device.getProject() != null ? device.getProject().getId() : packet.getProjectId();
+        if (!StringUtils.hasText(emailOwner) || projectId == null) {
+            return;
+        }
+        Optional<Credentials> credentialsOptional = credentialsService.findByEmailAndProjectId(emailOwner, projectId);
+        if (credentialsOptional.isEmpty()) {
+            return;
+        }
+        Credentials adminCredentials = credentialsOptional.get();
+        Admin admin = adminCredentials.getAdmin();
+        if (admin == null) {
+            return;
+        }
+        Admin managedAdmin = adminService.getAdmin(admin.getId());
+        if (managedAdmin == null) {
+            return;
+        }
+        List<Credentials> authorizedOperators = managedAdmin.getAuthorizedOperators();
+        if (authorizedOperators == null || authorizedOperators.isEmpty()) {
+            return;
+        }
+        operatorActivationService.notifyActivation(device, packet, managedAdmin, authorizedOperators);
     }
 }
 

--- a/src/test/java/it/sensorplatform/test/OperatorActivationFlowTests.java
+++ b/src/test/java/it/sensorplatform/test/OperatorActivationFlowTests.java
@@ -1,0 +1,121 @@
+package it.sensorplatform.test;
+
+import it.sensorplatform.dto.OperatorActivationNotification;
+import it.sensorplatform.dto.PacketDTO;
+import it.sensorplatform.model.Admin;
+import it.sensorplatform.model.Credentials;
+import it.sensorplatform.model.Device;
+import it.sensorplatform.model.Project;
+import it.sensorplatform.repository.AdminRepository;
+import it.sensorplatform.repository.CredentialsRepository;
+import it.sensorplatform.repository.DeviceRepository;
+import it.sensorplatform.repository.ProjectRepository;
+import it.sensorplatform.service.AdminService;
+import it.sensorplatform.service.OperatorActivationService;
+import it.sensorplatform.service.PacketService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class OperatorActivationFlowTests {
+
+    @Autowired
+    private PacketService packetService;
+
+    @Autowired
+    private DeviceRepository deviceRepository;
+
+    @Autowired
+    private ProjectRepository projectRepository;
+
+    @Autowired
+    private CredentialsRepository credentialsRepository;
+
+    @Autowired
+    private AdminRepository adminRepository;
+
+    @Autowired
+    private AdminService adminService;
+
+    @Autowired
+    private OperatorActivationService operatorActivationService;
+
+    @Test
+    void publishesNotificationsOnlyToAuthorizedOperators() {
+        Project project = new Project();
+        project.setName("activation-demo");
+        projectRepository.save(project);
+
+        Credentials adminCredentials = new Credentials();
+        adminCredentials.setUsername("admin-activation");
+        adminCredentials.setEmail("admin.activation@example.com");
+        adminCredentials.setPassword("pass");
+        adminCredentials.setRole("ADMIN");
+        adminCredentials.setProjectId(project.getId());
+        credentialsRepository.save(adminCredentials);
+
+        Admin admin = new Admin();
+        admin.setCredentials(adminCredentials);
+        adminRepository.save(admin);
+
+        Credentials authorizedOperator = new Credentials();
+        authorizedOperator.setUsername("authorized-operator");
+        authorizedOperator.setEmail("authorized@example.com");
+        authorizedOperator.setPassword("pass");
+        authorizedOperator.setRole("OPERATOR");
+        authorizedOperator.setProjectId(project.getId());
+        credentialsRepository.save(authorizedOperator);
+
+        Credentials unauthorizedOperator = new Credentials();
+        unauthorizedOperator.setUsername("unauthorized-operator");
+        unauthorizedOperator.setEmail("unauthorized@example.com");
+        unauthorizedOperator.setPassword("pass");
+        unauthorizedOperator.setRole("OPERATOR");
+        unauthorizedOperator.setProjectId(project.getId());
+        credentialsRepository.save(unauthorizedOperator);
+
+        adminService.authorizeOperator(admin.getId(), authorizedOperator.getId());
+
+        Device device = new Device();
+        device.setName("pending-device");
+        device.setMacAddress("AA:BB:CC:DD:EE:01");
+        device.setDevEui("AABBCCDDEE0001");
+        device.setActivated(false);
+        device.setEmailOwner(adminCredentials.getEmail());
+        device.setProject(project);
+        deviceRepository.save(device);
+
+        PacketDTO packet = new PacketDTO();
+        packet.setMacAddress("AA:BB:CC:DD:EE:01");
+        packet.setProjectId(project.getId());
+        packet.setLatitude(45.1);
+        packet.setLongitude(7.2);
+
+        PacketService.Result result = packetService.handlePacket(packet);
+        assertEquals(PacketService.Result.ACTIVATION, result);
+
+        List<OperatorActivationNotification> authorizedNotifications =
+                operatorActivationService.listForOperator(project.getId(), authorizedOperator.getId());
+        assertEquals(1, authorizedNotifications.size());
+        OperatorActivationNotification notification = authorizedNotifications.get(0);
+        assertEquals(device.getId(), notification.getDeviceId());
+        assertEquals(adminCredentials.getEmail(), notification.getAdminEmail());
+        assertEquals(project.getId(), notification.getProjectId());
+
+        List<OperatorActivationNotification> unauthorizedNotifications =
+                operatorActivationService.listForOperator(project.getId(), unauthorizedOperator.getId());
+        assertTrue(unauthorizedNotifications.isEmpty());
+
+        OperatorActivationNotification consumed = operatorActivationService.consume(
+                project.getId(), device.getId(), authorizedOperator.getId());
+        assertNotNull(consumed);
+        assertTrue(operatorActivationService.listForOperator(project.getId(), authorizedOperator.getId()).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- add an OperatorActivationService with DTO and SSE management to store activation requests and replay them to authorized operators
- update PacketService to resolve the admin that owns a device and publish activation notifications to authorized operators before marking the device as activated
- expose REST and SSE endpoints for operators to subscribe to and consume activation notifications
- cover the flow with an integration test that verifies only authorized operators see the activation notifications

## Testing
- `mvn test` *(fails: cannot reach Maven Central to resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a3ed35a8832ea43dbcc4e218272d