### PR TITLE
Add helper for activation identifiers and restore SSE list

### DIFF
--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -86,10 +86,15 @@
                         <div class="title-with-search">
                                 <h2 class="section-title">Activation Requests</h2>
                         </div>
-                        <a th:href="@{'/operator/' + ${project.id} + '/activations'}" class="activation-requests-link">
-                                <span class="activation-requests-icon" aria-hidden="true">⚡</span>
-                                <span>Open activation requests</span>
-                        </a>
+                        <div id="activation-feedback" class="activation-feedback" role="status" aria-live="polite"></div>
+                        <div id="activation-requests-wrapper">
+                                <p id="activation-requests-empty">No activation requests</p>
+                                <ul id="activation-requests-list" class="activation-request-list"></ul>
+                                <a th:href="@{'/operator/' + ${project.id} + '/activations'}" class="activation-requests-link">
+                                        <span class="activation-requests-icon" aria-hidden="true">⚡</span>
+                                        <span>Open activation requests</span>
+                                </a>
+                        </div>
 
                         <div class="title-with-search">
                                 <h2>Your Devices on Map</h2>
@@ -298,6 +303,353 @@
                         fetchAndDisplayDevices(groupName);
                 });
         });
+
+        const csrfTokenMeta = document.querySelector('meta[name="_csrf"]');
+        const csrfHeaderMeta = document.querySelector('meta[name="_csrf_header"]');
+        const csrfToken = csrfTokenMeta ? csrfTokenMeta.getAttribute('content') : null;
+        const csrfHeader = csrfHeaderMeta ? csrfHeaderMeta.getAttribute('content') : null;
+
+        function buildHeaders() {
+                const headers = {'Content-Type': 'application/json'};
+                if (csrfToken && csrfHeader) {
+                        headers[csrfHeader] = csrfToken;
+                }
+                return headers;
+        }
+
+        const activationRequests = new Map();
+        const activationList = document.getElementById('activation-requests-list');
+        const activationEmpty = document.getElementById('activation-requests-empty');
+        const activationFeedback = document.getElementById('activation-feedback');
+        let activationFeedbackTimeout = null;
+
+        function refreshActivationEmptyState() {
+                if (!activationEmpty) {
+                        return;
+                }
+                activationEmpty.style.display = activationRequests.size === 0 ? 'block' : 'none';
+        }
+
+        function showActivationFeedback(message, isError = false) {
+                if (!activationFeedback) {
+                        return;
+                }
+                if (activationFeedbackTimeout) {
+                        window.clearTimeout(activationFeedbackTimeout);
+                        activationFeedbackTimeout = null;
+                }
+                if (!message) {
+                        activationFeedback.textContent = '';
+                        activationFeedback.style.padding = '0';
+                        activationFeedback.style.marginBottom = '0';
+                        activationFeedback.style.backgroundColor = 'transparent';
+                        return;
+                }
+                activationFeedback.textContent = message;
+                activationFeedback.style.padding = '8px 12px';
+                activationFeedback.style.marginBottom = '8px';
+                activationFeedback.style.backgroundColor = isError ? 'rgba(176,0,32,0.15)' : 'rgba(10,135,84,0.15)';
+                activationFeedback.style.color = isError ? '#b00020' : '#0a8754';
+                activationFeedbackTimeout = window.setTimeout(() => {
+                        activationFeedback.textContent = '';
+                        activationFeedback.style.padding = '0';
+                        activationFeedback.style.marginBottom = '0';
+                        activationFeedback.style.backgroundColor = 'transparent';
+                }, 6000);
+        }
+
+        function updateLocationContent(element, latitude, longitude) {
+                if (!element) {
+                        return;
+                }
+                if (latitude == null || longitude == null) {
+                        element.textContent = 'unknown';
+                        return;
+                }
+                const latFixed = Number(latitude).toFixed(5);
+                const lonFixed = Number(longitude).toFixed(5);
+                element.textContent = `${latFixed}, ${lonFixed}`;
+        }
+
+        function formatActivationIdentifier(notification) {
+                if (!notification) {
+                        return {label: 'MAC', value: 'n/a'};
+                }
+                const formattedMac = formatMac(notification.macAddress);
+                if (formattedMac) {
+                        return {label: 'MAC', value: formattedMac};
+                }
+                if (notification.devEui) {
+                        const normalized = String(notification.devEui).trim();
+                        if (normalized) {
+                                return {label: 'DevEUI', value: normalized.toUpperCase()};
+                        }
+                }
+                return {label: 'MAC', value: 'n/a'};
+        }
+
+        function updateActivationElement(element, notification) {
+                if (!element || !notification) {
+                        return;
+                }
+                const title = element.querySelector('.activation-request-title');
+                if (title) {
+                        title.textContent = notification.deviceName || 'Unnamed device';
+                }
+                const identifier = formatActivationIdentifier(notification);
+                const macLabel = element.querySelector('.activation-request-mac-label');
+                if (macLabel) {
+                        macLabel.textContent = `${identifier.label}:`;
+                }
+                const macValue = element.querySelector('.activation-request-mac-value');
+                if (macValue) {
+                        macValue.textContent = identifier.value || 'n/a';
+                }
+                const adminValue = element.querySelector('.activation-request-admin-value');
+                if (adminValue) {
+                        adminValue.textContent = notification.adminEmail || 'n/a';
+                }
+                const locationValue = element.querySelector('.activation-request-location-value');
+                updateLocationContent(locationValue, notification.latitude, notification.longitude);
+        }
+
+        function createActivationElement(notification) {
+                const li = document.createElement('li');
+                li.className = 'activation-request-item';
+                li.dataset.deviceId = notification.deviceId;
+
+                const title = document.createElement('div');
+                title.className = 'activation-request-title';
+                li.appendChild(title);
+
+                const macLine = document.createElement('div');
+                macLine.className = 'activation-request-field';
+                const macLabel = document.createElement('strong');
+                macLabel.className = 'activation-request-mac-label';
+                macLine.appendChild(macLabel);
+                macLine.appendChild(document.createTextNode(' '));
+                const macValue = document.createElement('span');
+                macValue.className = 'activation-request-mac-value';
+                macLine.appendChild(macValue);
+                li.appendChild(macLine);
+
+                const adminLine = document.createElement('div');
+                adminLine.className = 'activation-request-field';
+                adminLine.innerHTML = '<strong>Admin:</strong> <span class="activation-request-admin-value"></span>';
+                li.appendChild(adminLine);
+
+                const locationLine = document.createElement('div');
+                locationLine.className = 'activation-request-field';
+                locationLine.innerHTML = '<strong>Location:</strong> <span class="activation-request-location-value"></span>';
+                li.appendChild(locationLine);
+
+                const actions = document.createElement('div');
+                actions.className = 'activation-request-actions';
+
+                const acceptButton = document.createElement('button');
+                acceptButton.type = 'button';
+                acceptButton.className = 'activation-request-accept';
+                acceptButton.textContent = 'Accept';
+
+                const refuseButton = document.createElement('button');
+                refuseButton.type = 'button';
+                refuseButton.className = 'activation-request-refuse';
+                refuseButton.textContent = 'Refuse';
+
+                actions.appendChild(acceptButton);
+                actions.appendChild(refuseButton);
+                li.appendChild(actions);
+
+                acceptButton.addEventListener('click', () => respondToActivation(notification, true, acceptButton, refuseButton));
+                refuseButton.addEventListener('click', () => respondToActivation(notification, false, acceptButton, refuseButton));
+
+                updateActivationElement(li, notification);
+                return {element: li, acceptButton, refuseButton};
+        }
+
+        function addActivationNotification(notification) {
+                if (!notification || notification.deviceId == null) {
+                        return;
+                }
+                const existing = activationRequests.get(notification.deviceId);
+                if (existing) {
+                        existing.notification = notification;
+                        updateActivationElement(existing.element, notification);
+                        refreshActivationEmptyState();
+                        return;
+                }
+                if (!activationList) {
+                        return;
+                }
+                const {element, acceptButton, refuseButton} = createActivationElement(notification);
+                activationRequests.set(notification.deviceId, {
+                        notification,
+                        element,
+                        acceptButton,
+                        refuseButton
+                });
+                activationList.appendChild(element);
+                refreshActivationEmptyState();
+        }
+
+        function removeActivationNotification(deviceId) {
+                const existing = activationRequests.get(deviceId);
+                if (!existing) {
+                        refreshActivationEmptyState();
+                        return;
+                }
+                if (existing.element && existing.element.parentElement) {
+                        existing.element.parentElement.removeChild(existing.element);
+                }
+                activationRequests.delete(deviceId);
+                refreshActivationEmptyState();
+        }
+
+        function getGeolocation() {
+                return new Promise((resolve, reject) => {
+                        if (!navigator.geolocation) {
+                                reject(new Error('Geolocation not supported'));
+                                return;
+                        }
+                        navigator.geolocation.getCurrentPosition(
+                                position => resolve({
+                                        latitude: Number(position.coords.latitude),
+                                        longitude: Number(position.coords.longitude)
+                                }),
+                                error => reject(error),
+                                {enableHighAccuracy: true, timeout: 10000}
+                        );
+                });
+        }
+
+        async function respondToActivation(notification, accepted, acceptButton, refuseButton) {
+                if (!notification) {
+                        return;
+                }
+                const entry = activationRequests.get(notification.deviceId);
+                const payloadNotification = entry ? entry.notification : notification;
+                if (acceptButton) {
+                        acceptButton.disabled = true;
+                }
+                if (refuseButton) {
+                        refuseButton.disabled = true;
+                }
+                try {
+                        let coordinates = {latitude: null, longitude: null};
+                        if (accepted) {
+                                try {
+                                        coordinates = await getGeolocation();
+                                } catch (geoError) {
+                                        const proceed = window.confirm('Unable to retrieve your location. Do you want to continue without coordinates?');
+                                        if (!proceed) {
+                                                throw geoError;
+                                        }
+                                }
+                        }
+                        const response = await fetch(`/api/operators/activations/${projectId}/${payloadNotification.deviceId}/response`, {
+                                method: 'POST',
+                                headers: buildHeaders(),
+                                credentials: 'same-origin',
+                                body: JSON.stringify({
+                                        accepted: accepted,
+                                        latitude: coordinates.latitude,
+                                        longitude: coordinates.longitude
+                                })
+                        });
+                        if (!response.ok) {
+                                throw new Error(`Server responded with status ${response.status}`);
+                        }
+                        const result = await response.json();
+                        handleActivationResolution(result);
+                } catch (error) {
+                        console.error('Activation response failed', error);
+                        showActivationFeedback('Unable to send response. Please try again.', true);
+                        if (acceptButton) {
+                                acceptButton.disabled = false;
+                        }
+                        if (refuseButton) {
+                                refuseButton.disabled = false;
+                        }
+                }
+        }
+
+        function handleActivationResolution(resolution) {
+                if (!resolution || resolution.deviceId == null) {
+                        return;
+                }
+                removeActivationNotification(resolution.deviceId);
+                const actor = resolution.operatorName || 'An operator';
+                const deviceName = resolution.deviceName || 'the device';
+                if (resolution.accepted) {
+                        showActivationFeedback(`${actor} activated ${deviceName}.`, false);
+                } else {
+                        showActivationFeedback(`${actor} refused ${deviceName}.`, true);
+                }
+                if (resolution.accepted) {
+                        const deviceData = {
+                                deviceId: resolution.deviceId,
+                                id: resolution.deviceId,
+                                name: resolution.deviceName,
+                                macAddress: resolution.macAddress,
+                                latitude: resolution.latitude,
+                                longitude: resolution.longitude,
+                                deviceType: resolution.deviceType
+                        };
+                        addOrUpdateDeviceMarker(deviceData);
+                        recalculateBounds();
+                        if (resolution.operatorId === currentOperatorId) {
+                                upsertDeviceRow(deviceData);
+                        }
+                }
+        }
+
+        async function loadPendingActivations() {
+                try {
+                        const response = await fetch(`/api/operators/activations/${projectId}`, {
+                                credentials: 'same-origin'
+                        });
+                        if (!response.ok) {
+                                throw new Error(`Status ${response.status}`);
+                        }
+                        const data = await response.json();
+                        if (Array.isArray(data)) {
+                                data.forEach(addActivationNotification);
+                        }
+                } catch (error) {
+                        console.error('Unable to load activation requests', error);
+                }
+        }
+
+        function subscribeToActivationStream() {
+                try {
+                        const eventSource = new EventSource(`/api/operators/activations/stream/${projectId}`);
+                        eventSource.addEventListener('activation-request', event => {
+                                try {
+                                        const notification = JSON.parse(event.data);
+                                        addActivationNotification(notification);
+                                } catch (parseError) {
+                                        console.error('Unable to parse activation request', parseError);
+                                }
+                        });
+                        eventSource.addEventListener('activation-response', event => {
+                                try {
+                                        const resolution = JSON.parse(event.data);
+                                        handleActivationResolution(resolution);
+                                } catch (parseError) {
+                                        console.error('Unable to parse activation response', parseError);
+                                }
+                        });
+                        eventSource.onerror = () => {
+                                console.warn('Activation event stream disconnected');
+                        };
+                } catch (error) {
+                        console.error('Unable to subscribe to activation stream', error);
+                }
+        }
+
+        refreshActivationEmptyState();
+        loadPendingActivations();
+        subscribeToActivationStream();
 
 </script>
 


### PR DESCRIPTION
## Summary
- restore the activation requests list on the operator view and keep a link to the dedicated page
- add a formatActivationIdentifier helper so MAC labels fall back to DevEUI when needed
- wire the SSE setup to use the helper for both the initial load and streamed updates

## Testing
- `./mvnw -q -DskipTests package` *(fails: unable to download Maven distribution in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d31182c42c832e93c858a2cb56b1ba