### PR TITLE
Align device list styling across themes

### DIFF
--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -247,9 +247,31 @@ details[open] summary {
 }
 
 .device-list {
-	padding-left: 2.3rem;
-	list-style-type: disc;
-	font-size: 1rem;
+        list-style: none;
+        margin: 0;
+        padding-left: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-size: 1rem;
+}
+
+details .device-list li {
+        position: relative;
+        padding-left: 1.5rem;
+}
+
+details .device-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0.45rem;
+        height: 0.45rem;
+        border-radius: 50%;
+        background-color: currentColor;
+        opacity: 0.6;
 }
 
 /* Pop-up Leaflet */

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -247,9 +247,31 @@ details[open] summary {
 }
 
 .device-list {
-	padding-left: 2.3rem;
-	list-style-type: disc;
-	font-size: 1rem;
+        list-style: none;
+        margin: 0;
+        padding-left: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-size: 1rem;
+}
+
+details .device-list li {
+        position: relative;
+        padding-left: 1.5rem;
+}
+
+details .device-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0.45rem;
+        height: 0.45rem;
+        border-radius: 50%;
+        background-color: currentColor;
+        opacity: 0.6;
 }
 
 /* Pop-up Leaflet */

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -247,9 +247,31 @@ details[open] summary {
 }
 
 .device-list {
-	padding-left: 2.3rem;
-	list-style-type: disc;
-	font-size: 1rem;
+        list-style: none;
+        margin: 0;
+        padding-left: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        font-size: 1rem;
+}
+
+details .device-list li {
+        position: relative;
+        padding-left: 1.5rem;
+}
+
+details .device-list li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 0.45rem;
+        height: 0.45rem;
+        border-radius: 50%;
+        background-color: currentColor;
+        opacity: 0.6;
 }
 
 /* Pop-up Leaflet */


### PR DESCRIPTION
## Summary
- update the `.device-list` rules across LTRAD, FIRE, and VOLCANO themes to remove default bullets and use a consistent flex column layout with spacing
- add custom indentation and decorative markers for `details .device-list li` elements so device entries remain legible without relying on list-style discs

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d65100f45083279a0c07d09024efa7