### PR TITLE
Refine admin device chart labels

### DIFF
--- a/src/main/resources/templates/admin/deviceDashboard.html
+++ b/src/main/resources/templates/admin/deviceDashboard.html
@@ -594,6 +594,11 @@
                                                 options: {
                                                         responsive: true,
                                                         maintainAspectRatio: false,
+                                                        layout: {
+                                                                padding: {
+                                                                        bottom: 16
+                                                                }
+                                                        },
                                                         interaction: { mode: 'index', intersect: false },
                                                         plugins: {
                                                                 legend: { labels: { color: '#ffffff' } },
@@ -604,7 +609,13 @@
                                                                 }
                                                         },
                                                         scales: {
-                                                                x: { ticks: { color: '#dde1f2' }, grid: { color: 'rgba(255,255,255,0.1)' } },
+                                                                x: {
+                                                                        ticks: {
+                                                                                color: '#dde1f2',
+                                                                                padding: 8
+                                                                        },
+                                                                        grid: { color: 'rgba(255,255,255,0.1)' }
+                                                                },
                                                                 y: { ticks: { color: '#dde1f2' }, grid: { color: 'rgba(255,255,255,0.1)' } }
                                                         }
                                                 }
@@ -651,8 +662,10 @@
                                 }
                                 const color = palette[colorIndex % palette.length];
                                 colorIndex += 1;
+                                const descriptorTitle = getDescriptorTitle(descriptor) || descriptor.displayName;
+                                const label = descriptor.unit ? `${descriptorTitle} (${descriptor.unit})` : descriptorTitle;
                                 datasets.set(descriptor.key, {
-                                        label: descriptor.unit ? `${descriptor.displayName} (${descriptor.unit})` : descriptor.displayName,
+                                        label,
                                         data: values,
                                         borderColor: color,
                                         backgroundColor: color + '33',
@@ -889,7 +902,7 @@
                         if (Number.isNaN(date.getTime())) {
                                 return '--';
                         }
-                        const options = short ? { hour: '2-digit', minute: '2-digit', second: '2-digit' } : { dateStyle: 'short', timeStyle: 'medium' };
+                        const options = short ? { hour: '2-digit', minute: '2-digit' } : { dateStyle: 'short', timeStyle: 'medium' };
                         return new Intl.DateTimeFormat(undefined, options).format(date);
                 }
 


### PR DESCRIPTION
## Summary
- derive trend chart dataset labels from the cleaned descriptor titles
- remove redundant unit text from admin device chart legends such as "Ppm"

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68d95c261e7c832384c5cb14c801ec18