### PR TITLE
Make device name optional when updating device

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -313,16 +313,12 @@ public class DeviceController {
 	}
 
         @PostMapping("/updateDevice/{projectId}/{macAddress}")
-        public String updateDevice(@PathVariable Long projectId, @PathVariable String macAddress, @RequestParam String name,
+        public String updateDevice(@PathVariable Long projectId, @PathVariable String macAddress,
+                        @RequestParam(required = false) String name,
                         @RequestParam(required = false) Double latitude, @RequestParam(required = false) Double longitude,
                         RedirectAttributes redirectAttributes) {
 
                 String normalizedKey = MacAddressUtils.normalize(macAddress);
-
-                if (name == null || name.trim().isEmpty()) {
-                        redirectAttributes.addFlashAttribute("error", "Device name is required.");
-                        return "redirect:/device/" + projectId + "/" + normalizedKey;
-                }
 
                 if (normalizedKey == null || normalizedKey.isBlank()) {
                         redirectAttributes.addFlashAttribute("error", "Device not found.");
@@ -337,7 +333,10 @@ public class DeviceController {
 
                 Device device = deviceOpt.get();
                 // Aggiorna solo i campi modificabili
-                device.setName(name);
+                String trimmedName = name != null ? name.trim() : null;
+                if (StringUtils.hasText(trimmedName)) {
+                        device.setName(trimmedName);
+                }
                 if (latitude != null && longitude != null) {
                         device.setLatitude(latitude);
                         device.setLongitude(longitude);

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -104,9 +104,10 @@
 				<span class="success" th:if="${success}" th:text="${success}"></span>
                             <form th:action="@{'/updateDevice/' + ${project.id} + '/' + ${device.deviceKey}}" method="post" class="device-form">
 			        
-					<label for="name">Name:</label>
-					<span class="errorform" th:if="${error}" th:text="${error}"></span>
-			        <input type="text" id="name" name="name" th:value="${device.name}" />
+                                <label for="name">Name (optional):</label>
+                                        <span class="errorform" th:if="${error}" th:text="${error}"></span>
+                                <input type="text" id="name" name="name" th:value="${device.name}" />
+                                <p class="form-hint">Leave blank to keep the current device name.</p>
 
 			        <label for="latitude">Latitude:</label>
                                 <input type="number" step="any" id="latitude" name="latitude" th:value="${device.latitude}" />


### PR DESCRIPTION
## Summary
- allow the device update endpoint to treat the name field as optional and retain the existing value when blank
- update the device edit template messaging to explain that the name can be left empty while adjusting coordinates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df9c2dd9b083239ad9cbb644434a0b