### PR TITLE
Align FIRE operator dashboard title to left

### DIFF
--- a/src/main/resources/static/css/fireOperator.css
+++ b/src/main/resources/static/css/fireOperator.css
@@ -37,8 +37,8 @@ html, body {
 }
 
 .page-title {
-  margin: 1.5rem auto 1rem;
-  text-align: center;
+  margin: 1.5rem 0 1rem;
+  text-align: left;
   font-size: 2rem;
   font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- adjust the FIRE operator dashboard page title styles to remove centered alignment and align it flush left

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3fcc9b9f4832394edf474df34d770