### PR TITLE
Add page title to operator dashboard

### DIFF
--- a/src/main/resources/static/css/fireOperator.css
+++ b/src/main/resources/static/css/fireOperator.css
@@ -35,6 +35,13 @@ html, body {
   align-items: center;
   gap: 1rem;
 }
+
+.page-title {
+  margin: 1.5rem auto 1rem;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+}
 .home-button {
   color: #fff;
   text-decoration: none;

--- a/src/main/resources/static/css/ltradOperator.css
+++ b/src/main/resources/static/css/ltradOperator.css
@@ -49,6 +49,13 @@ navbar h1 {
 	gap: 1rem;
 }
 
+.page-title {
+	margin: 1.5rem auto 1rem;
+	text-align: center;
+	font-size: 2rem;
+	font-weight: 700;
+}
+
 .home-button {
   color: #fff;
   text-decoration: none;

--- a/src/main/resources/static/css/volcanoOperator.css
+++ b/src/main/resources/static/css/volcanoOperator.css
@@ -49,6 +49,13 @@ navbar h1 {
 	gap: 1rem;
 }
 
+.page-title {
+	margin: 1.5rem auto 1rem;
+	text-align: center;
+	font-size: 2rem;
+	font-weight: 700;
+}
+
 .home-button {
   color: #fff;
   text-decoration: none;

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -55,7 +55,9 @@
 		</div>
 	</header>
 
-	<div class="main-layout">
+        <h1 class="page-title" th:text="${project.name} + ' – Operator Map'">Operator Map</h1>
+
+        <div class="main-layout">
 		<!-- Colonna sinistra -->
                 <div class="group-panel">
                         <div class="title-with-search">


### PR DESCRIPTION
## Summary
- add a prominent heading to the operator page that reflects the current project name
- style the heading consistently across the LTRAD, FIRE, and VOLCANO operator themes

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d3f83fcb40832385a258055924fc81