### PR TITLE
Adjust device manager and map layout

### DIFF
--- a/src/main/resources/static/css/manageProjectDevicesFire.css
+++ b/src/main/resources/static/css/manageProjectDevicesFire.css
@@ -185,19 +185,21 @@ navbar h1 {
 }
 
 .devices-panel {
-    width: 80%;
+    flex: 0 0 50%;
     background-color: #1B263B;
     padding: 1.5rem 2rem;
     box-shadow: inset -1px 0 5px rgba(0, 0, 0, 0.3);
     display: block;
-	overflow-y: auto; /* attiva lo scroll verticale */
-	overflow-x: hidden; /* opzionale per evitare scroll orizzontale */
-
+    overflow: auto;
+    min-width: 320px;
+    max-width: 75vw;
+    resize: horizontal;
 }
 
 /* Mappa */
 #map {
-    width: 20%;
+    flex: 1 1 50%;
+    min-width: 320px;
     height: 100%;
     overflow: hidden;
 }

--- a/src/main/resources/static/css/manageProjectDevicesLtrad.css
+++ b/src/main/resources/static/css/manageProjectDevicesLtrad.css
@@ -184,19 +184,21 @@ navbar h1 {
 }
 
 .devices-panel {
-    width: 80%;
+    flex: 0 0 50%;
     background-color: #0d1b2a;
     padding: 1.5rem 2rem;
     box-shadow: inset -1px 0 5px rgba(0, 0, 0, 0.3);
     display: block;
-	overflow-y: auto; /* attiva lo scroll verticale */
-	overflow-x: hidden; /* opzionale per evitare scroll orizzontale */
-
+    overflow: auto;
+    min-width: 320px;
+    max-width: 75vw;
+    resize: horizontal;
 }
 
 /* Mappa */
 #map {
-    width: 20%;
+    flex: 1 1 50%;
+    min-width: 320px;
     height: 100%;
     overflow: hidden;
 }

--- a/src/main/resources/static/css/manageProjectDevicesVolcano.css
+++ b/src/main/resources/static/css/manageProjectDevicesVolcano.css
@@ -290,27 +290,31 @@ html, body {
 
 /* Layout principale: sinistra gestione dispositivi, destra mappa */
 .main-layout {
-	display: flex;
-	height: calc(100vh - 3em);
-	overflow: hidden;
+        display: flex;
+        height: calc(100vh - 3em);
+        overflow: hidden;
 }
 
 .devices-panel {
-    width: 80%;
+    flex: 0 0 50%;
     background-color: #1B263B;
     padding: 1.5rem 2rem;
     box-shadow: inset -1px 0 5px rgba(0, 0, 0, 0.3);
     display: block;
-	overflow-y: auto; /* attiva lo scroll verticale */
-	overflow-x: hidden; /* opzionale per evitare scroll orizzontale */
+    overflow: auto;
+    min-width: 320px;
+    max-width: 75vw;
+    resize: horizontal;
 }
 
 /* Mappa */
 #map {
-	width: 60%;
-	height: 100%;
-	z-index:1;
-	/* previene scroll interni */
+        flex: 1 1 50%;
+        min-width: 320px;
+        height: 100%;
+        z-index:1;
+        overflow: hidden;
+        /* previene scroll interni */
 }
 
 /* Titoli */

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -244,10 +244,30 @@
         let initialDevices = [[${devices}]];
 	/*]]>*/
 
-	let map = L.map('map').setView([41.89, 12.48], 12);
-	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-		attribution: '&copy; OpenStreetMap contributors'
-	}).addTo(map);
+        let map = L.map('map').setView([41.89, 12.48], 12);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                attribution: '&copy; OpenStreetMap contributors'
+        }).addTo(map);
+
+        function invalidateMapSize() {
+                map.invalidateSize();
+        }
+
+        window.addEventListener('resize', invalidateMapSize);
+
+        if (window.ResizeObserver) {
+                const resizeObserver = new ResizeObserver(invalidateMapSize);
+                const devicesPanelElement = document.querySelector('.devices-panel');
+                const mapElement = document.getElementById('map');
+                if (devicesPanelElement) {
+                        resizeObserver.observe(devicesPanelElement);
+                }
+                if (mapElement) {
+                        resizeObserver.observe(mapElement);
+                }
+        }
+
+        requestAnimationFrame(invalidateMapSize);
 
         let markerByDeviceKey = new Map();
 


### PR DESCRIPTION
## Summary
- Set the device management panel and map to load side-by-side with a 50/50 split across all project themes.
- Allow the device management panel to be horizontally resizable while constraining its minimum and maximum widths.
- Invalidate the Leaflet map size when the layout changes so the map expands correctly when the panel is resized or the window changes.

## Testing
- Not run (not requested).

------
https://chatgpt.com/codex/tasks/task_e_68d6574062848327b6fe22ea4217f9cf