### PR TITLE
Update activation request identifier handling

### DIFF
--- a/src/main/resources/static/css/formNewDeviceFire.css
+++ b/src/main/resources/static/css/formNewDeviceFire.css
@@ -593,6 +593,24 @@ body {
     outline-offset: 3px;
 }
 
+.notifications-panel .btn-refuse {
+    background-color: #5a1a1a;
+    box-shadow: 0 14px 30px rgba(90, 26, 26, 0.35);
+}
+
+.notifications-panel .btn-refuse::before {
+    content: '\2715';
+}
+
+.notifications-panel .btn-refuse:hover {
+    box-shadow: 0 20px 40px rgba(90, 26, 26, 0.45);
+    background-color: #451111;
+}
+
+.notifications-panel .btn-refuse:focus-visible {
+    outline: 2px solid rgba(255, 188, 188, 0.85);
+}
+
 @media (max-width: 900px) {
     .notifications-panel {
         margin: 3rem 1.5rem;

--- a/src/main/resources/static/css/formNewDeviceLtrad.css
+++ b/src/main/resources/static/css/formNewDeviceLtrad.css
@@ -601,6 +601,24 @@ body {
     outline-offset: 3px;
 }
 
+.notifications-panel .btn-refuse {
+    background-color: #d9534f;
+    box-shadow: 0 14px 30px rgba(217, 83, 79, 0.35);
+}
+
+.notifications-panel .btn-refuse::before {
+    content: '\2715';
+}
+
+.notifications-panel .btn-refuse:hover {
+    box-shadow: 0 20px 40px rgba(217, 83, 79, 0.45);
+    background-color: #c9302c;
+}
+
+.notifications-panel .btn-refuse:focus-visible {
+    outline: 2px solid rgba(255, 169, 167, 0.9);
+}
+
 @media (max-width: 900px) {
     .notifications-panel {
         margin: 3rem 1.5rem;

--- a/src/main/resources/static/css/formNewDeviceVolcano.css
+++ b/src/main/resources/static/css/formNewDeviceVolcano.css
@@ -587,6 +587,24 @@ body {
     outline-offset: 3px;
 }
 
+.notifications-panel .btn-refuse {
+    background-color: #c44536;
+    box-shadow: 0 14px 30px rgba(196, 69, 54, 0.35);
+}
+
+.notifications-panel .btn-refuse::before {
+    content: '\2715';
+}
+
+.notifications-panel .btn-refuse:hover {
+    box-shadow: 0 20px 40px rgba(196, 69, 54, 0.45);
+    background-color: #a43729;
+}
+
+.notifications-panel .btn-refuse:focus-visible {
+    outline: 2px solid rgba(255, 196, 182, 0.85);
+}
+
 @media (max-width: 900px) {
     .notifications-panel {
         margin: 3rem 1.5rem;

--- a/src/main/resources/templates/operator/activationRequests.html
+++ b/src/main/resources/templates/operator/activationRequests.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
-    <title th:text="'Activation Requests - ' + ${project.name}">Activation Requests</title>
+    <title th:text="'Activation Requests'">Activation Requests</title>
     <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" th:if="${project.id == 1}" th:href="@{/css/formNewDeviceLtrad.css}" />
@@ -45,11 +45,10 @@
 <section class="notifications-panel" aria-labelledby="activation-title">
     <header class="notifications-header">
         <div class="notifications-header-text">
-            <h2 id="activation-title" class="notifications-title" th:text="'Activation requests · ' + ${project.name}">Activation requests</h2>
+            <h2 id="activation-title" class="notifications-title" th:text="'Activation requests'">Activation requests</h2>
             <p class="notifications-description">Pending devices that need an operator decision.</p>
         </div>
         <div class="notifications-header-actions">
-            <button type="button" class="btn-add" id="activation-refresh">Refresh</button>
             <a th:href="@{'/operator/' + ${project.id}}" class="btn-back" title="Back to map">Back to map</a>
         </div>
     </header>
@@ -68,7 +67,6 @@
     const requestContainer = document.getElementById('activation-list');
     const emptyState = document.getElementById('activation-empty');
     const feedbackElement = document.getElementById('activation-feedback');
-    const refreshButton = document.getElementById('activation-refresh');
 
     const csrfTokenMeta = document.querySelector('meta[name="_csrf"]');
     const csrfHeaderMeta = document.querySelector('meta[name="_csrf_header"]');
@@ -170,10 +168,22 @@
         if (title) {
             title.textContent = notification.deviceName || 'Unnamed device';
         }
-        const macValue = element.querySelector('.activation-device-mac');
-        if (macValue) {
-            const formatted = formatMac(notification.macAddress);
-            macValue.textContent = formatted || (notification.devEui || 'n/a');
+        const identifierLabel = element.querySelector('.activation-identifier-label');
+        const identifierValue = element.querySelector('.activation-identifier-value');
+        if (identifierLabel && identifierValue) {
+            const hasMac = Boolean(notification.macAddress);
+            const hasDevEui = Boolean(notification.devEui);
+            if (hasMac) {
+                identifierLabel.textContent = 'MAC:';
+                const formatted = formatMac(notification.macAddress);
+                identifierValue.textContent = formatted || notification.macAddress;
+            } else if (hasDevEui) {
+                identifierLabel.textContent = 'DevEUI:';
+                identifierValue.textContent = notification.devEui;
+            } else {
+                identifierLabel.textContent = 'Identifier:';
+                identifierValue.textContent = 'n/a';
+            }
         }
         const adminValue = element.querySelector('.activation-device-admin');
         if (adminValue) {
@@ -211,9 +221,9 @@
         title.className = 'activation-device-name';
         main.appendChild(title);
 
-        const macLine = document.createElement('p');
-        macLine.innerHTML = '<strong>MAC:</strong> <span class="activation-device-mac"></span>';
-        main.appendChild(macLine);
+        const identifierLine = document.createElement('p');
+        identifierLine.innerHTML = '<strong class="activation-identifier-label"></strong> <span class="activation-identifier-value"></span>';
+        main.appendChild(identifierLine);
 
         const adminLine = document.createElement('p');
         adminLine.innerHTML = '<strong>Admin:</strong> <span class="activation-device-admin"></span>';
@@ -243,7 +253,7 @@
 
         const refuseButton = document.createElement('button');
         refuseButton.type = 'button';
-        refuseButton.className = 'btn-spec';
+        refuseButton.className = 'btn-add btn-refuse';
         refuseButton.textContent = 'Refuse';
         refuseButton.addEventListener('click', () => respondToRequest(entry, false));
         actions.appendChild(refuseButton);
@@ -433,10 +443,6 @@
                 showFeedback('Unable to load activation requests. Please try again later.', true);
             }
         }
-    }
-
-    if (refreshButton) {
-        refreshButton.addEventListener('click', () => loadRequests(true));
     }
 
     loadRequests(false);


### PR DESCRIPTION
## Summary
- remove the project suffix from the activation requests title/header and drop the manual refresh control
- update activation request rendering so the identifier label/value reflect MAC or DevEUI dynamically
- style the refuse action to match accept button aesthetics across project themes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df970a28c48323bb3829a744eb2b67