### PR TITLE
Restyle groups list and operator controls

### DIFF
--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -251,10 +251,21 @@ navbar h1 {
 
 /* Lista gruppi */
 
+#groups-wrapper > ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+}
+
+#groups-wrapper > ul > li {
+    list-style: none;
+    margin: 0 0 0.35rem;
+}
+
 details summary {
-	cursor: pointer;
-	font-weight: bold;
-	padding: 5px 0;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 5px 0;
 }
 
 details[open] summary {
@@ -324,9 +335,47 @@ details .device-list li::before {
 }
 
 .title-with-search h2 {
-	margin-top:2rem;
+        margin-top:2rem;
     margin: 0;
     font-size: 1.4rem;
+}
+
+.operators-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.operators-header h2 {
+    margin: 0;
+}
+
+.register-operator-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #ff6b6b, #c1121f);
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    letter-spacing: 0.01em;
+    box-shadow: 0 8px 18px rgba(193, 18, 31, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.register-operator-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(193, 18, 31, 0.45);
+    filter: brightness(1.05);
+}
+
+.register-operator-btn svg {
+    stroke: currentColor;
 }
 
 /* Stile compatto */

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -251,10 +251,21 @@ navbar h1 {
 
 /* Lista gruppi */
 
+#groups-wrapper > ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+}
+
+#groups-wrapper > ul > li {
+    list-style: none;
+    margin: 0 0 0.35rem;
+}
+
 details summary {
-	cursor: pointer;
-	font-weight: bold;
-	padding: 5px 0;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 5px 0;
 }
 
 details[open] summary {
@@ -324,9 +335,47 @@ details .device-list li::before {
 }
 
 .title-with-search h2 {
-	margin-top:2rem;
+        margin-top:2rem;
     margin: 0;
     font-size: 1.4rem;
+}
+
+.operators-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.operators-header h2 {
+    margin: 0;
+}
+
+.register-operator-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #4dabf7, #1c7ed6);
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    letter-spacing: 0.01em;
+    box-shadow: 0 8px 18px rgba(28, 126, 214, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.register-operator-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(28, 126, 214, 0.45);
+    filter: brightness(1.05);
+}
+
+.register-operator-btn svg {
+    stroke: currentColor;
 }
 
 /* Stile compatto */

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -251,10 +251,21 @@ navbar h1 {
 
 /* Lista gruppi */
 
+#groups-wrapper > ul {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+}
+
+#groups-wrapper > ul > li {
+    list-style: none;
+    margin: 0 0 0.35rem;
+}
+
 details summary {
-	cursor: pointer;
-	font-weight: bold;
-	padding: 5px 0;
+        cursor: pointer;
+        font-weight: bold;
+        padding: 5px 0;
 }
 
 details[open] summary {
@@ -324,9 +335,47 @@ details .device-list li::before {
 }
 
 .title-with-search h2 {
-	margin-top:2rem;
+        margin-top:2rem;
     margin: 0;
     font-size: 1.4rem;
+}
+
+.operators-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.operators-header h2 {
+    margin: 0;
+}
+
+.register-operator-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #ff922b, #d9480f);
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    letter-spacing: 0.01em;
+    box-shadow: 0 8px 18px rgba(217, 72, 15, 0.35);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+.register-operator-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(217, 72, 15, 0.45);
+    filter: brightness(1.05);
+}
+
+.register-operator-btn svg {
+    stroke: currentColor;
 }
 
 /* Stile compatto */

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -63,35 +63,17 @@
 			<h1 class="group-container">Select a group to display its devices</h1>
 
 			<div class="title-with-search">
-				<h2 class="section-title">
-					Groups
-					<a th:href="@{'/manageGroups/' + ${project.id}}" class="edit-icon" title="Manage Groups">
-						<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor"
-							viewBox="0 0 24 24">
-							<path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 
-				                     7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 
-				                     0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
-						</svg>
-					</a>
-					<!-- Pulsante per registrare operatore -->
-					<a th:href="@{'/admin/formRegisterOperator/' + ${project.id}}" class="edit-icon"
-						style="margin-left:10px" title="Register Operator">
-						<!-- Icona "user-plus" -->
-						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none"
-							stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-							<!-- testa -->
-							<circle cx="8" cy="7" r="4" />
-							<!-- spalle -->
-							<path d="M2 21v-2a7 7 0 0 1 12 0v2" />
-							<!-- + più distanziato -->
-							<g transform="translate(1,0)">
-								<path d="M16 11h6" />
-								<path d="M19 8v6" />
-							</g>
-
-						</svg>
-					</a>
-				</h2>
+                                <h2 class="section-title">
+                                        Groups
+                                        <a th:href="@{'/manageGroups/' + ${project.id}}" class="edit-icon" title="Manage Groups">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" fill="currentColor"
+                                                        viewBox="0 0 24 24">
+                                                        <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71
+                                                     7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959
+                                                     0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z" />
+                                                </svg>
+                                        </a>
+                                </h2>
 				<form th:action="@{'/group/' + ${project.id}}" method="get" class="search-form">
 					<input type="text" name="groupName" placeholder="Search..." th:value="${param.groupName}" />
 					<button type="submit" title="Search">
@@ -189,7 +171,21 @@
                                   <div id="userDevicesPagination" class="table-pagination-controls"></div>
                           </div>
                           <div th:if="${user.admin != null}" id="operator-table-wrapper">
-                                  <h2>Operators</h2>
+                                  <div class="operators-header">
+                                          <h2>Operators</h2>
+                                          <a th:href="@{'/admin/formRegisterOperator/' + ${project.id}}"
+                                                  class="register-operator-btn" title="Register Operator">
+                                                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18"
+                                                          fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                                                          stroke-linejoin="round" aria-hidden="true">
+                                                          <circle cx="8" cy="7" r="4" />
+                                                          <path d="M2 21v-2a7 7 0 0 1 12 0v2" />
+                                                          <path d="M16 11h6" />
+                                                          <path d="M19 8v6" />
+                                                  </svg>
+                                                  <span>Register operator</span>
+                                          </a>
+                                  </div>
                                   <table id="operators-table">
                                           <thead>
                                                   <tr>


### PR DESCRIPTION
## Summary
- remove bullet markers from the groups dropdown and tidy the group list spacing across project themes
- move the register operator action beside the Operators heading with a refreshed button style for each theme

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6791f206c8327976f0b769fddc1f3