### PR TITLE
Deduplicate status indicators on device dashboard

### DIFF
--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -498,7 +498,17 @@
                         }
 
                         emptyState.hidden = true;
+                        const seenIndicators = new Set();
                         indicators.forEach(indicator => {
+                                const identifier = typeof indicator.key === 'string' && indicator.key.trim().length
+                                        ? indicator.key.trim()
+                                        : (typeof indicator.label === 'string' ? indicator.label.trim() : '');
+                                if (identifier && seenIndicators.has(identifier)) {
+                                        return;
+                                }
+                                if (identifier) {
+                                        seenIndicators.add(identifier);
+                                }
                                 const flag = document.createElement('div');
                                 flag.className = 'status-flag';
                                 const numeric = toNumber(indicator.value);


### PR DESCRIPTION
## Summary
- avoid rendering duplicate status indicators on the device dashboard by keeping only the first occurrence of each key or label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a4f2414883238ae930406a270f19