### PR TITLE
Adjust admin device trend charts spacing and labels

### DIFF
--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -594,6 +594,11 @@
                                                 options: {
                                                         responsive: true,
                                                         maintainAspectRatio: false,
+                                                        layout: {
+                                                                padding: {
+                                                                        bottom: 16
+                                                                }
+                                                        },
                                                         interaction: { mode: 'index', intersect: false },
                                                         plugins: {
                                                                 legend: { labels: { color: '#ffffff' } },
@@ -604,7 +609,13 @@
                                                                 }
                                                         },
                                                         scales: {
-                                                                x: { ticks: { color: '#dde1f2' }, grid: { color: 'rgba(255,255,255,0.1)' } },
+                                                                x: {
+                                                                        ticks: {
+                                                                                color: '#dde1f2',
+                                                                                padding: 8
+                                                                        },
+                                                                        grid: { color: 'rgba(255,255,255,0.1)' }
+                                                                },
                                                                 y: { ticks: { color: '#dde1f2' }, grid: { color: 'rgba(255,255,255,0.1)' } }
                                                         }
                                                 }
@@ -889,7 +900,7 @@
                         if (Number.isNaN(date.getTime())) {
                                 return '--';
                         }
-                        const options = short ? { hour: '2-digit', minute: '2-digit', second: '2-digit' } : { dateStyle: 'short', timeStyle: 'medium' };
+                        const options = short ? { hour: '2-digit', minute: '2-digit' } : { dateStyle: 'short', timeStyle: 'medium' };
                         return new Intl.DateTimeFormat(undefined, options).format(date);
                 }
 


### PR DESCRIPTION
## Summary
- remove seconds from the admin device trend chart timestamps for clearer axes
- add extra spacing beneath trend charts so the line no longer overlaps the x-axis labels

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68d95c261e7c832384c5cb14c801ec18