### PR TITLE
Handle indicator payload metrics when processing packets

### DIFF
--- a/src/main/java/it/sensorplatform/dto/PacketDTO.java
+++ b/src/main/java/it/sensorplatform/dto/PacketDTO.java
@@ -20,6 +20,7 @@ public class PacketDTO {
     private Double latitude;
     private Double longitude;
     private Map<String, Object> payload;
+    private Map<String, Object> indicatorPayload;
     private List<SpecEntry> spec;
     private List<String> indicator;
 
@@ -77,6 +78,14 @@ public class PacketDTO {
 
     public void setPayload(Map<String, Object> payload) {
         this.payload = payload;
+    }
+
+    public Map<String, Object> getIndicatorPayload() {
+        return indicatorPayload;
+    }
+
+    public void setIndicatorPayload(Map<String, Object> indicatorPayload) {
+        this.indicatorPayload = indicatorPayload;
     }
 
     public List<SpecEntry> getSpec() {

--- a/src/main/java/it/sensorplatform/service/PacketService.java
+++ b/src/main/java/it/sensorplatform/service/PacketService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.List;
@@ -105,7 +106,7 @@ public class PacketService {
 
         System.out.println("PacketService.handlePacket - forwarding data to IngestService for device: " + device.getMacAddress());
         // Case 3: normal data packet -> forward metrics to ingest service
-        Map<String, Object> payload = packet.getPayload();
+        Map<String, Object> payload = mergeMetrics(packet.getPayload(), packet.getIndicatorPayload());
         ingestService.process(
                 device,
                 Instant.now(),
@@ -114,6 +115,28 @@ public class PacketService {
                 packet.getIndicator()
         );
         return Result.DATA;
+    }
+
+    private Map<String, Object> mergeMetrics(Map<String, Object> payload,
+                                             Map<String, Object> indicatorPayload) {
+        if (indicatorPayload == null || indicatorPayload.isEmpty()) {
+            return payload;
+        }
+        Map<String, Object> merged = new LinkedHashMap<>();
+        if (payload != null && !payload.isEmpty()) {
+            merged.putAll(payload);
+        }
+        for (Map.Entry<String, Object> entry : indicatorPayload.entrySet()) {
+            String key = entry.getKey();
+            if (!StringUtils.hasText(key)) {
+                continue;
+            }
+            String trimmedKey = key.trim();
+            if (!trimmedKey.isEmpty()) {
+                merged.put(trimmedKey, entry.getValue());
+            }
+        }
+        return merged;
     }
 
     private void notifyOperators(Device device, PacketDTO packet) {

--- a/src/test/java/it/sensorplatform/test/PacketServiceTests.java
+++ b/src/test/java/it/sensorplatform/test/PacketServiceTests.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -103,6 +104,39 @@ class PacketServiceTests {
         assertFalse(updated.isActivated());
         assertEquals(0d, updated.getLatitude());
         assertEquals(0d, updated.getLongitude());
+    }
+
+    @Test
+    void mergesIndicatorPayloadIntoMetrics() {
+        Project project = new Project();
+        project.setName("demo");
+        projectRepository.save(project);
+
+        Device device = new Device();
+        device.setName("indicator-device");
+        device.setMacAddress("AA:11:22");
+        device.setEmailOwner("");
+        device.setActivated(true);
+        device.setLatitude(0d);
+        device.setLongitude(0d);
+        device.setProject(project);
+        deviceRepository.save(device);
+
+        PacketDTO dto = new PacketDTO();
+        dto.setMacAddress("AA:11:22");
+        dto.setPayload(Map.of("temperature", 21));
+        dto.setIndicator(List.of("alarm_flag"));
+        dto.setIndicatorPayload(Map.of("alarm_flag", 1));
+
+        PacketService.Result res = packetService.handlePacket(dto);
+        assertEquals(PacketService.Result.DATA, res);
+
+        var samples = ingestService.last(MacAddressUtils.normalize("AA:11:22"), 1);
+        assertEquals(1, samples.size());
+        var indicatorSamples = samples.get(0).indicators();
+        assertEquals(1, indicatorSamples.size());
+        assertEquals("alarm_flag", indicatorSamples.get(0).key());
+        assertEquals(1, indicatorSamples.get(0).value());
     }
 }
 


### PR DESCRIPTION
## Summary
- add support for the optional `indicatorPayload` map in `PacketDTO`
- merge indicator payload values into the telemetry metrics before calling `IngestService`
- cover the new behaviour with an integration test on `PacketService`

## Testing
- `./mvnw test` *(fails: unable to download Maven distribution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d68b2d45bc832382e017d387aec687