### PR TITLE
Adjust Volcano admin device table header

### DIFF
--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -118,7 +118,8 @@
                                           <thead>
                                                   <tr>
                                                           <th scope="col">Name</th>
-                                                          <th scope="col">DevEUI</th>
+                                                      <th scope="col"
+                                                          th:text="${project.id == 101} ? 'MacAddress' : 'DevEUI'">DevEUI</th>
                                                           <th scope="col">Type of device</th>
                                                           <th scope="col">Operator</th>
                                                           <th scope="col">Activated</th>


### PR DESCRIPTION
## Summary
- update the Volcano admin device table header to display "MacAddress" when viewing project 101

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dffa723f7c83238461d008378d94e5