### PR TITLE
Preserve device coordinates on operator removal

### DIFF
--- a/src/main/java/it/sensorplatform/controller/DeviceController.java
+++ b/src/main/java/it/sensorplatform/controller/DeviceController.java
@@ -466,8 +466,6 @@ public class DeviceController {
                 Device d = deviceOpt.get();
 
                 d.setOperator(null);
-                d.setLatitude(null);
-                d.setLongitude(null);
                 d.setActivated(false);
                 deviceService.save(d);
                 ra.addFlashAttribute("successMessage", "Operator removed.");


### PR DESCRIPTION
## Summary
- stop clearing stored latitude and longitude when removing an operator from a device
- ensure the device is merely deactivated and operator reference cleared

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df9fcd8c3483238afaba40f0e27c0f