### PR TITLE
Implement coordinate-based activation updates

### DIFF
--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -74,6 +74,29 @@ public class PacketService {
 
         Device device = existing.get();
 
+        Double latitude = packet.getLatitude();
+        Double longitude = packet.getLongitude();
+        boolean hasValidCoordinates = hasValidCoordinate(latitude) && hasValidCoordinate(longitude);
+        boolean hasEmailOwner = StringUtils.hasText(device.getEmailOwner());
+        boolean deviceUpdated = false;
+
+        if (hasValidCoordinates && hasEmailOwner) {
+            if (!device.isActivated()) {
+                device.setLatitude(latitude);
+                device.setLongitude(longitude);
+                device.setActivated(true);
+                deviceUpdated = true;
+            } else if (coordinatesDiffer(device.getLatitude(), latitude) || coordinatesDiffer(device.getLongitude(), longitude)) {
+                device.setLatitude(latitude);
+                device.setLongitude(longitude);
+                deviceUpdated = true;
+            }
+
+            if (deviceUpdated) {
+                deviceRepository.save(device);
+            }
+        }
+
         if (!device.isActivated()) {
             System.out.println("PacketService.handlePacket - activation packet for device: " + device.getId());
             notifyOperators(device, packet);
@@ -117,6 +140,17 @@ public class PacketService {
             return;
         }
         operatorActivationService.notifyActivation(device, packet, managedAdmin, authorizedOperators);
+    }
+
+    private boolean hasValidCoordinate(Double value) {
+        return value != null && !Double.isNaN(value) && Double.compare(value, 0d) != 0;
+    }
+
+    private boolean coordinatesDiffer(Double stored, Double incoming) {
+        if (incoming == null) {
+            return false;
+        }
+        return stored == null || Double.compare(stored, incoming) != 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- update PacketService to auto-activate devices that send valid coordinates when an owner email is configured
- persist coordinate changes for already-activated devices when incoming packets include updated values
- add coordinate validation helpers used by the packet handling flow

## Testing
- `./mvnw test` *(fails: wget unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5563f13488323a73395367b808d2a