### PR TITLE
Add dynamic status colors to admin map pins

### DIFF
--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -643,3 +643,37 @@ details .device-list li::before {
 /* solo il bottone Assign */
 .btn-assign svg { stroke:rgb(0, 0, 0); fill:none; stroke-width: 2; }
 .btn-assign svg .plus { stroke-width:2; } /* 2.6–3 rende il + bello visibile */
+
+.device-marker-icon {
+        background: transparent;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+}
+
+.device-marker-pin {
+        display: block;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid rgba(0, 0, 0, 0.35);
+        box-shadow: 0 0 8px rgba(0, 0, 0, 0.45);
+        background: #757575;
+        transition: background-color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+}
+
+.device-marker-icon--ok .device-marker-pin {
+        background: #2e7d32;
+        border-color: #1b5e20;
+}
+
+.device-marker-icon--alert .device-marker-pin {
+        background: #c62828;
+        border-color: #8e0000;
+}
+
+.device-marker-icon--unknown .device-marker-pin {
+        background: #5c6bc0;
+        border-color: #2c387e;
+}

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -644,3 +644,37 @@ details .device-list li::before {
 .btn-assign svg { stroke:rgb(0, 0, 0); fill:none; stroke-width: 2; }
 .btn-assign svg .plus { stroke-width:2; } /* 2.6–3 rende il + bello visibile */
 
+.device-marker-icon {
+        background: transparent;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+}
+
+.device-marker-pin {
+        display: block;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid rgba(0, 0, 0, 0.35);
+        box-shadow: 0 0 8px rgba(0, 0, 0, 0.45);
+        background: #607d8b;
+        transition: background-color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+}
+
+.device-marker-icon--ok .device-marker-pin {
+        background: #2e7d32;
+        border-color: #1b5e20;
+}
+
+.device-marker-icon--alert .device-marker-pin {
+        background: #c62828;
+        border-color: #8e0000;
+}
+
+.device-marker-icon--unknown .device-marker-pin {
+        background: #546e7a;
+        border-color: #29434e;
+}
+

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -644,3 +644,37 @@ details .device-list li::before {
 /* solo il bottone Assign */
 .btn-assign svg { stroke:rgb(0, 0, 0); fill:none; stroke-width: 2; }
 .btn-assign svg .plus { stroke-width:2; } /* 2.6–3 rende il + bello visibile */
+
+.device-marker-icon {
+        background: transparent;
+        border: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+}
+
+.device-marker-pin {
+        display: block;
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid rgba(0, 0, 0, 0.35);
+        box-shadow: 0 0 8px rgba(0, 0, 0, 0.45);
+        background: #607d8b;
+        transition: background-color 0.3s ease, border-color 0.3s ease, transform 0.2s ease;
+}
+
+.device-marker-icon--ok .device-marker-pin {
+        background: #2e7d32;
+        border-color: #1b5e20;
+}
+
+.device-marker-icon--alert .device-marker-pin {
+        background: #c62828;
+        border-color: #8e0000;
+}
+
+.device-marker-icon--unknown .device-marker-pin {
+        background: #ffb74d;
+        border-color: #ef6c00;
+}

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -215,9 +215,25 @@
 			attribution: '&copy; OpenStreetMap contributors'
 		}).addTo(map);
 
-                let markerByDeviceKey = new Map();
+                const markerByDeviceKey = new Map();
+                const markerStatusIcons = {
+                        unknown: createDeviceIcon('unknown'),
+                        ok: createDeviceIcon('ok'),
+                        alert: createDeviceIcon('alert')
+                };
 
                 let allLatLngs = [];
+
+                function createDeviceIcon(status) {
+                        const safeStatus = typeof status === 'string' ? status : 'unknown';
+                        return L.divIcon({
+                                className: `device-marker-icon device-marker-icon--${safeStatus}`,
+                                html: '<span class="device-marker-pin"></span>',
+                                iconSize: [26, 26],
+                                iconAnchor: [13, 13],
+                                popupAnchor: [0, -13]
+                        });
+                }
 
                 function formatIdentifier(value) {
                         if (!value) {
@@ -239,7 +255,7 @@
                         const latlng = [d.latitude, d.longitude];
                         allLatLngs.push(latlng);
 
-                        const marker = L.marker(latlng).addTo(map);
+                        const marker = L.marker(latlng, { icon: markerStatusIcons.unknown }).addTo(map);
                         const key = resolveDeviceKey(d);
                         const formattedKey = formatIdentifier(key);
                         const fallbackDevEui = d.devEui ? formatIdentifier(d.devEui) : '';
@@ -259,14 +275,75 @@
                                         window.location.href = destination;
                                 });
                                 markerByDeviceKey.set(key, marker);
+                                refreshDeviceMarkerStatus(key);
                         }
                 });
 
