### PR TITLE
Restyle admin groups list as cards

### DIFF
--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -196,7 +196,72 @@ navbar h1 {
 
 
 .groups {
-	font-size: 1.2rem;
+        font-size: 1.2rem;
+}
+
+summary::-webkit-details-marker {
+        display: none;
+}
+
+.group-card {
+        background-color: #241013;
+        border: 1px solid rgba(204, 0, 0, 0.4);
+        border-radius: 12px;
+        margin-bottom: 1rem;
+        box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+        overflow: hidden;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.group-card:hover {
+        border-color: rgba(255, 71, 26, 0.75);
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+}
+
+.groups summary {
+        cursor: pointer;
+        list-style: none;
+}
+
+.group-summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.9rem 1.1rem;
+        background: rgba(47, 16, 18, 0.95);
+        transition: background 0.2s ease;
+}
+
+.group-card:hover .group-summary,
+.groups[open] > summary .group-summary {
+        background: rgba(204, 0, 0, 0.25);
+        box-shadow: inset 0 0 0 1px rgba(204, 0, 0, 0.35);
+}
+
+.group-name {
+        font-weight: 600;
+        flex: 1;
+}
+
+.group-count {
+        background: rgba(204, 0, 0, 0.25);
+        border: 1px solid rgba(204, 0, 0, 0.45);
+        border-radius: 999px;
+        padding: 0.2rem 0.75rem;
+        font-size: 0.85rem;
+        font-weight: 500;
+        color: #ffd0d0;
+        white-space: nowrap;
+}
+
+.group-chevron {
+        fill: #ff8a80;
+        transition: transform 0.3s ease;
+}
+
+.groups[open] .group-chevron {
+        transform: rotate(180deg);
 }
 
 /* Colonna destra - mappa fissa */
@@ -252,41 +317,51 @@ navbar h1 {
 /* Lista gruppi */
 
 details summary {
-	cursor: pointer;
-	font-weight: bold;
-	padding: 5px 0;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 0;
 }
 
 details[open] summary {
-	color: white;
+        color: white;
 }
 
-.device-list {
+.group-card .device-list {
         list-style: none;
         margin: 0;
-        padding-left: 0;
+        padding: 0.85rem 1.2rem 1.1rem;
+        border-top: 1px solid rgba(204, 0, 0, 0.4);
+        background: rgba(25, 10, 12, 0.9);
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.65rem;
         font-size: 1rem;
 }
 
-details .device-list li {
+.group-card .device-list li {
         position: relative;
         padding-left: 1.5rem;
+        border-bottom: 1px solid rgba(204, 0, 0, 0.2);
+        padding-bottom: 0.5rem;
+        margin-bottom: 0.2rem;
 }
 
-details .device-list li::before {
+.group-card .device-list li:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+        margin-bottom: 0;
+}
+
+.group-card .device-list li::before {
         content: "";
         position: absolute;
         left: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 0.45rem;
-        height: 0.45rem;
+        top: 0.45rem;
+        width: 0.55rem;
+        height: 0.55rem;
         border-radius: 50%;
-        background-color: currentColor;
-        opacity: 0.6;
+        background: #cc0000;
+        box-shadow: 0 0 0 2px rgba(204, 0, 0, 0.3);
 }
 
 /* Pop-up Leaflet */

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -196,7 +196,72 @@ navbar h1 {
 
 
 .groups {
-	font-size: 1.2rem;
+        font-size: 1.2rem;
+}
+
+summary::-webkit-details-marker {
+        display: none;
+}
+
+.group-card {
+        background-color: #10253f;
+        border: 1px solid rgba(0, 123, 255, 0.35);
+        border-radius: 12px;
+        margin-bottom: 1rem;
+        box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+        overflow: hidden;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.group-card:hover {
+        border-color: rgba(0, 123, 255, 0.65);
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+}
+
+.groups summary {
+        cursor: pointer;
+        list-style: none;
+}
+
+.group-summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.9rem 1.1rem;
+        background: rgba(15, 39, 68, 0.9);
+        transition: background 0.2s ease;
+}
+
+.group-card:hover .group-summary,
+.groups[open] > summary .group-summary {
+        background: rgba(0, 123, 255, 0.2);
+        box-shadow: inset 0 0 0 1px rgba(0, 123, 255, 0.35);
+}
+
+.group-name {
+        font-weight: 600;
+        flex: 1;
+}
+
+.group-count {
+        background: rgba(0, 123, 255, 0.25);
+        border: 1px solid rgba(0, 123, 255, 0.4);
+        border-radius: 999px;
+        padding: 0.2rem 0.75rem;
+        font-size: 0.85rem;
+        font-weight: 500;
+        color: #b8d9ff;
+        white-space: nowrap;
+}
+
+.group-chevron {
+        fill: #a4c9ff;
+        transition: transform 0.3s ease;
+}
+
+.groups[open] .group-chevron {
+        transform: rotate(180deg);
 }
 
 /* Colonna destra - mappa fissa */
@@ -252,41 +317,51 @@ navbar h1 {
 /* Lista gruppi */
 
 details summary {
-	cursor: pointer;
-	font-weight: bold;
-	padding: 5px 0;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 0;
 }
 
 details[open] summary {
-	color: white;
+        color: white;
 }
 
-.device-list {
+.group-card .device-list {
         list-style: none;
         margin: 0;
-        padding-left: 0;
+        padding: 0.85rem 1.2rem 1.1rem;
+        border-top: 1px solid rgba(0, 123, 255, 0.35);
+        background: rgba(11, 26, 47, 0.85);
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.65rem;
         font-size: 1rem;
 }
 
-details .device-list li {
+.group-card .device-list li {
         position: relative;
         padding-left: 1.5rem;
+        border-bottom: 1px solid rgba(0, 123, 255, 0.15);
+        padding-bottom: 0.5rem;
+        margin-bottom: 0.2rem;
 }
 
-details .device-list li::before {
+.group-card .device-list li:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+        margin-bottom: 0;
+}
+
+.group-card .device-list li::before {
         content: "";
         position: absolute;
         left: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 0.45rem;
-        height: 0.45rem;
+        top: 0.45rem;
+        width: 0.55rem;
+        height: 0.55rem;
         border-radius: 50%;
-        background-color: currentColor;
-        opacity: 0.6;
+        background: #007bff;
+        box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
 }
 
 /* Pop-up Leaflet */

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -196,7 +196,72 @@ navbar h1 {
 
 
 .groups {
-	font-size: 1.2rem;
+        font-size: 1.2rem;
+}
+
+summary::-webkit-details-marker {
+        display: none;
+}
+
+.group-card {
+        background-color: #261a0f;
+        border: 1px solid rgba(230, 126, 0, 0.45);
+        border-radius: 12px;
+        margin-bottom: 1rem;
+        box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+        overflow: hidden;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.group-card:hover {
+        border-color: rgba(255, 170, 51, 0.85);
+        box-shadow: 0 10px 20px rgba(0, 0, 0, 0.45);
+}
+
+.groups summary {
+        cursor: pointer;
+        list-style: none;
+}
+
+.group-summary {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.9rem 1.1rem;
+        background: rgba(44, 26, 10, 0.95);
+        transition: background 0.2s ease;
+}
+
+.group-card:hover .group-summary,
+.groups[open] > summary .group-summary {
+        background: rgba(230, 126, 0, 0.25);
+        box-shadow: inset 0 0 0 1px rgba(230, 126, 0, 0.35);
+}
+
+.group-name {
+        font-weight: 600;
+        flex: 1;
+}
+
+.group-count {
+        background: rgba(230, 126, 0, 0.25);
+        border: 1px solid rgba(230, 126, 0, 0.45);
+        border-radius: 999px;
+        padding: 0.2rem 0.75rem;
+        font-size: 0.85rem;
+        font-weight: 500;
+        color: #ffe0b3;
+        white-space: nowrap;
+}
+
+.group-chevron {
+        fill: #ffbe76;
+        transition: transform 0.3s ease;
+}
+
+.groups[open] .group-chevron {
+        transform: rotate(180deg);
 }
 
 /* Colonna destra - mappa fissa */
@@ -252,41 +317,51 @@ navbar h1 {
 /* Lista gruppi */
 
 details summary {
-	cursor: pointer;
-	font-weight: bold;
-	padding: 5px 0;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 0;
 }
 
 details[open] summary {
-	color: white;
+        color: white;
 }
 
-.device-list {
+.group-card .device-list {
         list-style: none;
         margin: 0;
-        padding-left: 0;
+        padding: 0.85rem 1.2rem 1.1rem;
+        border-top: 1px solid rgba(230, 126, 0, 0.45);
+        background: rgba(23, 14, 6, 0.9);
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.65rem;
         font-size: 1rem;
 }
 
-details .device-list li {
+.group-card .device-list li {
         position: relative;
         padding-left: 1.5rem;
+        border-bottom: 1px solid rgba(230, 126, 0, 0.2);
+        padding-bottom: 0.5rem;
+        margin-bottom: 0.2rem;
 }
 
-details .device-list li::before {
+.group-card .device-list li:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+        margin-bottom: 0;
+}
+
+.group-card .device-list li::before {
         content: "";
         position: absolute;
         left: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 0.45rem;
-        height: 0.45rem;
+        top: 0.45rem;
+        width: 0.55rem;
+        height: 0.55rem;
         border-radius: 50%;
-        background-color: currentColor;
-        opacity: 0.6;
+        background: #e67e00;
+        box-shadow: 0 0 0 2px rgba(230, 126, 0, 0.3);
 }
 
 /* Pop-up Leaflet */

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -105,14 +105,24 @@
 
 			<div id="groups-wrapper">
 				<div th:if="${groups.isEmpty()}">No groups available</div>
-				<ul>
-					<li th:each="group : ${groups}">
-						<details class="groups">
-							<summary th:text="${group.name}" th:attr="data-group-name=${group.name}">Group</summary>
-							<ul class="device-list"></ul>
-						</details>
-					</li>
-				</ul>
+                                <ul>
+                                        <li th:each="group : ${groups}">
+                                                <div class="group-card">
+                                                        <details class="groups">
+                                                                <summary th:attr="data-group-name=${group.name}">
+                                                                        <div class="group-summary">
+                                                                                <span class="group-name" th:text="${group.name}">Group</span>
+                                                                                <span class="group-count" th:text="${group.devices.size()} + ' devices'">0 devices</span>
+                                                                                <svg class="group-chevron" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true" focusable="false">
+                                                                                        <path d="M7 10l5 5 5-5z" />
+                                                                                </svg>
+                                                                        </div>
+                                                                </summary>
+                                                                <ul class="device-list"></ul>
+                                                        </details>
+                                                </div>
+                                        </li>
+                                </ul>
 			</div>
 
 			<div class="title-with-search">


### PR DESCRIPTION
## Summary
- wrap each admin group listing in a card container with a structured summary header and device count badge
- refresh the group list styling across all project themes to present stacked cards and cohesive device lists

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d66586b97483278ca6eb089a357d30