### PR TITLE
Remove group section from operator page

### DIFF
--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -57,32 +57,7 @@
 
 	<div class="main-layout">
 		<!-- Colonna sinistra -->
-		<div class="group-panel">
-			<h1 class="group-container">Select a group to focus the map</h1>
-			<div class="title-with-search">
-				<h2 class="section-title">Groups</h2>
-				<form th:action="@{'/operator/' + ${project.id}}" method="get" class="search-form">
-					<input type="text" name="groupName" placeholder="Search..." th:value="${param.groupName}" />
-					<button type="submit" title="Search">
-						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 24 24">
-							<circle cx="11" cy="11" r="8" stroke="white" stroke-width="2" fill="none" />
-							<line x1="17" y1="17" x2="22" y2="22" stroke="white" stroke-width="2" />
-						</svg>
-					</button>
-				</form>
-			</div>
-                        <div id="groups-wrapper">
-                                <div th:if="${groups.isEmpty()}">No groups available</div>
-                                <ul>
-                                        <li th:each="group : ${groups}">
-                                                <details class="groups">
-                                                        <summary th:text="${group.name}" th:attr="data-group-name=${group.name}">Group</summary>
-                                                        <ul class="device-list"></ul>
-                                                </details>
-                                        </li>
-                                </ul>
-                        </div>
-
+                <div class="group-panel">
                         <div class="title-with-search">
                                 <h2 class="section-title">Activation Requests</h2>
                         </div>
@@ -270,39 +245,6 @@
                         <td>${type}</td>
                 `;
         }
-
-        function fetchAndDisplayDevices(groupName) {
-                fetch('/api/groups/name/' + encodeURIComponent(groupName) + '/devices')
-                        .then(response => response.json())
-                        .then(devices => {
-                                const validDevices = devices.filter(d => d.latitude != null && d.longitude != null);
-                                if (validDevices.length > 0) {
-                                        const bounds = L.latLngBounds(validDevices.map(d => [d.latitude, d.longitude]));
-                                        map.fitBounds(bounds, {padding: [20, 20]});
-                                }
-                                document.querySelectorAll(`summary[data-group-name="${groupName}"]`).forEach(summary => {
-                                        const details = summary.parentElement;
-                                        const ul = details.querySelector('.device-list');
-                                        if (!ul) {
-                                                return;
-                                        }
-                                        ul.innerHTML = '';
-                                        devices.forEach(device => {
-                                                const li = document.createElement('li');
-                                                li.textContent = `${device.name} (${formatMac(device.macAddress)})`;
-                                                ul.appendChild(li);
-                                        });
-                                });
-                        })
-                        .catch(error => console.error('Unable to load group devices', error));
-        }
-
-        document.querySelectorAll('summary[data-group-name]').forEach(summary => {
-                summary.addEventListener('click', () => {
-                        const groupName = summary.getAttribute('data-group-name');
-                        fetchAndDisplayDevices(groupName);
-                });
-        });
 
         const csrfTokenMeta = document.querySelector('meta[name="_csrf"]');
         const csrfHeaderMeta = document.querySelector('meta[name="_csrf_header"]');


### PR DESCRIPTION
## Summary
- remove the group selection UI from the operator dashboard
- delete the related JavaScript used to load and display devices per group

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3f62793d083238a05e27f9b078884