### PR TITLE
Improve operator layout responsiveness

### DIFF
--- a/src/main/resources/static/css/fireOperator.css
+++ b/src/main/resources/static/css/fireOperator.css
@@ -134,7 +134,7 @@ html, body {
 .main-layout {
   display: flex;
   height: calc(100vh - 3em);
-  overflow: hidden;
+  flex-wrap: wrap;
 }
 .group-panel {
   width: 40%;
@@ -150,6 +150,19 @@ html, body {
   height: 100%;
   overflow: hidden;
   z-index: 1;
+}
+
+@media (max-width: 992px) {
+  .main-layout {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .group-panel,
+  #map {
+    width: 100%;
+    min-height: 360px;
+  }
 }
 .groups {
   font-size: 1.2rem;

--- a/src/main/resources/static/css/ltradOperator.css
+++ b/src/main/resources/static/css/ltradOperator.css
@@ -182,9 +182,9 @@ navbar h1 {
 
 /* Layout principale */
 .main-layout {
-	display: flex;
-	height: calc(100vh - 3em);
-	overflow: hidden;
+        display: flex;
+        height: calc(100vh - 3em);
+        flex-wrap: wrap;
 }
 
 .group-panel {
@@ -204,10 +204,23 @@ navbar h1 {
 
 /* Colonna mappa */
 #map {
-	width: 60%;
-	height: 100%;
-	overflow: hidden;
-	z-index: 1;
+        width: 60%;
+        height: 100%;
+        overflow: hidden;
+        z-index: 1;
+}
+
+@media (max-width: 992px) {
+        .main-layout {
+                flex-direction: column;
+                height: auto;
+        }
+
+        .group-panel,
+        #map {
+                width: 100%;
+                min-height: 360px;
+        }
 }
 
 /* Lista gruppi */

--- a/src/main/resources/static/css/volcanoOperator.css
+++ b/src/main/resources/static/css/volcanoOperator.css
@@ -182,9 +182,9 @@ navbar h1 {
 
 /* Layout principale */
 .main-layout {
-	display: flex;
-	height: calc(100vh - 3em);
-	overflow: hidden;
+        display: flex;
+        height: calc(100vh - 3em);
+        flex-wrap: wrap;
 }
 
 .group-panel {
@@ -203,10 +203,23 @@ navbar h1 {
 
 /* Colonna mappa */
 #map {
-	width: 60%;
-	height: 100%;
-	overflow: hidden;
-	z-index: 1;
+        width: 60%;
+        height: 100%;
+        overflow: hidden;
+        z-index: 1;
+}
+
+@media (max-width: 992px) {
+        .main-layout {
+                flex-direction: column;
+                height: auto;
+        }
+
+        .group-panel,
+        #map {
+                width: 100%;
+                min-height: 360px;
+        }
 }
 
 /* Lista gruppi */


### PR DESCRIPTION
## Summary
- allow operator layout to wrap and avoid overflow clipping
- add breakpoint to stack panels vertically and preserve map usability on narrow screens

## Testing
- not run (mobile simulation requires browser tooling unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d99bb566ec8327b67b8ae588d832af