### PR TITLE
Align manage groups action styling

### DIFF
--- a/src/main/resources/static/css/manageGroupsFire.css
+++ b/src/main/resources/static/css/manageGroupsFire.css
@@ -297,8 +297,35 @@ html, body {
 }
 
 .btn-save:hover {
-	background-color: #1b5e20;
-	transform: scale(1.05);
+        background-color: #1b5e20;
+        transform: scale(1.05);
+}
+
+.btn-icon {
+        width: 2.4rem;
+        height: 2.4rem;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: background-color 0.2s, transform 0.1s;
+}
+
+.btn-icon svg {
+        display: block;
+}
+
+.btn-delete {
+        background-color: #e53935;
+        color: white;
+}
+
+.btn-delete:hover {
+        background-color: #c62828;
+        transform: scale(1.05);
 }
 
 .card-edit-device {
@@ -318,7 +345,14 @@ html, body {
     color: #ff1a1a;
     text-align: center;
     font-size: 1.5rem;
-	margin-top:-0.5rem;
+        margin-top:-0.5rem;
+}
+
+.card-edit-device td:last-child {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.5rem;
 }
 
 .device-form {

--- a/src/main/resources/static/css/manageGroupsLtrad.css
+++ b/src/main/resources/static/css/manageGroupsLtrad.css
@@ -283,19 +283,46 @@ html, body {
 
 /* Pulsante salva */
 .btn-save {
-	background-color: #2e7d32;
-	color: white;
-	padding: 0.5rem 1rem;
-	border: none;
-	border-radius: 6px;
-	font-weight: bold;
-	cursor: pointer;
-	transition: background-color 0.2s ease, transform 0.2s ease;
+        background-color: #2e7d32;
+        color: white;
+        padding: 0.5rem 1rem;
+        border: none;
+        border-radius: 6px;
+        font-weight: bold;
+        cursor: pointer;
+        transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .btn-save:hover {
-	background-color: #1b5e20;
-	transform: scale(1.05);
+        background-color: #1b5e20;
+        transform: scale(1.05);
+}
+
+.btn-icon {
+        width: 2.4rem;
+        height: 2.4rem;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: background-color 0.2s, transform 0.1s;
+}
+
+.btn-icon svg {
+        display: block;
+}
+
+.btn-delete {
+        background-color: #e53935;
+        color: white;
+}
+
+.btn-delete:hover {
+        background-color: #c62828;
+        transform: scale(1.05);
 }
 
 .card-edit-device {
@@ -315,7 +342,14 @@ html, body {
     color: #00bfff;
     text-align: center;
     font-size: 1.5rem;
-	margin-top:-0.5rem;
+        margin-top:-0.5rem;
+}
+
+.card-edit-device td:last-child {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.5rem;
 }
 
 .device-form {

--- a/src/main/resources/static/css/manageGroupsVolcano.css
+++ b/src/main/resources/static/css/manageGroupsVolcano.css
@@ -294,8 +294,35 @@ html, body {
 }
 
 .btn-save:hover {
-	background-color: #1b5e20;
-	transform: scale(1.05);
+        background-color: #1b5e20;
+        transform: scale(1.05);
+}
+
+.btn-icon {
+        width: 2.4rem;
+        height: 2.4rem;
+        padding: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: background-color 0.2s, transform 0.1s;
+}
+
+.btn-icon svg {
+        display: block;
+}
+
+.btn-delete {
+        background-color: #e53935;
+        color: white;
+}
+
+.btn-delete:hover {
+        background-color: #c62828;
+        transform: scale(1.05);
 }
 
 .card-edit-device {
@@ -315,7 +342,14 @@ html, body {
     color: #00bfff;
     text-align: center;
     font-size: 1.5rem;
-	margin-top:-0.5rem;
+        margin-top:-0.5rem;
+}
+
+.card-edit-device td:last-child {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 0.5rem;
 }
 
 .device-form {

--- a/src/main/resources/templates/admin/manageGroups.html
+++ b/src/main/resources/templates/admin/manageGroups.html
@@ -112,9 +112,14 @@
 				    <td>
 				        <form th:action="@{'/group/' + ${project.id} + '/' + ${group.id} + '/removeDevice/' + ${device.macAddress}}" 
 				              method="post" th:csrf="true">
-				            <button type="submit" class="btn-icon btn-delete" title="Remove from Group">🗑️</button>
-				        </form>
-				    </td>
+                                            <button type="submit" class="btn-icon btn-delete" title="Remove from Group">
+                                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+                                                    <path d="M16 9v10H8V9h8m-1.5-6h-5l-1 1H5v2h14V4h-3.5l-1-1z" />
+                                                    <path d="M9 9h6v10H9z" opacity=".35" />
+                                                </svg>
+                                            </button>
+                                        </form>
+                                    </td>
 				</tr>
 		        <tr th:if="${#lists.isEmpty(group.devices)}">
 		            <td colspan="4">No devices assigned to this group.</td>


### PR DESCRIPTION
## Summary
- replace the remove-device emoji with the shared inline SVG trash icon
- add shared button styling and centered action cell layout for manage groups themes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d663dd04c88327817d44d86cb49587