+                function parseIndicatorValue(value) {
+                        if (value === null || value === undefined) {
+                                return null;
+                        }
+                        if (typeof value === 'number' && Number.isFinite(value)) {
+                                return value;
+                        }
+                        const asNumber = Number(String(value).trim());
+                        return Number.isNaN(asNumber) ? null : asNumber;
+                }
+
+                function determineMarkerStatus(indicators) {
+                        if (!Array.isArray(indicators) || !indicators.length) {
+                                return 'unknown';
+                        }
+                        const hasAlert = indicators.some(indicator => {
+                                const numeric = parseIndicatorValue(indicator && indicator.value);
+                                return numeric !== null && numeric >= 1;
+                        });
+                        return hasAlert ? 'alert' : 'ok';
+                }
+
+                async function refreshDeviceMarkerStatus(deviceKey) {
+                        if (!deviceKey) {
+                                return;
+                        }
+                        const marker = markerByDeviceKey.get(deviceKey);
+                        if (!marker) {
+                                return;
+                        }
+                        try {
+                                const response = await fetch(`/api/admin/devices/${encodeURIComponent(deviceKey)}/telemetry/latest`);
+                                if (response.status === 204) {
+                                        marker.setIcon(markerStatusIcons.unknown);
+                                        return;
+                                }
+                                if (!response.ok) {
+                                        return;
+                                }
+                                const sample = await response.json();
+                                const status = determineMarkerStatus(sample ? sample.indicators : null);
+                                marker.setIcon(markerStatusIcons[status] || markerStatusIcons.unknown);
+                        } catch (error) {
+                                console.error('Unable to refresh device status', error);
+                        }
+                }
+
+                function refreshAllDeviceStatuses() {
+                        markerByDeviceKey.forEach((_, deviceKey) => {
+                                refreshDeviceMarkerStatus(deviceKey);
+                        });
+                }
+
 		// Disegna il poligono solo se ci sono almeno 3 punti
-		if (allLatLngs.length > 0) {
-			const bounds = L.latLngBounds(allLatLngs);
-			map.fitBounds(bounds, {padding: [30, 30]});
-		}
+                if (allLatLngs.length > 0) {
+                        const bounds = L.latLngBounds(allLatLngs);
+                        map.fitBounds(bounds, {padding: [30, 30]});
+                }
+
+                setInterval(refreshAllDeviceStatuses, 20000);
+                document.addEventListener('visibilitychange', () => {
+                        if (document.visibilityState === 'visible') {
+                                refreshAllDeviceStatuses();
+                        }
+                });
 
 
 
@@ -292,6 +369,10 @@
                                                         const deviceName = device.name || '';
                                                         li.textContent = identifier ? `${deviceName} (${identifier})` : deviceName;
                                                         ul.appendChild(li);
+                                                        const deviceKey = resolveDeviceKey(device);
+                                                        if (deviceKey) {
+                                                                refreshDeviceMarkerStatus(deviceKey);
+                                                        }
                                                 });
                                         });
                                 });


### PR DESCRIPTION
## Summary
- create reusable Leaflet marker icons that change color according to the latest diagnostic indicators
- periodically fetch telemetry samples for each device on the admin groups map to keep pin status up to date
- add theme-aware styles for the new pin icons across the admin map stylesheets

## Testing
- not run (front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68d6b1748b888323b6a5e03befd4fa95