### PR TITLE
Fix identifier formatting in groups template

### DIFF
--- a/src/main/java/it/sensorplatform/util/MacAddressUtils.java
+++ b/src/main/java/it/sensorplatform/util/MacAddressUtils.java
@@ -23,5 +23,20 @@ public final class MacAddressUtils {
         String cleaned = normalize(mac);
         return cleaned == null ? "" : cleaned.replaceAll("..(?!$)", "$0:");
     }
+
+    public static String formatIdentifierForProject(Number projectId, String macAddress, String devEui) {
+        boolean preferMac = projectId != null && projectId.longValue() == 101L;
+
+        String primary = preferMac ? macAddress : devEui;
+        String secondary = preferMac ? devEui : macAddress;
+
+        String formattedPrimary = format(primary);
+        if (!formattedPrimary.isEmpty()) {
+            return formattedPrimary;
+        }
+
+        String formattedSecondary = format(secondary);
+        return formattedSecondary.isEmpty() ? "--" : formattedSecondary;
+    }
 }
 

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -151,17 +151,7 @@
                                                   <tr th:each="device : ${devices}">
                                                           <td th:text="${device.name}">Name</td>
                                                           <td
-                                                              th:text="${project.id == 101}
-                                                                      ? (device.macAddress != null
-                                                                              ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)
-                                                                              : (device.devEui != null
-                                                                                      ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui)
-                                                                                      : '--'))
-                                                                      : (device.devEui != null
-                                                                              ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui)
-                                                                              : (device.macAddress != null
-                                                                                      ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)
-                                                                                      : '--'))">
+                                                              th:text="${T(it.sensorplatform.util.MacAddressUtils).formatIdentifierForProject(project.id, device.macAddress, device.devEui)}">
                                                                   Identifier
                                                           </td>
                                                           <td th:text="${device.tod}">Mac Address</td>

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -100,17 +100,7 @@
                                                 <tr th:each="device : ${devices}">
                                                         <td th:text="${device.name}">Name</td>
                                                         <td
-                                                                th:text="${project.id == 101}
-                                                                        ? (device.macAddress != null
-                                                                                ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)
-                                                                                : (device.devEui != null
-                                                                                        ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui)
-                                                                                        : '--'))
-                                                                        : (device.devEui != null
-                                                                                ? T(it.sensorplatform.util.MacAddressUtils).format(device.devEui)
-                                                                                : (device.macAddress != null
-                                                                                        ? T(it.sensorplatform.util.MacAddressUtils).format(device.macAddress)
-                                                                                        : '--'))">
+                                                                th:text="${T(it.sensorplatform.util.MacAddressUtils).formatIdentifierForProject(project.id, device.macAddress, device.devEui)}">
                                                                 Identifier
                                                         </td>
                                                         <td th:text="${device.tod}">Type</td>


### PR DESCRIPTION
## Summary
- add a utility method to format device identifiers based on the active project
- replace the nested ternary expressions in the admin and operator templates with the helper to avoid Thymeleaf parsing errors

## Testing
- ./mvnw test *(fails: unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d41ca68a708323968e64681104504f