### PR TITLE
Update Assign GSheet modal column heading

### DIFF
--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -196,7 +196,7 @@
                                         <thead>
                                                 <tr>
                                                         <th scope="col">Name</th>
-                                                        <th scope="col">Identifier</th>
+                                                        <th scope="col">MacAddress/DevEui</th>
                                                         <th scope="col">Current GSheet</th>
                                                         <th scope="col">Select</th>
                                                 </tr>


### PR DESCRIPTION
## Summary
- rename the Assign GSheet modal identifier column header to "MacAddress/DevEui"

## Testing
- Manually opened the Assign GSheet modal in the browser to verify the updated header


------
https://chatgpt.com/codex/tasks/task_e_68d64ce9dd808327ab5a20af1d9208ed