### PR TITLE
Update LTRAD device imports and align operator heading

### DIFF
--- a/src/main/java/it/sensorplatform/util/MacAddressUtils.java
+++ b/src/main/java/it/sensorplatform/util/MacAddressUtils.java
@@ -25,10 +25,8 @@ public final class MacAddressUtils {
     }
 
     public static String formatIdentifierForProject(Number projectId, String macAddress, String devEui) {
-        boolean preferMac = projectId != null && projectId.longValue() == 101L;
-
-        String primary = preferMac ? macAddress : devEui;
-        String secondary = preferMac ? devEui : macAddress;
+        String primary = devEui;
+        String secondary = macAddress;
 
         String formattedPrimary = format(primary);
         if (!formattedPrimary.isEmpty()) {

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -60,19 +60,19 @@ insert into project_tods(project_id, tods_id)values(101, 3)
 -- 5. Dispositivi (devono esistere i gruppi e i progetti)
 
 /* MIMI - Dispositivi posizionati sulle principali uscite del Grande Raccordo Anulare (A90) */
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.884167, 12.380556, 1, 1, 1, 'flamy003@gmail.com', '21:06:1C:EC:E7:20', 'Device1', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.958056, 12.579444, 1, 2, 1, 'flamy003@gmail.com', '34:09:1C:EC:E7:21', 'Device2', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.945556, 12.591667, 1, 3, 1, 'flamy003@gmail.com', '56:08:1C:EC:E7:22', 'Device3', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.939000, 12.600000, 1, 4, 1, 'flamy003@gmail.com', '15:05:1B:EC:E7:23', 'Device4', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.801111, 12.453889, 1, 5, 1, 'flamy003@gmail.com', '17:04:1C:EC:E7:24', 'Device5', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, activated)values(41.807500, 12.420278, 1, 6, 1, 'flamy003@gmail.com', '18:03:1C:EC:E7:25', 'Device6', 1, false);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.884167, 12.380556, 1, 1, 1, 'flamy003@gmail.com', '0004A30B001C1D10', 'Device1', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.958056, 12.579444, 1, 2, 1, 'flamy003@gmail.com', '0004A30B001C1D11', 'Device2', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.945556, 12.591667, 1, 3, 1, 'flamy003@gmail.com', '0004A30B001C1D12', 'Device3', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.939000, 12.600000, 1, 4, 1, 'flamy003@gmail.com', '0004A30B001C1D13', 'Device4', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.801111, 12.453889, 1, 5, 1, 'flamy003@gmail.com', '0004A30B001C1D14', 'Device5', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, activated)values(41.807500, 12.420278, 1, 6, 1, 'flamy003@gmail.com', '0004A30B001C1D15', 'Device6', 1, false);
 
 /* Dispositivi aggiuntivi MIMI */
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.812778, 12.396389, 1, 24, 1, 'flamy003@gmail.com', 'E3:06:1C:EC:E7:3D', 'Device7', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.818056, 12.390833, 1, 25, 1, 'flamy003@gmail.com', 'F4:06:1C:EC:E7:3E', 'Device8', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.823889, 12.388889, 1, 26, 1, 'flamy003@gmail.com', '10:07:1C:EC:E7:3F', 'Device9', 1, 5, true);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.850556, 12.378889, 1, 27, 1, 'flamy003@gmail.com', '21:07:1C:EC:E7:40', 'Device10', 1, 5, false);
-insert into device(latitude, longitude, group_id, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(41.865556, 12.373889, 1, 28, 1, 'flamy003@gmail.com', '32:07:1C:EC:E7:41', 'Device10', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.812778, 12.396389, 1, 24, 1, 'flamy003@gmail.com', '0004A30B001C1D20', 'Device7', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.818056, 12.390833, 1, 25, 1, 'flamy003@gmail.com', '0004A30B001C1D21', 'Device8', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.823889, 12.388889, 1, 26, 1, 'flamy003@gmail.com', '0004A30B001C1D22', 'Device9', 1, 5, true);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.850556, 12.378889, 1, 27, 1, 'flamy003@gmail.com', '0004A30B001C1D23', 'Device10', 1, 5, false);
+insert into device(latitude, longitude, group_id, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(41.865556, 12.373889, 1, 28, 1, 'flamy003@gmail.com', '0004A30B001C1D24', 'Device10', 1, 5, true);
 
 
 /* KUCA - sparsi nel nord Italia */

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -76,35 +76,35 @@ insert into device(latitude, longitude, group_id, id, project_id, email_owner, d
 
 
 /* KUCA - sparsi nel nord Italia */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.440001, 10.995001, 7, 51, 'luca.bussi@outlook.it','BD1F10FEEE7187E2', 'Device1', 2, 6, true);  -- Verona
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, activated)values(44.494889, 11.342616, 8, 51, 'luca.bussi@outlook.it','BD1F10FEEE7187E3', 'Device2', 2, false);  -- Bologna
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.070339, 7.686864, 9, 51, 'luca.bussi@outlook.it','BD1F10FEEE7187E4', 'Device3', 2, 6, true);   -- Torino
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(46.062008, 11.121083, 10, 51, 'luca.bussi@outlook.it', 'BD1F10FEEE7187E5', 'Device4', 2, 6, true); -- Trento
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, activated)values(45.649526, 13.776818, 11, 51, 'luca.bussi@outlook.it', 'BD1F10FEEE7187E2', 'Device5', 2, false); -- Trieste
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(44.801485, 10.327903, 12, 51, 'marco.verdi@example.it', 'BD1F10FEEE7187E2', 'Device6', 2, 6, true); -- Parma
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(45.440001, 10.995001, 7, 51, 'luca.bussi@outlook.it','BD1F10FEEE7187E2', 'Device1', 2, 6, true);  -- Verona
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, activated)values(44.494889, 11.342616, 8, 51, 'luca.bussi@outlook.it','BD1F10FEEE7187E3', 'Device2', 2, false);  -- Bologna
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(45.070339, 7.686864, 9, 51, 'luca.bussi@outlook.it','BD1F10FEEE7187E4', 'Device3', 2, 6, true);   -- Torino
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(46.062008, 11.121083, 10, 51, 'luca.bussi@outlook.it', 'BD1F10FEEE7187E5', 'Device4', 2, 6, true); -- Trento
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, activated)values(45.649526, 13.776818, 11, 51, 'luca.bussi@outlook.it', 'BD1F10FEEE7187E2', 'Device5', 2, false); -- Trieste
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(44.801485, 10.327903, 12, 51, 'marco.verdi@example.it', 'BD1F10FEEE7187E2', 'Device6', 2, 6, true); -- Parma
 
 /* Dispositivi aggiuntivi KUCA */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.184724, 9.158207, 29, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F1', 'Device7', 2, 6, true); -- Pavia
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, activated)values(44.405650, 8.946256, 30, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F2', 'Device8', 2, false); -- Genova
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(45.465422, 9.185924, 31, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F3', 'Device9', 2, 6, true); -- Milano
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id,  activated)values(45.327064, 8.419981, 32, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F4', 'Device10', 2, false); -- Novara
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(46.498295, 11.354758, 33, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F5', 'Device11', 2, 6, true); -- Bolzano
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(45.184724, 9.158207, 29, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F1', 'Device7', 2, 6, true); -- Pavia
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, activated)values(44.405650, 8.946256, 30, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F2', 'Device8', 2, false); -- Genova
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(45.465422, 9.185924, 31, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F3', 'Device9', 2, 6, true); -- Milano
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id,  activated)values(45.327064, 8.419981, 32, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F4', 'Device10', 2, false); -- Novara
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(46.498295, 11.354758, 33, 51, 'luca.bussi@outlook.it', 'AC1F09FFFE1787F5', 'Device11', 2, 6, true); -- Bolzano
 
 
 /* JEM - sud e isole */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.821371, 14.426468, 13, 101, 'jhon30.herrera@gmail.com', '26:06:1C:EC:E7:32', 'Device1', 3, 7, true); -- Vesuvio
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(37.751005, 14.993356, 14, 101, 'jhon30.herrera@gmail.com', '37:06:1C:EC:E7:33', 'Device2', 3, 7, true); -- Etna
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.792520, 15.213890, 15, 101, 'jhon30.herrera@gmail.com', '58:06:1C:EC:E7:34', 'Device3', 3, 7, true); -- Stromboli
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.403837, 14.962126, 16, 101, 'jhon30.herrera@gmail.com', '6B:06:1C:EC:E7:35', 'Device4', 3, 7, true);  -- Isola di Vulcano
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.827907, 14.139006, 17, 101, 'jhon30.herrera@gmail.com', '7C:06:1C:EC:E7:36', 'Device5', 3, 7, true); -- Campi Flegrei
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(42.895464, 11.615520, 18, 101, 'jhon30.herrera@gmail.com', '8D:06:1C:EC:E7:37', 'Device6', 3, 7, false); -- Monte Amiata
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(40.821371, 14.426468, 13, 101, 'jhon30.herrera@gmail.com', '26061CECE732', 'Device1', 3, 7, true); -- Vesuvio
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(37.751005, 14.993356, 14, 101, 'jhon30.herrera@gmail.com', '37061CECE733', 'Device2', 3, 7, true); -- Etna
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(38.792520, 15.213890, 15, 101, 'jhon30.herrera@gmail.com', '58061CECE734', 'Device3', 3, 7, true); -- Stromboli
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(38.403837, 14.962126, 16, 101, 'jhon30.herrera@gmail.com', '6B061CECE735', 'Device4', 3, 7, true);  -- Isola di Vulcano
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(40.827907, 14.139006, 17, 101, 'jhon30.herrera@gmail.com', '7C061CECE736', 'Device5', 3, 7, true); -- Campi Flegrei
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(42.895464, 11.615520, 18, 101, 'jhon30.herrera@gmail.com', '8D061CECE737', 'Device6', 3, 7, false); -- Monte Amiata
 
 /* Dispositivi aggiuntivi VOLCANO */
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.748470, 14.485210, 19, 101, 'jhon30.herrera@gmail.com', '9E:06:1C:EC:E7:38', 'Device7', 3, 7, true); -- Pompei
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.805705, 14.348053, 20, 101, 'jhon30.herrera@gmail.com', 'AF:06:1C:EC:E7:39', 'Device8', 3, 7, true); -- Ercolano
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(37.290037, 13.586708, 21, 101, 'jhon30.herrera@gmail.com', 'B0:06:1C:EC:E7:3A', 'Device9', 3, 7, true); -- Valle dei Templi (Agrigento)
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(40.423006, 15.005619, 22, 101, 'jhon30.herrera@gmail.com', 'C1:06:1C:EC:E7:3B', 'Device10', 3, 7, false); -- Paestum
-insert into device(latitude, longitude, id, project_id, email_owner, mac_address, name, tod_id, operator_id, activated)values(38.357722, 38.316898, 23, 101, 'jhon30.herrera@gmail.com', 'D2:06:1C:EC:E7:3C', 'Device11', 3, 7, true); -- Arslantepe
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(40.748470, 14.485210, 19, 101, 'jhon30.herrera@gmail.com', '9E061CECE738', 'Device7', 3, 7, true); -- Pompei
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(40.805705, 14.348053, 20, 101, 'jhon30.herrera@gmail.com', 'AF061CECE739', 'Device8', 3, 7, true); -- Ercolano
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(37.290037, 13.586708, 21, 101, 'jhon30.herrera@gmail.com', 'B0061CECE73A', 'Device9', 3, 7, true); -- Valle dei Templi (Agrigento)
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(40.423006, 15.005619, 22, 101, 'jhon30.herrera@gmail.com', 'C1061CECE73B', 'Device10', 3, 7, false); -- Paestum
+insert into device(latitude, longitude, id, project_id, email_owner, dev_eui, name, tod_id, operator_id, activated)values(38.357722, 38.316898, 23, 101, 'jhon30.herrera@gmail.com', 'D2061CECE73C', 'Device11', 3, 7, true); -- Arslantepe
 
 insert into spec(id, measurement, unit_of_measurement, component)values(1, 'Temperature', '°C' ,'Sen5x')
 insert into spec(id, measurement, unit_of_measurement, component)values(2, 'Relative Humidity', '%RH' ,'Sen5x')

