### PR TITLE
Fix indicator join table mapping

### DIFF
--- a/src/main/java/it/sensorplatform/model/TypeOfDevice.java
+++ b/src/main/java/it/sensorplatform/model/TypeOfDevice.java
@@ -11,7 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotBlank;
 
 @Entity
@@ -26,11 +26,12 @@ public class TypeOfDevice {
         @ManyToMany
         private List<Spec> specs;
 
-        @OneToMany
+        @ManyToMany
         @JoinTable(
                         name = "type_of_device_indicator",
                         joinColumns = @JoinColumn(name = "type_of_device_id"),
-                        inverseJoinColumns = @JoinColumn(name = "indicator_id"))
+                        inverseJoinColumns = @JoinColumn(name = "indicator_id"),
+                        uniqueConstraints = @UniqueConstraint(columnNames = { "type_of_device_id", "indicator_id" }))
         private List<Indicator> indicators;
 
 	public Long getId() {


### PR DESCRIPTION
## Summary
- map TypeOfDevice.indicators as a ManyToMany association using the existing join table
- enforce a composite unique constraint on type_of_device_indicator for the type and indicator pair
- remove the unused OneToMany import

## Testing
- ./mvnw test *(fails: Maven wrapper could not download Maven distribution in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d653b0d36083239ef83445011ca4ee