### PR TITLE
Adjust assign GSheet table columns

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -607,17 +607,22 @@ body.modal-open {
 
 .gsheet-table th:nth-child(1),
 .gsheet-table td:nth-child(1) {
-    width: 25%;
+    width: 20%;
 }
 
 .gsheet-table th:nth-child(2),
 .gsheet-table td:nth-child(2) {
-    width: 25%;
+    width: 35%;
+}
+
+.gsheet-table td:nth-child(2) {
+    overflow-wrap: anywhere;
+    word-break: break-all;
 }
 
 .gsheet-table th:nth-child(3),
 .gsheet-table td:nth-child(3) {
-    width: 40%;
+    width: 35%;
 }
 
 .gsheet-table th:nth-child(4),

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -595,17 +595,22 @@ body.modal-open {
 
 .gsheet-table th:nth-child(1),
 .gsheet-table td:nth-child(1) {
-    width: 25%;
+    width: 20%;
 }
 
 .gsheet-table th:nth-child(2),
 .gsheet-table td:nth-child(2) {
-    width: 25%;
+    width: 35%;
+}
+
+.gsheet-table td:nth-child(2) {
+    overflow-wrap: anywhere;
+    word-break: break-all;
 }
 
 .gsheet-table th:nth-child(3),
 .gsheet-table td:nth-child(3) {
-    width: 40%;
+    width: 35%;
 }
 
 .gsheet-table th:nth-child(4),

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -698,17 +698,22 @@ body.modal-open {
 
 .gsheet-table th:nth-child(1),
 .gsheet-table td:nth-child(1) {
-    width: 25%;
+    width: 20%;
 }
 
 .gsheet-table th:nth-child(2),
 .gsheet-table td:nth-child(2) {
-    width: 25%;
+    width: 35%;
+}
+
+.gsheet-table td:nth-child(2) {
+    overflow-wrap: anywhere;
+    word-break: break-all;
 }
 
 .gsheet-table th:nth-child(3),
 .gsheet-table td:nth-child(3) {
-    width: 40%;
+    width: 35%;
 }
 
 .gsheet-table th:nth-child(4),


### PR DESCRIPTION
## Summary
- widen the DevEui column in the Assign GSheet modal across all themes
- allow long identifiers in the second column to wrap instead of overflowing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d64c11202483279707494af791735e