### PR TITLE
Fix missing Objects import in OperatorActivationService

### DIFF
--- a/src/main/java/it/sensorplatform/service/OperatorActivationService.java
+++ b/src/main/java/it/sensorplatform/service/OperatorActivationService.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
## Summary
- add the missing `java.util.Objects` import in `OperatorActivationService` so stream filtering compiles

## Testing
- `mvn -DskipTests compile` *(fails: cannot reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ac88b1a483278b2ca342aec19653