### PR TITLE
Handle inactive devices on admin groups map

### DIFF
--- a/src/main/resources/static/css/fireGroups.css
+++ b/src/main/resources/static/css/fireGroups.css
@@ -673,6 +673,11 @@ details .device-list li::before {
         border-color: #8e0000;
 }
 
+.device-marker-icon--inactive .device-marker-pin {
+        background: #9e9e9e;
+        border-color: #616161;
+}
+
 .device-marker-icon--unknown .device-marker-pin {
         background: #5c6bc0;
         border-color: #2c387e;

--- a/src/main/resources/static/css/ltradGroups.css
+++ b/src/main/resources/static/css/ltradGroups.css
@@ -673,6 +673,11 @@ details .device-list li::before {
         border-color: #8e0000;
 }
 
+.device-marker-icon--inactive .device-marker-pin {
+        background: #9e9e9e;
+        border-color: #616161;
+}
+
 .device-marker-icon--unknown .device-marker-pin {
         background: #546e7a;
         border-color: #29434e;

--- a/src/main/resources/static/css/volcanoGroups.css
+++ b/src/main/resources/static/css/volcanoGroups.css
@@ -674,6 +674,11 @@ details .device-list li::before {
         border-color: #8e0000;
 }
 
+.device-marker-icon--inactive .device-marker-pin {
+        background: #9e9e9e;
+        border-color: #616161;
+}
+
 .device-marker-icon--unknown .device-marker-pin {
         background: #ffb74d;
         border-color: #ef6c00;

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -216,10 +216,12 @@
 		}).addTo(map);
 
                 const markerByDeviceKey = new Map();
+                const deviceMetadataByDeviceKey = new Map();
                 const markerStatusIcons = {
                         unknown: createDeviceIcon('unknown'),
                         ok: createDeviceIcon('ok'),
-                        alert: createDeviceIcon('alert')
+                        alert: createDeviceIcon('alert'),
+                        inactive: createDeviceIcon('inactive')
                 };
 
                 let allLatLngs = [];
@@ -251,12 +253,52 @@
                         return device.deviceKey || device.devEui || '';
                 }
 
+                function normalizeActivated(value) {
+                        if (value === null || value === undefined) {
+                                return undefined;
+                        }
+                        if (typeof value === 'string') {
+                                const trimmed = value.trim().toLowerCase();
+                                if (trimmed === 'true') {
+                                        return true;
+                                }
+                                if (trimmed === 'false') {
+                                        return false;
+                                }
+                                return undefined;
+                        }
+                        return Boolean(value);
+                }
+
+                function updateDeviceMetadata(device) {
+                        const key = resolveDeviceKey(device);
+                        if (!key) {
+                                return;
+                        }
+                        const normalizedActivated = normalizeActivated(device ? device.activated : undefined);
+                        if (normalizedActivated === undefined) {
+                                if (!deviceMetadataByDeviceKey.has(key)) {
+                                        deviceMetadataByDeviceKey.set(key, {});
+                                }
+                                return;
+                        }
+                        const metadata = deviceMetadataByDeviceKey.get(key) || {};
+                        metadata.activated = normalizedActivated;
+                        deviceMetadataByDeviceKey.set(key, metadata);
+                }
+
+                function getDeviceActivationStatus(deviceKey) {
+                        const metadata = deviceMetadataByDeviceKey.get(deviceKey);
+                        return metadata ? metadata.activated : undefined;
+                }
+
                 initialDevices.forEach(function (d) {
                         const latlng = [d.latitude, d.longitude];
                         allLatLngs.push(latlng);
 
                         const marker = L.marker(latlng, { icon: markerStatusIcons.unknown }).addTo(map);
                         const key = resolveDeviceKey(d);
+                        updateDeviceMetadata(d);
                         const formattedKey = formatIdentifier(key);
                         const fallbackDevEui = d.devEui ? formatIdentifier(d.devEui) : '';
                         const identifierLabel = formattedKey || fallbackDevEui || 'N/A';
@@ -275,6 +317,9 @@
                                         window.location.href = destination;
                                 });
                                 markerByDeviceKey.set(key, marker);
+                                if (getDeviceActivationStatus(key) === false) {
+                                        marker.setIcon(markerStatusIcons.inactive);
+                                }
                                 refreshDeviceMarkerStatus(key);
                         }
                 });
@@ -290,7 +335,10 @@
                         return Number.isNaN(asNumber) ? null : asNumber;
                 }
 
-                function determineMarkerStatus(indicators) {
+                function determineMarkerStatus(indicators, activated) {
+                        if (activated === false) {
+                                return 'inactive';
+                        }
                         if (!Array.isArray(indicators) || !indicators.length) {
                                 return 'unknown';
                         }
@@ -309,6 +357,11 @@
                         if (!marker) {
                                 return;
                         }
+                        const activated = getDeviceActivationStatus(deviceKey);
+                        if (activated === false) {
+                                marker.setIcon(markerStatusIcons.inactive);
+                                return;
+                        }
                         try {
                                 const response = await fetch(`/api/admin/devices/${encodeURIComponent(deviceKey)}/telemetry/latest`);
                                 if (response.status === 204) {
@@ -319,7 +372,7 @@
                                         return;
                                 }
                                 const sample = await response.json();
-                                const status = determineMarkerStatus(sample ? sample.indicators : null);
+                                const status = determineMarkerStatus(sample ? sample.indicators : null, activated);
                                 marker.setIcon(markerStatusIcons[status] || markerStatusIcons.unknown);
                         } catch (error) {
                                 console.error('Unable to refresh device status', error);
@@ -350,7 +403,10 @@
 		function fetchAndDisplayDevices(groupName) {
 			fetch('/api/groups/name/' + encodeURIComponent(groupName) + '/devices')
 				.then(response => response.json())
-				.then(devices => {
+                                .then(devices => {
+                                        devices.forEach(device => {
+                                                updateDeviceMetadata(device);
+                                        });
                                         const validDevices = devices.filter(d => d.latitude != null && d.longitude != null);
                                         if (validDevices.length === 1) {
                                                 map.setView([validDevices[0].latitude, validDevices[0].longitude], 15);
@@ -371,6 +427,12 @@
                                                         ul.appendChild(li);
                                                         const deviceKey = resolveDeviceKey(device);
                                                         if (deviceKey) {
+                                                                if (getDeviceActivationStatus(deviceKey) === false) {
+                                                                        const marker = markerByDeviceKey.get(deviceKey);
+                                                                        if (marker) {
+                                                                                marker.setIcon(markerStatusIcons.inactive);
+                                                                        }
+                                                                }
                                                                 refreshDeviceMarkerStatus(deviceKey);
                                                         }
                                                 });


### PR DESCRIPTION
## Summary
- add an inactive marker icon and persist activation metadata for devices shown on the admin group map
- update status refresh logic to skip telemetry for deactivated devices and keep active devices using ok/alert indicators
- style the inactive marker pin with a gray fill across all project themes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfa0d72a488323aa729206a9e07d43