### PR TITLE
Remove confirm dialog before removing operator

### DIFF
--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -479,18 +479,21 @@
                                         e.preventDefault();
                                         const deviceKey = removeBtn.getAttribute('data-mac');
                                         if (!deviceKey) return;
-                                        if (!confirm('Remove operator from this device?')) return;
+
+                                        removeBtn.disabled = true;
+                                        removeBtn.setAttribute('aria-disabled', 'true');
+                                        removeBtn.classList.add('is-removing');
 
                                         // POST via form per includere CSRF
                                         const f = document.createElement('form');
                                         f.method = 'post';
                                         f.action = REMOVE_OP_URL({deviceKey});
-					const csrf = document.querySelector('input[name="_csrf"]');
-					if (csrf) {
-						const t = document.createElement('input');
-						t.type = 'hidden'; t.name = '_csrf'; t.value = csrf.value;
-						f.appendChild(t);
-					}
+                                        const csrf = document.querySelector('input[name="_csrf"]');
+                                        if (csrf) {
+                                                const t = document.createElement('input');
+                                                t.type = 'hidden'; t.name = '_csrf'; t.value = csrf.value;
+                                                f.appendChild(t);
+                                        }
                                         document.body.appendChild(f);
                                         f.submit();
                                 }


### PR DESCRIPTION
## Summary
- remove the confirm dialog when clicking the remove-operator button
- disable the button while submitting to provide lightweight feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65258b8d883279bf3b91f09e8b929