### PR TITLE
Allow async dispatcher requests for REST endpoints

### DIFF
--- a/AetherSense-codex-add-jackson-aware-setter-for-indicator/src/main/java/it/sensorplatform/authentication/AuthConfiguration.java
+++ b/AetherSense-codex-add-jackson-aware-setter-for-indicator/src/main/java/it/sensorplatform/authentication/AuthConfiguration.java
@@ -17,6 +17,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import jakarta.servlet.DispatcherType;
+
 import it.sensorplatform.failurehandler.CustomAuthenticationFailureHandler;
 import it.sensorplatform.successhandler.CustomLoginSuccessHandler;
 
@@ -79,12 +81,13 @@ public class AuthConfiguration {
     )
 )
 
-		.authorizeHttpRequests(auth -> auth
-				.requestMatchers(HttpMethod.GET, "/", "/home", "/login", "/register", "/access", "/css/**", "/img/**", "/favicon.ico", "/videos/**", "/project/**").permitAll()
-				.requestMatchers(HttpMethod.POST, "/login", "/register").permitAll()
-				.requestMatchers(HttpMethod.POST, "/api/packets").permitAll()
-				
-				.requestMatchers(HttpMethod.GET, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers(HttpMethod.GET, "/", "/home", "/login", "/register", "/access", "/css/**", "/img/**", "/favicon.ico", "/videos/**", "/project/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/login", "/register").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/packets").permitAll()
+                                .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
+
+                                .requestMatchers(HttpMethod.GET, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)
 				.requestMatchers(HttpMethod.POST, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)
 				
 				.requestMatchers(HttpMethod.GET, "/admin/ltrad/**").hasAuthority(LTRAD_ADMIN_ROLE)

--- a/src/main/java/it/sensorplatform/authentication/AuthConfiguration.java
+++ b/src/main/java/it/sensorplatform/authentication/AuthConfiguration.java
@@ -17,6 +17,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import jakarta.servlet.DispatcherType;
+
 import it.sensorplatform.failurehandler.CustomAuthenticationFailureHandler;
 import it.sensorplatform.successhandler.CustomLoginSuccessHandler;
 
@@ -79,12 +81,13 @@ public class AuthConfiguration {
     )
 )
 
-		.authorizeHttpRequests(auth -> auth
-				.requestMatchers(HttpMethod.GET, "/", "/home", "/login", "/register", "/access", "/css/**", "/img/**", "/favicon.ico", "/videos/**", "/project/**").permitAll()
-				.requestMatchers(HttpMethod.POST, "/login", "/register").permitAll()
-				.requestMatchers(HttpMethod.POST, "/api/packets").permitAll()
-				
-				.requestMatchers(HttpMethod.GET, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)
+                .authorizeHttpRequests(auth -> auth
+                                .requestMatchers(HttpMethod.GET, "/", "/home", "/login", "/register", "/access", "/css/**", "/img/**", "/favicon.ico", "/videos/**", "/project/**").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/login", "/register").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/packets").permitAll()
+                                .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
+
+                                .requestMatchers(HttpMethod.GET, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)
 				.requestMatchers(HttpMethod.POST, "/superadmin/**").hasAuthority(SUPERADMIN_ROLE)
 				
 				.requestMatchers(HttpMethod.GET, "/admin/ltrad/**").hasAuthority(LTRAD_ADMIN_ROLE)


### PR DESCRIPTION
## Summary
- allow Spring Security to automatically permit asynchronous dispatches by explicitly permitting DispatcherType.ASYNC
- mirror the security configuration change in the secondary module copy

## Testing
- ./mvnw -q -DskipTests package *(fails: unable to download Maven distribution in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b3ab91388327bdf9d879e20a59eb