### PR TITLE
Align telemetry ingestion with packet spec and indicators

### DIFF
--- a/src/main/java/it/sensorplatform/service/IngestService.java
+++ b/src/main/java/it/sensorplatform/service/IngestService.java
@@ -271,7 +271,20 @@ public class IngestService {
                                                 List<Spec> savedSpecs,
                                                 Set<String> indicatorKeyHints) {
         LinkedHashSet<String> keys = new LinkedHashSet<>();
-        if (savedSpecs != null) {
+        boolean hasSpecEntries = false;
+        if (specEntries != null) {
+            for (PacketDTO.SpecEntry entry : specEntries) {
+                if (entry == null) {
+                    continue;
+                }
+                String key = sanitize(entry.getKey());
+                if (key != null) {
+                    keys.add(key);
+                    hasSpecEntries = true;
+                }
+            }
+        }
+        if (!hasSpecEntries && savedSpecs != null) {
             for (Spec spec : savedSpecs) {
                 if (spec == null) {
                     continue;
@@ -282,18 +295,7 @@ public class IngestService {
                 }
             }
         }
-        if (specEntries != null) {
-            for (PacketDTO.SpecEntry entry : specEntries) {
-                if (entry == null) {
-                    continue;
-                }
-                String key = sanitize(entry.getKey());
-                if (key != null) {
-                    keys.add(key);
-                }
-            }
-        }
-        if (metrics != null) {
+        if (keys.isEmpty() && metrics != null) {
             for (String rawKey : metrics.keySet()) {
                 String key = sanitize(rawKey);
                 if (key == null) {
@@ -496,7 +498,8 @@ public class IngestService {
                 String labelPart = trimmed.substring(separator + 1).trim();
                 descriptors.add(new IndicatorDescriptor(sanitize(keyPart), labelPart.isEmpty() ? null : labelPart));
             } else {
-                descriptors.add(new IndicatorDescriptor(null, trimmed));
+                String key = sanitize(trimmed);
+                descriptors.add(new IndicatorDescriptor(key, trimmed));
             }
         }
         return descriptors;
@@ -506,22 +509,26 @@ public class IngestService {
                                               List<IndicatorDescriptor> indicatorDescriptors,
                                               Set<String> measurementKeys,
                                               Map<String, Indicator> savedIndicatorsByKey) {
-        LinkedHashSet<String> keys = new LinkedHashSet<>();
-        if (savedIndicatorsByKey != null) {
-            keys.addAll(savedIndicatorsByKey.keySet());
-        }
+        LinkedHashSet<String> ordered = new LinkedHashSet<>();
         if (indicatorDescriptors != null) {
             for (IndicatorDescriptor descriptor : indicatorDescriptors) {
                 if (descriptor == null) {
                     continue;
                 }
                 String key = sanitize(descriptor.key());
+                if (key == null) {
+                    String fromLabel = sanitize(descriptor.label());
+                    key = fromLabel;
+                }
                 if (key != null) {
-                    keys.add(key);
+                    ordered.add(key);
                 }
             }
         }
-        if (metrics != null) {
+        if (savedIndicatorsByKey != null) {
+            ordered.addAll(savedIndicatorsByKey.keySet());
+        }
+        if (ordered.isEmpty() && metrics != null) {
             for (String rawKey : metrics.keySet()) {
                 String key = sanitize(rawKey);
                 if (key == null) {
@@ -533,28 +540,10 @@ public class IngestService {
                 if (measurementKeys != null && measurementKeys.contains(key)) {
                     continue;
                 }
-                keys.add(key);
+                ordered.add(key);
             }
         }
-        LinkedHashSet<String> remaining = new LinkedHashSet<>(keys);
-        List<String> ordered = new ArrayList<>();
-        if (indicatorDescriptors != null) {
-            for (IndicatorDescriptor descriptor : indicatorDescriptors) {
-                if (descriptor == null) {
-                    continue;
-                }
-                String key = sanitize(descriptor.key());
-                if (key != null && remaining.remove(key)) {
-                    ordered.add(key);
-                } else if (key == null && !remaining.isEmpty()) {
-                    String next = remaining.iterator().next();
-                    remaining.remove(next);
-                    ordered.add(next);
-                }
-            }
-        }
-        ordered.addAll(remaining);
-        return ordered;
+        return new ArrayList<>(ordered);
     }
 
     private String resolveIndicatorLabel(String key,

--- a/src/test/java/it/sensorplatform/service/IngestServiceTests.java
+++ b/src/test/java/it/sensorplatform/service/IngestServiceTests.java
@@ -127,5 +127,46 @@ class IngestServiceTests {
         assertEquals("SEN55 Fan Error", indicatorSample.label());
         assertEquals(1, indicatorSample.value());
     }
+
+    @Test
+    void buildsMeasurementsAndIndicatorsFromPacketSpec() {
+        IngestService ingestService = new IngestService();
+
+        PacketDTO.SpecEntry specEntry = new PacketDTO.SpecEntry();
+        specEntry.setKey("SEN55-PM2.5-ug/m3");
+        specEntry.setLabel("SEN55-PM2.5-ug/m3");
+        specEntry.setMin(0.0);
+        specEntry.setMax(1000.0);
+
+        ingestService.process(
+                "AA:BB:CC:DD:EE:FF",
+                null,
+                Instant.parse("2024-04-01T00:00:00Z"),
+                Map.of(
+                        "SEN55-PM2.5-ug/m3", 12.3,
+                        "SEN55-FanError-none", 1
+                ),
+                List.of(specEntry),
+                List.of("SEN55-FanError-none")
+        );
+
+        List<IngestService.Sample> samples = ingestService.last("AA:BB:CC:DD:EE:FF", 1);
+        assertEquals(1, samples.size());
+
+        IngestService.Sample sample = samples.get(0);
+        assertEquals(1, sample.measurements().size());
+        assertEquals(1, sample.indicators().size());
+
+        IngestService.MeasurementSample measurement = sample.measurements().get(0);
+        assertEquals("SEN55-PM2.5-ug/m3", measurement.key());
+        assertEquals(12.3, measurement.value());
+        assertEquals(0.0, measurement.min());
+        assertEquals(1000.0, measurement.max());
+
+        IngestService.IndicatorSample indicatorSample = sample.indicators().get(0);
+        assertEquals("SEN55-FanError-none", indicatorSample.key());
+        assertEquals("SEN55-FanError-none", indicatorSample.label());
+        assertEquals(1, indicatorSample.value());
+    }
 }
 


### PR DESCRIPTION
## Summary
- derive measurement cards directly from the packet `spec` list with safe fallbacks for legacy data
- interpret indicator entries as explicit keys so they no longer appear among measurement specs
- add a regression test covering the FIRE-aligned packet format separation between specs and indicators

## Testing
- ./mvnw test *(fails: unable to download Maven distribution in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a04bf43c8323bcfaa77173ee4a1f