### PR TITLE
Add viewport meta tags to HTML templates

### DIFF
--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title th:if="${project.id == 1}">L-TRAD Group</title>
 	<title th:if="${project.id == 51}">FIRE Group</title>
 	<title th:if="${project.id == 101}">VOLCANO Group</title>

--- a/src/main/resources/templates/admin/manageGroups.html
+++ b/src/main/resources/templates/admin/manageGroups.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Manage Groups</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 	<meta name="_csrf" th:content="${_csrf.token}" />

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title th:text="${project.name} + ' – Operator Map'">Operator Map</title>
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />

--- a/src/main/resources/templates/operator/activationRequests.html
+++ b/src/main/resources/templates/operator/activationRequests.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title th:text="'Activation Requests - ' + ${project.name}">Activation Requests</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 

--- a/src/main/resources/templates/project/fireHome.html
+++ b/src/main/resources/templates/project/fireHome.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>FIRE – Home</title>
 	<link rel="stylesheet" th:href="@{/css/fireHome.css}" />
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">

--- a/src/main/resources/templates/project/ltradHome.html
+++ b/src/main/resources/templates/project/ltradHome.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>L-TRAD – Home</title>
 	<link rel="stylesheet" th:href="@{/css/ltradHome.css}" />
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">

--- a/src/main/resources/templates/project/volcanoHome.html
+++ b/src/main/resources/templates/project/volcanoHome.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 
 <head>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>VOLCANO – Home</title>
 	<link rel="stylesheet" th:href="@{/css/volcanoHome.css}" />
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">

--- a/src/main/resources/templates/registrationSuccessful.html
+++ b/src/main/resources/templates/registrationSuccessful.html
@@ -3,6 +3,7 @@
 
 <head>
 	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Registration Successful</title>
 	<link rel="stylesheet" th:href="@{/css/registrationSuccessful.css}">
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title th:text="'New Device Notifications - ' + ${project.name}">Notifications</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 

--- a/src/main/resources/templates/superadmin/formNewSpec.html
+++ b/src/main/resources/templates/superadmin/formNewSpec.html
@@ -3,6 +3,7 @@
 
 <head>
 	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>Add Specification</title>
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 

--- a/src/main/resources/templates/superadmin/formNewTod.html
+++ b/src/main/resources/templates/superadmin/formNewTod.html
@@ -3,6 +3,7 @@
 
 <head>
 	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title th:text="'Add Type of Device - ' + ${project.name}">Add Type of Device</title>
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 

--- a/src/main/resources/templates/superadmin/formUpdateDevice.html
+++ b/src/main/resources/templates/superadmin/formUpdateDevice.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Device Details</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 	<!-- CSS per LTRAD -->

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
 	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title th:text="'Device Management - ' + ${project.name}">Device Management</title>
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Device Details</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 	<!-- CSS per LTRAD -->


### PR DESCRIPTION
## Summary
- add a viewport meta tag to admin, operator, project, and registration templates for responsive layout
- add the same viewport meta tag to superadmin management and device detail templates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9911f684883279f1646a1270a12dd