### PR TITLE
Color-code admin map pins based on indicator status

### DIFF
--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -148,12 +148,41 @@ navbar h1 {
 
 
 .dropdown-link:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
 }
 
 
 .dropdown-logout:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
+}
+
+.device-marker {
+        background: transparent;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+}
+
+.device-marker-dot {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        border: 2px solid #ffffff;
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+        background-color: var(--device-marker-color, #9aa0a6);
+}
+
+.device-marker-ok .device-marker-dot {
+        --device-marker-color: #22c55e;
+}
+
+.device-marker-alert .device-marker-dot {
+        --device-marker-color: #f87171;
+}
+
+.device-marker-unknown .device-marker-dot {
+        --device-marker-color: #9aa0a6;
 }
 
 

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -148,12 +148,41 @@ navbar h1 {
 
 
 .dropdown-link:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
 }
 
 
 .dropdown-logout:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
+}
+
+.device-marker {
+        background: transparent;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+}
+
+.device-marker-dot {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        border: 2px solid #ffffff;
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+        background-color: var(--device-marker-color, #9aa0a6);
+}
+
+.device-marker-ok .device-marker-dot {
+        --device-marker-color: #22c55e;
+}
+
+.device-marker-alert .device-marker-dot {
+        --device-marker-color: #f87171;
+}
+
+.device-marker-unknown .device-marker-dot {
+        --device-marker-color: #9aa0a6;
 }
 
 

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -148,12 +148,41 @@ navbar h1 {
 
 
 .dropdown-link:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
 }
 
 
 .dropdown-logout:hover {
-	background-color: rgba(255, 255, 255, 0.1);
+        background-color: rgba(255, 255, 255, 0.1);
+}
+
+.device-marker {
+        background: transparent;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+}
+
+.device-marker-dot {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        border: 2px solid #ffffff;
+        box-shadow: 0 0 4px rgba(0, 0, 0, 0.4);
+        background-color: var(--device-marker-color, #9aa0a6);
+}
+
+.device-marker-ok .device-marker-dot {
+        --device-marker-color: #22c55e;
+}
+
+.device-marker-alert .device-marker-dot {
+        --device-marker-color: #f87171;
+}
+
+.device-marker-unknown .device-marker-dot {
+        --device-marker-color: #9aa0a6;
 }
 
 

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -219,6 +219,22 @@
 
                 let allLatLngs = [];
 
+                const markerIcons = {
+                        ok: createStatusIcon('ok'),
+                        alert: createStatusIcon('alert'),
+                        unknown: createStatusIcon('unknown')
+                };
+
+                function createStatusIcon(status) {
+                        return L.divIcon({
+                                className: `device-marker device-marker-${status}`,
+                                iconSize: [24, 24],
+                                iconAnchor: [12, 12],
+                                popupAnchor: [0, -12],
+                                html: '<span class="device-marker-dot"></span>'
+                        });
+                }
+
                 function formatIdentifier(value) {
                         if (!value) {
                                 return '';
@@ -239,7 +255,7 @@
                         const latlng = [d.latitude, d.longitude];
                         allLatLngs.push(latlng);
 
-                        const marker = L.marker(latlng).addTo(map);
+                        const marker = L.marker(latlng, { icon: markerIcons.unknown }).addTo(map);
                         const key = resolveDeviceKey(d);
                         const formattedKey = formatIdentifier(key);
                         const fallbackDevEui = d.devEui ? formatIdentifier(d.devEui) : '';
@@ -262,6 +278,11 @@
                         }
                 });
 
+                if (markerByDeviceKey.size > 0) {
+                        refreshAllMarkerStatuses();
+                        setInterval(refreshAllMarkerStatuses, 60000);
+                }
+
 		// Disegna il poligono solo se ci sono almeno 3 punti
 		if (allLatLngs.length > 0) {
 			const bounds = L.latLngBounds(allLatLngs);
@@ -270,9 +291,9 @@
 
 
 
-		function fetchAndDisplayDevices(groupName) {
-			fetch('/api/groups/name/' + encodeURIComponent(groupName) + '/devices')
-				.then(response => response.json())
+                function fetchAndDisplayDevices(groupName) {
+                        fetch('/api/groups/name/' + encodeURIComponent(groupName) + '/devices')
+                                .then(response => response.json())
 				.then(devices => {
                                         const validDevices = devices.filter(d => d.latitude != null && d.longitude != null);
                                         if (validDevices.length === 1) {
@@ -304,11 +325,81 @@
 			});
 		});
 
-		document.getElementById("groupInput").addEventListener("change", function () {
-			const groupName = this.value;
-			fetchAndDisplayDevices(groupName);
-		});
-	</script>
+                const groupInputElement = document.getElementById("groupInput");
+                if (groupInputElement) {
+                        groupInputElement.addEventListener("change", function () {
+                                const groupName = this.value;
+                                fetchAndDisplayDevices(groupName);
+                        });
+                }
+
+                function refreshAllMarkerStatuses() {
+                        const tasks = [];
+                        markerByDeviceKey.forEach((marker, key) => {
+                                tasks.push(updateMarkerStatusForDevice(key, marker));
+                        });
+                        if (tasks.length) {
+                                Promise.all(tasks).catch(error => console.error('Failed to refresh marker statuses', error));
+                        }
+                }
+
+                async function updateMarkerStatusForDevice(deviceKey, marker) {
+                        try {
+                                const status = await fetchDeviceStatus(deviceKey);
+                                applyStatusIcon(marker, status);
+                        } catch (error) {
+                                console.error('Failed to update marker status for', deviceKey, error);
+                                applyStatusIcon(marker, 'unknown');
+                        }
+                }
+
+                async function fetchDeviceStatus(deviceKey) {
+                        const response = await fetch(`/api/admin/devices/${encodeURIComponent(deviceKey)}/telemetry/latest`);
+                        if (!response.ok) {
+                                return 'unknown';
+                        }
+                        if (response.status === 204) {
+                                return 'unknown';
+                        }
+                        const payload = await response.json();
+                        const indicators = Array.isArray(payload?.indicators) ? payload.indicators : [];
+                        if (indicators.length === 0) {
+                                return 'ok';
+                        }
+                        const hasAlert = indicators.some(indicatorHasAlertValue);
+                        return hasAlert ? 'alert' : 'ok';
+                }
+
+                function indicatorHasAlertValue(indicator) {
+                        if (!indicator) {
+                                return false;
+                        }
+                        const value = indicator.value;
+                        if (value === null || value === undefined) {
+                                return false;
+                        }
+                        if (typeof value === 'boolean') {
+                                return value;
+                        }
+                        const numeric = Number(value);
+                        if (!Number.isNaN(numeric)) {
+                                return numeric !== 0;
+                        }
+                        const normalized = String(value).trim().toLowerCase();
+                        if (!normalized) {
+                                return false;
+                        }
+                        if (normalized === '0' || normalized === 'false' || normalized === 'ok' || normalized === 'clear') {
+                                return false;
+                        }
+                        return true;
+                }
+
+                function applyStatusIcon(marker, status) {
+                        const icon = markerIcons[status] || markerIcons.unknown;
+                        marker.setIcon(icon);
+                }
+        </script>
 
         <script>
                 document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
## Summary
- add Leaflet div icons to render admin map pins with green, red, or gray styling
- query each device's latest telemetry indicators and update markers when alerts are detected
- share reusable marker styles across LTRAD, FIRE, and VOLCANO admin themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6808df4a08327896eadd5948f079e