--- a/src/main/resources/static/css/ltradOperator.css
+++ b/src/main/resources/static/css/ltradOperator.css
@@ -50,10 +50,10 @@ navbar h1 {
 }
 
 .page-title {
-	margin: 1.5rem auto 1rem;
-	text-align: center;
-	font-size: 2rem;
-	font-weight: 700;
+        margin: 1.5rem 0 1rem;
+        text-align: left;
+        font-size: 2rem;
+        font-weight: 700;
 }
 
 .home-button {

--- a/src/main/resources/static/css/volcanoOperator.css
+++ b/src/main/resources/static/css/volcanoOperator.css
@@ -50,10 +50,10 @@ navbar h1 {
 }
 
 .page-title {
-	margin: 1.5rem auto 1rem;
-	text-align: center;
-	font-size: 2rem;
-	font-weight: 700;
+        margin: 1.5rem 0 1rem;
+        text-align: left;
+        font-size: 2rem;
+        font-weight: 700;
 }
 
 .home-button {

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -101,7 +101,7 @@
 				<h2>Your Devices</h2>
                                 <form th:action="@{'/group/' + ${project.id}}" method="get" class="search-form">
                                         <input type="text" name="deviceInfo"
-                                                th:attr="placeholder=${project.id == 101} ? 'Search by name or MAC...' : 'Search by name or DevEUI...'"
+                                                placeholder="Search by name or DevEUI..."
                                                 th:value="${param.deviceInfo}" />
 					<button type="submit" title="Search">
 						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 24 24">
@@ -118,10 +118,7 @@
                                           <thead>
                                                   <tr>
                                                           <th scope="col">Name</th>
-                                                          <th scope="col"
-                                                              th:text="${project.id == 101} ? 'MAC Address' : 'DevEUI'">
-                                                                  Identifier
-                                                          </th>
+                                                          <th scope="col">DevEUI</th>
                                                           <th scope="col">Type of device</th>
                                                           <th scope="col">Operator</th>
                                                           <th scope="col">Activated</th>
@@ -136,7 +133,7 @@
                                                               th:text="${T(it.sensorplatform.util.MacAddressUtils).formatIdentifierForProject(project.id, device.macAddress, device.devEui)}">
                                                                   Identifier
                                                           </td>
-                                                          <td th:text="${device.tod}">Mac Address</td>
+                                                          <td th:text="${device.tod}">Type of device</td>
                                                           <td>
                                                                   <span th:if="${device.operator != null}" th:text="${device.operator}">Operator</span>
                                                           </td>

--- a/src/main/resources/templates/operator.html
+++ b/src/main/resources/templates/operator.html
@@ -75,7 +75,7 @@
                                 <h2>Your Devices on Map</h2>
                                 <form th:action="@{'/operator/' + ${project.id}}" method="get" class="search-form">
                                         <input type="text" name="deviceInfo"
-                                                th:attr="placeholder=${project.id == 101} ? 'Search by name or MAC...' : 'Search by name or DevEUI...'"
+                                                placeholder="Search by name or DevEUI..."
                                                 th:value="${param.deviceInfo}" />
 					<button type="submit" title="Search">
 						<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="white" viewBox="0 0 24 24">
@@ -92,10 +92,7 @@
                                         <thead>
                                                 <tr>
                                                         <th scope="col">Name</th>
-                                                        <th scope="col"
-                                                                th:text="${project.id == 101} ? 'MAC Address' : 'DevEUI'">
-                                                                Identifier
-                                                        </th>
+                                                        <th scope="col">DevEUI</th>
                                                         <th scope="col">Type</th>
                                                 </tr>
                                         </thead>

--- a/src/main/resources/templates/operator/activationRequests.html
+++ b/src/main/resources/templates/operator/activationRequests.html
@@ -171,15 +171,16 @@
         const identifierLabel = element.querySelector('.activation-identifier-label');
         const identifierValue = element.querySelector('.activation-identifier-value');
         if (identifierLabel && identifierValue) {
-            const hasMac = Boolean(notification.macAddress);
             const hasDevEui = Boolean(notification.devEui);
-            if (hasMac) {
+            const hasMac = Boolean(notification.macAddress);
+            if (hasDevEui) {
+                identifierLabel.textContent = 'DevEUI:';
+                const formatted = formatMac(notification.devEui);
+                identifierValue.textContent = formatted || notification.devEui;
+            } else if (hasMac) {
                 identifierLabel.textContent = 'MAC:';
                 const formatted = formatMac(notification.macAddress);
                 identifierValue.textContent = formatted || notification.macAddress;
-            } else if (hasDevEui) {
-                identifierLabel.textContent = 'DevEUI:';
-                identifierValue.textContent = notification.devEui;
             } else {
                 identifierLabel.textContent = 'Identifier:';
                 identifierValue.textContent = 'n/a';


### PR DESCRIPTION
## Summary
- replace the LTRAD seed data to use DevEUIs instead of MAC addresses for device imports
- left-align the Operator Dashboard heading in the LTRAD operator view

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df9fc53b348323aa42c792aa80cc2c