### PR TITLE
Add operator activation response flow with UI geolocation handling

### DIFF
--- a/src/main/java/it/sensorplatform/controller/rest/OperatorActivationController.java
+++ b/src/main/java/it/sensorplatform/controller/rest/OperatorActivationController.java
@@ -1,14 +1,18 @@
 package it.sensorplatform.controller.rest;
 
+import it.sensorplatform.dto.OperatorActivationDecision;
 import it.sensorplatform.dto.OperatorActivationNotification;
+import it.sensorplatform.dto.OperatorActivationResolution;
 import it.sensorplatform.model.Credentials;
 import it.sensorplatform.service.CredentialsService;
 import it.sensorplatform.service.OperatorActivationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,9 +20,11 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/operators/activations")
+@PreAuthorize("hasAnyAuthority('LTRAD_OPERATOR','FIRE_OPERATOR','VOLCANO_OPERATOR')")
 public class OperatorActivationController {
 
     private final OperatorActivationService operatorActivationService;
@@ -56,6 +62,27 @@ public class OperatorActivationController {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(notification);
+    }
+
+    @PostMapping("/{projectId}/{deviceId}/response")
+    public ResponseEntity<OperatorActivationResolution> respond(@PathVariable Long projectId,
+                                                                @PathVariable Long deviceId,
+                                                                @RequestBody OperatorActivationDecision decision,
+                                                                Principal principal) {
+        Credentials operator = requireOperator(principal);
+        validateProjectAccess(operator, projectId);
+        if (decision == null || decision.accepted() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "accepted field is required");
+        }
+        Optional<OperatorActivationResolution> resolution = operatorActivationService.respond(
+                projectId,
+                deviceId,
+                operator,
+                decision.accepted(),
+                decision.latitude(),
+                decision.longitude()
+        );
+        return resolution.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     private Credentials requireOperator(Principal principal) {

--- a/src/main/java/it/sensorplatform/dto/OperatorActivationDecision.java
+++ b/src/main/java/it/sensorplatform/dto/OperatorActivationDecision.java
@@ -1,0 +1,7 @@
+package it.sensorplatform.dto;
+
+/**
+ * Request payload used by operators to accept or refuse an activation.
+ */
+public record OperatorActivationDecision(Boolean accepted, Double latitude, Double longitude) {
+}

--- a/src/main/java/it/sensorplatform/dto/OperatorActivationResolution.java
+++ b/src/main/java/it/sensorplatform/dto/OperatorActivationResolution.java
@@ -1,0 +1,96 @@
+package it.sensorplatform.dto;
+
+import java.time.Instant;
+
+/**
+ * DTO emitted when an operator responds to an activation request.
+ */
+public class OperatorActivationResolution {
+
+    private final Long deviceId;
+    private final String deviceName;
+    private final String macAddress;
+    private final Long projectId;
+    private final String projectName;
+    private final boolean accepted;
+    private final Double latitude;
+    private final Double longitude;
+    private final Long operatorId;
+    private final String operatorName;
+    private final String deviceType;
+    private final Instant timestamp;
+
+    public OperatorActivationResolution(Long deviceId,
+                                        String deviceName,
+                                        String macAddress,
+                                        Long projectId,
+                                        String projectName,
+                                        boolean accepted,
+                                        Double latitude,
+                                        Double longitude,
+                                        Long operatorId,
+                                        String operatorName,
+                                        String deviceType,
+                                        Instant timestamp) {
+        this.deviceId = deviceId;
+        this.deviceName = deviceName;
+        this.macAddress = macAddress;
+        this.projectId = projectId;
+        this.projectName = projectName;
+        this.accepted = accepted;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.operatorId = operatorId;
+        this.operatorName = operatorName;
+        this.deviceType = deviceType;
+        this.timestamp = timestamp != null ? timestamp : Instant.now();
+    }
+
+    public Long getDeviceId() {
+        return deviceId;
+    }
+
+    public String getDeviceName() {
+        return deviceName;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public String getProjectName() {
+        return projectName;
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    public Long getOperatorId() {
+        return operatorId;
+    }
+
+    public String getOperatorName() {
+        return operatorName;
+    }
+
+    public String getDeviceType() {
+        return deviceType;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}

--- a/src/main/java/it/sensorplatform/service/OperatorActivationService.java
+++ b/src/main/java/it/sensorplatform/service/OperatorActivationService.java
@@ -1,10 +1,13 @@
 package it.sensorplatform.service;
 
 import it.sensorplatform.dto.OperatorActivationNotification;
+import it.sensorplatform.dto.OperatorActivationResolution;
 import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.model.Admin;
 import it.sensorplatform.model.Credentials;
 import it.sensorplatform.model.Device;
+import it.sensorplatform.repository.DeviceRepository;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -14,7 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -24,10 +27,17 @@ import java.util.stream.Collectors;
 public class OperatorActivationService {
 
     private static final String EVENT_NAME = "activation-request";
+    private static final String RESPONSE_EVENT_NAME = "activation-response";
 
     private final Map<Long, Map<Long, OperatorActivationNotification>> notificationsByProject =
             new ConcurrentHashMap<>();
     private final Map<Long, List<SseEmitter>> emittersByOperator = new ConcurrentHashMap<>();
+
+    private final DeviceRepository deviceRepository;
+
+    public OperatorActivationService(DeviceRepository deviceRepository) {
+        this.deviceRepository = deviceRepository;
+    }
 
     public void notifyActivation(Device device,
                                  PacketDTO packet,
@@ -70,7 +80,7 @@ public class OperatorActivationService {
         }
 
         for (Long operatorId : operatorIds) {
-            emitToOperator(operatorId, notification);
+            emitToOperator(operatorId, EVENT_NAME, notification);
         }
     }
 
@@ -107,6 +117,69 @@ public class OperatorActivationService {
         return notification;
     }
 
+    public Optional<OperatorActivationResolution> respond(Long projectId,
+                                                          Long deviceId,
+                                                          Credentials operator,
+                                                          boolean accepted,
+                                                          Double latitude,
+                                                          Double longitude) {
+        if (projectId == null || deviceId == null || operator == null) {
+            return Optional.empty();
+        }
+        Map<Long, OperatorActivationNotification> map = notificationsByProject.get(projectId);
+        if (map == null) {
+            return Optional.empty();
+        }
+        OperatorActivationNotification notification = map.get(deviceId);
+        if (notification == null) {
+            return Optional.empty();
+        }
+        Long operatorId = operator.getId();
+        if (!notification.isVisibleTo(operatorId)) {
+            throw new AccessDeniedException("Operator cannot respond to this activation");
+        }
+
+        map.remove(deviceId);
+        if (map.isEmpty()) {
+            notificationsByProject.remove(projectId);
+        }
+
+        Optional<Device> deviceOptional = deviceRepository.findById(deviceId);
+        if (deviceOptional.isEmpty()) {
+            return Optional.empty();
+        }
+        Device device = deviceOptional.get();
+        if (accepted) {
+            if (latitude != null) {
+                device.setLatitude(latitude);
+            }
+            if (longitude != null) {
+                device.setLongitude(longitude);
+            }
+            device.setActivated(true);
+            device.setOperator(operator);
+        }
+        deviceRepository.save(device);
+
+        OperatorActivationResolution resolution = new OperatorActivationResolution(
+                notification.getDeviceId(),
+                notification.getDeviceName(),
+                notification.getMacAddress(),
+                notification.getProjectId(),
+                notification.getProjectName(),
+                accepted,
+                latitude,
+                longitude,
+                operatorId,
+                resolveOperatorName(operator),
+                device.getTod() != null ? device.getTod().getName() : null,
+                Instant.now()
+        );
+
+        broadcastResolution(notification, resolution);
+        return Optional.of(resolution);
+    }
+
     public SseEmitter subscribe(Long operatorId, Long projectId) {
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
         emittersByOperator
@@ -120,11 +193,11 @@ public class OperatorActivationService {
         return emitter;
     }
 
-    private void emitToOperator(Long operatorId, OperatorActivationNotification notification) {
+    private void emitToOperator(Long operatorId, String eventName, Object payload) {
         List<SseEmitter> emitters = emittersByOperator.getOrDefault(operatorId, Collections.emptyList());
         for (SseEmitter emitter : new ArrayList<>(emitters)) {
             try {
-                emitter.send(SseEmitter.event().name(EVENT_NAME).data(notification));
+                emitter.send(SseEmitter.event().name(eventName).data(payload));
             } catch (Exception e) {
                 emitter.complete();
                 removeEmitter(operatorId, emitter);
@@ -206,5 +279,26 @@ public class OperatorActivationService {
                 .map(Credentials::getId)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private void broadcastResolution(OperatorActivationNotification notification,
+                                     OperatorActivationResolution resolution) {
+        if (notification == null || resolution == null) {
+            return;
+        }
+        for (Long operatorId : notification.getAuthorizedOperatorIds()) {
+            emitToOperator(operatorId, RESPONSE_EVENT_NAME, resolution);
+        }
+    }
+
+    private String resolveOperatorName(Credentials operator) {
+        if (operator == null) {
+            return null;
+        }
+        String visible = operator.getVisibleUsername();
+        if (StringUtils.hasText(visible)) {
+            return visible;
+        }
+        return operator.getUsername();
     }
 }

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -77,11 +77,6 @@ public class PacketService {
         if (!device.isActivated()) {
             System.out.println("PacketService.handlePacket - activation packet for device: " + device.getId());
             notifyOperators(device, packet);
-            // Case 2: activation packet -> update flags and location
-            if (packet.getLatitude() != null) device.setLatitude(packet.getLatitude());
-            if (packet.getLongitude() != null) device.setLongitude(packet.getLongitude());
-            device.setActivated(true);
-            deviceRepository.save(device);
             return Result.ACTIVATION;
         }
 

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -11,9 +11,12 @@
 	<!-- CSS per FIRE -->
 	<link rel="stylesheet" th:if="${project.id == 51}" th:href="@{/css/fireOperator.css}" />
 	<!-- CSS per VOLCANO -->
-	<link rel="stylesheet" th:if="${project.id == 101}" th:href="@{/css/volcanoOperator.css}" />
+        <link rel="stylesheet" th:if="${project.id == 101}" th:href="@{/css/volcanoOperator.css}" />
 
-	<script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
+        <meta th:if="${_csrf != null}" name="_csrf" th:content="${_csrf.token}" />
+        <meta th:if="${_csrf != null}" name="_csrf_header" th:content="${_csrf.headerName}" />
+
+        <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js"></script>
 </head>
 
 <body>
@@ -68,20 +71,29 @@
 					</button>
 				</form>
 			</div>
-			<div id="groups-wrapper">
-				<div th:if="${groups.isEmpty()}">No groups available</div>
-				<ul>
-					<li th:each="group : ${groups}">
-						<details class="groups">
-							<summary th:text="${group.name}" th:attr="data-group-name=${group.name}">Group</summary>
-							<ul class="device-list"></ul>
-						</details>
-					</li>
-				</ul>
-			</div>
+                        <div id="groups-wrapper">
+                                <div th:if="${groups.isEmpty()}">No groups available</div>
+                                <ul>
+                                        <li th:each="group : ${groups}">
+                                                <details class="groups">
+                                                        <summary th:text="${group.name}" th:attr="data-group-name=${group.name}">Group</summary>
+                                                        <ul class="device-list"></ul>
+                                                </details>
+                                        </li>
+                                </ul>
+                        </div>
 
-			<div class="title-with-search">
-				<h2>Your Devices on Map</h2>
+                        <div class="title-with-search">
+                                <h2 class="section-title">Activation Requests</h2>
+                        </div>
+                        <div id="activation-feedback" class="activation-feedback" role="status" aria-live="polite"></div>
+                        <div id="activation-requests-wrapper">
+                                <p id="activation-requests-empty">No activation requests</p>
+                                <ul id="activation-requests-list" class="activation-request-list"></ul>
+                        </div>
+
+                        <div class="title-with-search">
+                                <h2>Your Devices on Map</h2>
 				<form th:action="@{'/operator/' + ${project.id}}" method="get" class="search-form">
 					<input type="text" name="deviceInfo" placeholder="Search by name or MAC..."
 						th:value="${param.deviceInfo}" />
@@ -94,8 +106,8 @@
 				</form>
 			</div>
 
-			<div id="user-devices-wrapper">
-				<div th:if="${devices.isEmpty()}">No positioned devices</div>
+                        <div id="user-devices-wrapper">
+                                <div th:if="${devices.isEmpty()}" id="user-devices-empty">No positioned devices</div>
 				<table>
 					<thead>
 						<tr>
@@ -119,78 +131,495 @@
 		<div id="map"></div>
 	</div>
 
-	<script th:inline="javascript">
-		/*<![CDATA[*/
-		let initialDevices = [[${devices}]];
-		/*]]>*/
+	
+<script th:inline="javascript">
+        /*<![CDATA[*/
+        const initialDevices = [[${devices}]];
+        const projectId = [[${project.id}]];
+        const currentOperatorId = [[${user.id}]];
+        /*]]>*/
 
-		let map = L.map('map').setView([41.89, 12.48], 12);
-		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-			attribution: '&copy; OpenStreetMap contributors'
-		}).addTo(map);
+        const map = L.map('map').setView([41.89, 12.48], 12);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
 
-                let markerByMac = new Map();
-                let allLatLngs = [];
+        const markerByKey = new Map();
 
-                function formatMac(mac) {
-                        if (!mac) {
-                                return '';
-                        }
-                        const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
-                        const pairs = cleaned.match(/.{1,2}/g);
-                        return pairs ? pairs.join(':') : '';
+        function formatMac(mac) {
+                if (!mac) {
+                        return '';
                 }
+                const cleaned = mac.replace(/[^a-fA-F0-9]/g, '').toUpperCase();
+                const pairs = cleaned.match(/.{1,2}/g);
+                return pairs ? pairs.join(':') : '';
+        }
 
-                initialDevices.forEach(function (d) {
-                        if (d.latitude != null && d.longitude != null) {
-                                const latlng = [d.latitude, d.longitude];
-                                allLatLngs.push(latlng);
-                                const marker = L.marker(latlng).addTo(map);
-                                const popupContent = "Device: " + d.name + "<br>" +
-                                        "MacAddress: " + formatMac(d.macAddress) + "<br>" +
-                                        "Latitude: " + d.latitude + "<br>" +
-                                        "Longitude: " + d.longitude;
-                                marker.bindPopup(popupContent);
-                                marker.on("mouseover", function () {this.openPopup();});
-                                marker.on("mouseout", function () {this.closePopup();});
-                                markerByMac.set(d.macAddress, marker);
-                        }
-                });
+        function resolveDeviceKey(device) {
+                if (!device) {
+                        return null;
+                }
+                if (device.macAddress) {
+                        return device.macAddress.toUpperCase();
+                }
+                if (device.devEui) {
+                        return device.devEui.toUpperCase();
+                }
+                if (device.deviceId) {
+                        return `DEVICE-${device.deviceId}`;
+                }
+                if (device.id) {
+                        return `DEVICE-${device.id}`;
+                }
+                return null;
+        }
 
-		if (allLatLngs.length > 0) {
-			const bounds = L.latLngBounds(allLatLngs);
-			map.fitBounds(bounds, {padding: [30, 30]});
-		}
+        function buildPopupContent(device) {
+                const name = device.name || 'Device';
+                const mac = formatMac(device.macAddress);
+                const lat = device.latitude != null ? device.latitude : 'n/a';
+                const lon = device.longitude != null ? device.longitude : 'n/a';
+                return `Device: ${name}<br>MacAddress: ${mac}<br>Latitude: ${lat}<br>Longitude: ${lon}`;
+        }
 
-		function fetchAndDisplayDevices(groupName) {
-			fetch('/api/groups/name/' + encodeURIComponent(groupName) + '/devices')
-				.then(response => response.json())
-				.then(devices => {
-                                        const validDevices = devices.filter(d => d.latitude != null && d.longitude != null);
-                                        if (validDevices.length > 0) {
-                                                const bounds = L.latLngBounds(validDevices.map(d => [d.latitude, d.longitude]));
-                                                map.fitBounds(bounds, {padding: [20, 20]});
+        function addOrUpdateDeviceMarker(device) {
+                if (!device || device.latitude == null || device.longitude == null) {
+                        return;
+                }
+                const key = resolveDeviceKey(device);
+                if (!key) {
+                        return;
+                }
+                const latlng = [device.latitude, device.longitude];
+                let marker = markerByKey.get(key);
+                if (!marker) {
+                        marker = L.marker(latlng).addTo(map);
+                        marker.on('mouseover', function () { this.openPopup(); });
+                        marker.on('mouseout', function () { this.closePopup(); });
+                        markerByKey.set(key, marker);
+                } else {
+                        marker.setLatLng(latlng);
+                }
+                marker.bindPopup(buildPopupContent(device));
+        }
+
+        function recalculateBounds() {
+                const latLngs = Array.from(markerByKey.values()).map(marker => marker.getLatLng());
+                if (latLngs.length > 0) {
+                        const bounds = L.latLngBounds(latLngs);
+                        map.fitBounds(bounds, {padding: [30, 30]});
+                }
+        }
+
+        initialDevices.forEach(addOrUpdateDeviceMarker);
+        recalculateBounds();
+
+        const userDevicesWrapper = document.getElementById('user-devices-wrapper');
+
+        function ensureUserDevicesTable() {
+                if (!userDevicesWrapper) {
+                        return null;
+                }
+                const empty = document.getElementById('user-devices-empty');
+                if (empty) {
+                        empty.remove();
+                }
+                let table = userDevicesWrapper.querySelector('table');
+                if (!table) {
+                        table = document.createElement('table');
+                        table.innerHTML = `
+                                <thead>
+                                        <tr>
+                                                <th scope="col">Name</th>
+                                                <th scope="col">Mac Address</th>
+                                                <th scope="col">Type</th>
+                                        </tr>
+                                </thead>
+                                <tbody></tbody>
+                        `;
+                        userDevicesWrapper.appendChild(table);
+                }
+                return table.querySelector('tbody');
+        }
+
+        function upsertDeviceRow(device) {
+                if (!device) {
+                        return;
+                }
+                const tbody = ensureUserDevicesTable();
+                if (!tbody) {
+                        return;
+                }
+                const rowSelector = `tr[data-device-id="${device.deviceId}"]`;
+                let row = tbody.querySelector(rowSelector);
+                if (!row) {
+                        row = document.createElement('tr');
+                        row.dataset.deviceId = device.deviceId;
+                        tbody.appendChild(row);
+                }
+                const name = device.name || 'Device';
+                const mac = formatMac(device.macAddress);
+                const type = device.deviceType || '';
+                row.innerHTML = `
+                        <td>${name}</td>
+                        <td>${mac}</td>
+                        <td>${type}</td>
+                `;
+        }
+
+        function fetchAndDisplayDevices(groupName) {
+                fetch('/api/groups/name/' + encodeURIComponent(groupName) + '/devices')
+                        .then(response => response.json())
+                        .then(devices => {
+                                const validDevices = devices.filter(d => d.latitude != null && d.longitude != null);
+                                if (validDevices.length > 0) {
+                                        const bounds = L.latLngBounds(validDevices.map(d => [d.latitude, d.longitude]));
+                                        map.fitBounds(bounds, {padding: [20, 20]});
+                                }
+                                document.querySelectorAll(`summary[data-group-name="${groupName}"]`).forEach(summary => {
+                                        const details = summary.parentElement;
+                                        const ul = details.querySelector('.device-list');
+                                        if (!ul) {
+                                                return;
                                         }
-					document.querySelectorAll(`summary[data-group-name="${groupName}"]`).forEach(summary => {
-						const details = summary.parentElement;
-						const ul = details.querySelector('.device-list');
-						ul.innerHTML = '';
-						devices.forEach(device => {
-							const li = document.createElement('li');
-                                                        li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
-							ul.appendChild(li);
-						});
-					});
-				});
-		}
+                                        ul.innerHTML = '';
+                                        devices.forEach(device => {
+                                                const li = document.createElement('li');
+                                                li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
+                                                ul.appendChild(li);
+                                        });
+                                });
+                        })
+                        .catch(error => console.error('Unable to load group devices', error));
+        }
 
-		document.querySelectorAll("summary[data-group-name]").forEach(summary => {
-			summary.addEventListener("click", () => {
-				const groupName = summary.getAttribute("data-group-name");
-				fetchAndDisplayDevices(groupName);
-			});
-		});
-	</script>
+        document.querySelectorAll('summary[data-group-name]').forEach(summary => {
+                summary.addEventListener('click', () => {
+                        const groupName = summary.getAttribute('data-group-name');
+                        fetchAndDisplayDevices(groupName);
+                });
+        });
+
+        const csrfTokenMeta = document.querySelector('meta[name="_csrf"]');
+        const csrfHeaderMeta = document.querySelector('meta[name="_csrf_header"]');
+        const csrfToken = csrfTokenMeta ? csrfTokenMeta.getAttribute('content') : null;
+        const csrfHeader = csrfHeaderMeta ? csrfHeaderMeta.getAttribute('content') : null;
+
+        function buildHeaders() {
+                const headers = {'Content-Type': 'application/json'};
+                if (csrfToken && csrfHeader) {
+                        headers[csrfHeader] = csrfToken;
+                }
+                return headers;
+        }
+
+        const activationRequests = new Map();
+        const activationList = document.getElementById('activation-requests-list');
+        const activationEmpty = document.getElementById('activation-requests-empty');
+        const activationFeedback = document.getElementById('activation-feedback');
+        let activationFeedbackTimeout = null;
+
+        function refreshActivationEmptyState() {
+                if (!activationEmpty) {
+                        return;
+                }
+                activationEmpty.style.display = activationRequests.size === 0 ? 'block' : 'none';
+        }
+
+        function showActivationFeedback(message, isError = false) {
+                if (!activationFeedback) {
+                        return;
+                }
+                if (activationFeedbackTimeout) {
+                        window.clearTimeout(activationFeedbackTimeout);
+                        activationFeedbackTimeout = null;
+                }
+                if (!message) {
+                        activationFeedback.textContent = '';
+                        activationFeedback.style.padding = '0';
+                        activationFeedback.style.marginBottom = '0';
+                        activationFeedback.style.backgroundColor = 'transparent';
+                        return;
+                }
+                activationFeedback.textContent = message;
+                activationFeedback.style.padding = '8px 12px';
+                activationFeedback.style.marginBottom = '8px';
+                activationFeedback.style.backgroundColor = isError ? 'rgba(176,0,32,0.15)' : 'rgba(10,135,84,0.15)';
+                activationFeedback.style.color = isError ? '#b00020' : '#0a8754';
+                activationFeedbackTimeout = window.setTimeout(() => {
+                        activationFeedback.textContent = '';
+                        activationFeedback.style.padding = '0';
+                        activationFeedback.style.marginBottom = '0';
+                        activationFeedback.style.backgroundColor = 'transparent';
+                }, 6000);
+        }
+
+        function updateLocationContent(element, latitude, longitude) {
+                if (!element) {
+                        return;
+                }
+                if (latitude == null || longitude == null) {
+                        element.textContent = 'unknown';
+                        return;
+                }
+                const latFixed = Number(latitude).toFixed(5);
+                const lonFixed = Number(longitude).toFixed(5);
+                element.textContent = `${latFixed}, ${lonFixed}`;
+        }
+
+        function updateActivationElement(element, notification) {
+                if (!element || !notification) {
+                        return;
+                }
+                const title = element.querySelector('.activation-request-title');
+                if (title) {
+                        title.textContent = notification.deviceName || 'Unnamed device';
+                }
+                const macValue = element.querySelector('.activation-request-mac-value');
+                if (macValue) {
+                        macValue.textContent = formatMac(notification.macAddress);
+                }
+                const adminValue = element.querySelector('.activation-request-admin-value');
+                if (adminValue) {
+                        adminValue.textContent = notification.adminEmail || 'n/a';
+                }
+                const locationValue = element.querySelector('.activation-request-location-value');
+                updateLocationContent(locationValue, notification.latitude, notification.longitude);
+        }
+
+        function createActivationElement(notification) {
+                const li = document.createElement('li');
+                li.className = 'activation-request-item';
+                li.dataset.deviceId = notification.deviceId;
+
+                const title = document.createElement('div');
+                title.className = 'activation-request-title';
+                li.appendChild(title);
+
+                const macLine = document.createElement('div');
+                macLine.className = 'activation-request-field';
+                macLine.innerHTML = '<strong>MAC:</strong> <span class="activation-request-mac-value"></span>';
+                li.appendChild(macLine);
+
+                const adminLine = document.createElement('div');
+                adminLine.className = 'activation-request-field';
+                adminLine.innerHTML = '<strong>Admin:</strong> <span class="activation-request-admin-value"></span>';
+                li.appendChild(adminLine);
+
+                const locationLine = document.createElement('div');
+                locationLine.className = 'activation-request-field';
+                locationLine.innerHTML = '<strong>Location:</strong> <span class="activation-request-location-value"></span>';
+                li.appendChild(locationLine);
+
+                const actions = document.createElement('div');
+                actions.className = 'activation-request-actions';
+
+                const acceptButton = document.createElement('button');
+                acceptButton.type = 'button';
+                acceptButton.className = 'activation-request-accept';
+                acceptButton.textContent = 'Accept';
+
+                const refuseButton = document.createElement('button');
+                refuseButton.type = 'button';
+                refuseButton.className = 'activation-request-refuse';
+                refuseButton.textContent = 'Refuse';
+
+                actions.appendChild(acceptButton);
+                actions.appendChild(refuseButton);
+                li.appendChild(actions);
+
+                acceptButton.addEventListener('click', () => respondToActivation(notification, true, acceptButton, refuseButton));
+                refuseButton.addEventListener('click', () => respondToActivation(notification, false, acceptButton, refuseButton));
+
+                updateActivationElement(li, notification);
+                return { element: li, acceptButton, refuseButton };
+        }
+
+        function addActivationNotification(notification) {
+                if (!notification || notification.deviceId == null) {
+                        return;
+                }
+                const existing = activationRequests.get(notification.deviceId);
+                if (existing) {
+                        existing.notification = notification;
+                        updateActivationElement(existing.element, notification);
+                        refreshActivationEmptyState();
+                        return;
+                }
+                if (!activationList) {
+                        return;
+                }
+                const { element, acceptButton, refuseButton } = createActivationElement(notification);
+                activationRequests.set(notification.deviceId, {
+                        notification,
+                        element,
+                        acceptButton,
+                        refuseButton
+                });
+                activationList.appendChild(element);
+                refreshActivationEmptyState();
+        }
+
+        function removeActivationNotification(deviceId) {
+                const existing = activationRequests.get(deviceId);
+                if (!existing) {
+                        refreshActivationEmptyState();
+                        return;
+                }
+                if (existing.element && existing.element.parentElement) {
+                        existing.element.parentElement.removeChild(existing.element);
+                }
+                activationRequests.delete(deviceId);
+                refreshActivationEmptyState();
+        }
+
+        function getGeolocation() {
+                return new Promise((resolve, reject) => {
+                        if (!navigator.geolocation) {
+                                reject(new Error('Geolocation not supported'));
+                                return;
+                        }
+                        navigator.geolocation.getCurrentPosition(
+                                position => resolve({
+                                        latitude: Number(position.coords.latitude),
+                                        longitude: Number(position.coords.longitude)
+                                }),
+                                error => reject(error),
+                                {enableHighAccuracy: true, timeout: 10000}
+                        );
+                });
+        }
+
+        async function respondToActivation(notification, accepted, acceptButton, refuseButton) {
+                if (!notification) {
+                        return;
+                }
+                const entry = activationRequests.get(notification.deviceId);
+                const payloadNotification = entry ? entry.notification : notification;
+                if (acceptButton) {
+                        acceptButton.disabled = true;
+                }
+                if (refuseButton) {
+                        refuseButton.disabled = true;
+                }
+                try {
+                        let coordinates = {latitude: null, longitude: null};
+                        if (accepted) {
+                                try {
+                                        coordinates = await getGeolocation();
+                                } catch (geoError) {
+                                        const proceed = window.confirm('Unable to retrieve your location. Do you want to continue without coordinates?');
+                                        if (!proceed) {
+                                                throw geoError;
+                                        }
+                                }
+                        }
+                        const response = await fetch(`/api/operators/activations/${projectId}/${payloadNotification.deviceId}/response`, {
+                                method: 'POST',
+                                headers: buildHeaders(),
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                        accepted: accepted,
+                                        latitude: coordinates.latitude,
+                                        longitude: coordinates.longitude
+                                })
+                        });
+                        if (!response.ok) {
+                                throw new Error(`Server responded with status ${response.status}`);
+                        }
+                        const result = await response.json();
+                        handleActivationResolution(result);
+                } catch (error) {
+                        console.error('Activation response failed', error);
+                        showActivationFeedback('Unable to send response. Please try again.', true);
+                        if (acceptButton) {
+                                acceptButton.disabled = false;
+                        }
+                        if (refuseButton) {
+                                refuseButton.disabled = false;
+                        }
+                }
+        }
+
+        function handleActivationResolution(resolution) {
+                if (!resolution || resolution.deviceId == null) {
+                        return;
+                }
+                removeActivationNotification(resolution.deviceId);
+                const actor = resolution.operatorName || 'An operator';
+                const deviceName = resolution.deviceName || 'the device';
+                if (resolution.accepted) {
+                        showActivationFeedback(`${actor} activated ${deviceName}.`, false);
+                } else {
+                        showActivationFeedback(`${actor} refused ${deviceName}.`, true);
+                }
+                if (resolution.accepted) {
+                        const deviceData = {
+                                deviceId: resolution.deviceId,
+                                id: resolution.deviceId,
+                                name: resolution.deviceName,
+                                macAddress: resolution.macAddress,
+                                latitude: resolution.latitude,
+                                longitude: resolution.longitude,
+                                deviceType: resolution.deviceType
+                        };
+                        addOrUpdateDeviceMarker(deviceData);
+                        recalculateBounds();
+                        if (resolution.operatorId === currentOperatorId) {
+                                upsertDeviceRow(deviceData);
+                        }
+                }
+        }
+
+        async function loadPendingActivations() {
+                try {
+                        const response = await fetch(`/api/operators/activations/${projectId}`, {
+                                credentials: 'same-origin'
+                        });
+                        if (!response.ok) {
+                                throw new Error(`Status ${response.status}`);
+                        }
+                        const data = await response.json();
+                        if (Array.isArray(data)) {
+                                data.forEach(addActivationNotification);
+                        }
+                } catch (error) {
+                        console.error('Unable to load activation requests', error);
+                }
+        }
+
+        function subscribeToActivationStream() {
+                try {
+                        const eventSource = new EventSource(`/api/operators/activations/stream/${projectId}`);
+                        eventSource.addEventListener('activation-request', event => {
+                                try {
+                                        const notification = JSON.parse(event.data);
+                                        addActivationNotification(notification);
+                                } catch (parseError) {
+                                        console.error('Unable to parse activation request', parseError);
+                                }
+                        });
+                        eventSource.addEventListener('activation-response', event => {
+                                try {
+                                        const resolution = JSON.parse(event.data);
+                                        handleActivationResolution(resolution);
+                                } catch (parseError) {
+                                        console.error('Unable to parse activation response', parseError);
+                                }
+                        });
+                        eventSource.onerror = () => {
+                                console.warn('Activation event stream disconnected');
+                        };
+                } catch (error) {
+                        console.error('Unable to subscribe to activation stream', error);
+                }
+        }
+
+        refreshActivationEmptyState();
+        loadPendingActivations();
+        subscribeToActivationStream();
+</script>
+
 
         <script>
                 document.addEventListener("DOMContentLoaded", function () {

--- a/src/test/java/it/sensorplatform/test/OperatorActivationFlowTests.java
+++ b/src/test/java/it/sensorplatform/test/OperatorActivationFlowTests.java
@@ -1,6 +1,7 @@
 package it.sensorplatform.test;
 
 import it.sensorplatform.dto.OperatorActivationNotification;
+import it.sensorplatform.dto.OperatorActivationResolution;
 import it.sensorplatform.dto.PacketDTO;
 import it.sensorplatform.model.Admin;
 import it.sensorplatform.model.Credentials;
@@ -16,6 +17,7 @@ import it.sensorplatform.service.PacketService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -101,6 +103,11 @@ class OperatorActivationFlowTests {
         PacketService.Result result = packetService.handlePacket(packet);
         assertEquals(PacketService.Result.ACTIVATION, result);
 
+        Device pending = deviceRepository.findById(device.getId()).orElseThrow();
+        assertFalse(pending.isActivated());
+        assertNull(pending.getLatitude());
+        assertNull(pending.getLongitude());
+
         List<OperatorActivationNotification> authorizedNotifications =
                 operatorActivationService.listForOperator(project.getId(), authorizedOperator.getId());
         assertEquals(1, authorizedNotifications.size());
@@ -113,9 +120,33 @@ class OperatorActivationFlowTests {
                 operatorActivationService.listForOperator(project.getId(), unauthorizedOperator.getId());
         assertTrue(unauthorizedNotifications.isEmpty());
 
-        OperatorActivationNotification consumed = operatorActivationService.consume(
-                project.getId(), device.getId(), authorizedOperator.getId());
-        assertNotNull(consumed);
+        OperatorActivationResolution resolution = operatorActivationService.respond(
+                project.getId(),
+                device.getId(),
+                authorizedOperator,
+                true,
+                46.3,
+                8.5
+        ).orElseThrow();
+        assertTrue(resolution.isAccepted());
+        assertEquals(authorizedOperator.getId(), resolution.getOperatorId());
+        assertEquals(device.getId(), resolution.getDeviceId());
+
+        Device activated = deviceRepository.findById(device.getId()).orElseThrow();
+        assertTrue(activated.isActivated());
+        assertEquals(46.3, activated.getLatitude());
+        assertEquals(8.5, activated.getLongitude());
+        assertEquals(authorizedOperator.getId(), activated.getOperator().getId());
+
         assertTrue(operatorActivationService.listForOperator(project.getId(), authorizedOperator.getId()).isEmpty());
+
+        assertThrows(AccessDeniedException.class, () -> operatorActivationService.respond(
+                project.getId(),
+                device.getId(),
+                unauthorizedOperator,
+                true,
+                40.0,
+                10.0
+        ));
     }
 }

--- a/src/test/java/it/sensorplatform/test/PacketServiceTests.java
+++ b/src/test/java/it/sensorplatform/test/PacketServiceTests.java
@@ -76,7 +76,7 @@ class PacketServiceTests {
     }
 
     @Test
-    void activatesDeviceWhenNotYetActivated() {
+    void notifiesActivationWithoutAutomaticallyActivatingDevice() {
         Project project = new Project();
         project.setName("demo");
         projectRepository.save(project);
@@ -100,9 +100,9 @@ class PacketServiceTests {
         assertEquals(PacketService.Result.ACTIVATION, res);
 
         Device updated = deviceRepository.findByMacAddress(MacAddressUtils.normalize("AA:FF:00")).orElseThrow();
-        assertTrue(updated.isActivated());
-        assertEquals(45.0, updated.getLatitude());
-        assertEquals(7.0, updated.getLongitude());
+        assertFalse(updated.isActivated());
+        assertEquals(0d, updated.getLatitude());
+        assertEquals(0d, updated.getLongitude());
     }
 }
 


### PR DESCRIPTION
## Summary
- add an operator-only activation response endpoint that persists geolocation data and publishes resolution events
- enrich the operator activation service with SSE response broadcasts and new DTOs to describe operator decisions
- update the operator dashboard to surface activation requests, request geolocation permission, and call the new API while keeping the map/table in sync
- adapt the activation flow tests to exercise the new manual approval path and ensure packets no longer auto-activate devices

## Testing
- `./mvnw test` *(fails: unable to download Maven wrapper dependencies in the sandbox)*
- `mvn test` *(fails: cannot reach Maven Central to resolve the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a6cb81b8832eb1ec92bca4edbb96