### PR TITLE
Fix Thymeleaf literal string parsing error in notifications template

### DIFF
--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -42,7 +42,7 @@
     <header class="notifications-header">
         <div class="notifications-header-text">
             <h2 id="notifications-title" class="notifications-title"
-                th:text="New device notifications">New device notifications</h2>
+                th:text="'New device notifications'">New device notifications</h2>
             <p class="notifications-description">Live feed of devices waiting to be paired with the project.</p>
         </div>
         <div class="notifications-header-actions">


### PR DESCRIPTION
## Summary
- ensure the notifications title in the superadmin device notifications template uses a literal string expression Thymeleaf can parse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6585fff1c832383c6f299161e961f