### PR TITLE
Replace L-TRAD branding with LTRAD

### DIFF
--- a/src/main/resources/templates/admin/formRegisterOperator.html
+++ b/src/main/resources/templates/admin/formRegisterOperator.html
@@ -18,7 +18,7 @@
 <body>
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
-			<h1><a th:if="${projectId == 1}" th:href="@{'/admin/group/'+${projectId}}" class="nav-title-link">L-TRAD</a>
+			<h1><a th:if="${projectId == 1}" th:href="@{'/admin/group/'+${projectId}}" class="nav-title-link">LTRAD</a>
 			</h1>
 			<h1><a th:if="${projectId == 51}" th:href="@{'/admin/group/'+${projectId}}" class="nav-title-link">FIRE</a>
 			</h1>

--- a/src/main/resources/templates/admin/groups.html
+++ b/src/main/resources/templates/admin/groups.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 
 <head>
-	<title th:if="${project.id == 1}">L-TRAD Group</title>
+	<title th:if="${project.id == 1}">LTRAD Group</title>
 	<title th:if="${project.id == 51}">FIRE Group</title>
 	<title th:if="${project.id == 101}">VOLCANO Group</title>
 
@@ -25,7 +25,7 @@
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
 			<h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}"
-					class="nav-title-link">L-TRAD</a></h1>
+					class="nav-title-link">LTRAD</a></h1>
 			<h1><a th:if="${project.id == 51}" th:href="@{'/success'(projectId=${project.id})}"
 					class="nav-title-link">FIRE</a></h1>
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}"

--- a/src/main/resources/templates/admin/manageGroups.html
+++ b/src/main/resources/templates/admin/manageGroups.html
@@ -21,7 +21,7 @@
 <body>
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
-		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">L-TRAD</a></h1>
+		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">LTRAD</a></h1>
 			<h1><a th:if="${project.id == 51}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">FIRE</a></h1>
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -53,7 +53,7 @@
 	    <button class="project-box ltrad"
 	        th:data-href="@{'/access?projectId=' + ${ltrad.id}}"
 	        onclick="window.location.href=this.dataset.href">
-	        <h3>L-TRAD</h3>
+	        <h3>LTRAD</h3>
 	        <p>Technical replacement system for public lighting using drones</p>
 	    </button>
 
@@ -75,7 +75,7 @@
 	
 	<section id="info" class="features-section">
 	    <div class="feature-box ltrad">
-	        <h2>L-TRAD</h2>
+	        <h2>LTRAD</h2>
 	        <p>
 	            💡 Smart system for managing public lighting with real-time fault detection and air quality monitoring
 	            (Particulate, VOC, NOx) via SEN55 sensors and LoRa communication. Automated replacement with aerial

--- a/src/main/resources/templates/project/ltradHome.html
+++ b/src/main/resources/templates/project/ltradHome.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="https://www.thymeleaf.org/extras/spring-security">
 
 <head>
-	<title>L-TRAD – Home</title>
+	<title>LTRAD – Home</title>
 	<link rel="stylesheet" th:href="@{/css/ltradHome.css}" />
 	<link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
 </head>
@@ -10,7 +10,7 @@
 <body>
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
-			<h1>L-TRAD</h1>
+			<h1>LTRAD</h1>
 		</div>
 		<div class="nav-right">
                         <div sec:authorize="isAuthenticated()" th:if="${user != null}" class="auth-user dropdown">
@@ -45,8 +45,8 @@
 	<main class="main-text">
 
 		<section>
-			<h2>💡 L-TRAD – Smart Lighting and Environmental Monitoring</h2>
-			<p><strong>L-TRAD</strong> (Lightning Technical Replacement Aerial Device) is an innovative system for
+			<h2>💡 LTRAD – Smart Lighting and Environmental Monitoring</h2>
+			<p><strong>LTRAD</strong> (Lightning Technical Replacement Aerial Device) is an innovative system for
 				managing public lighting,
 				designed to make cities safer, more sustainable, and more efficient.</p>
 

--- a/src/main/resources/templates/project/volcanoHome.html
+++ b/src/main/resources/templates/project/volcanoHome.html
@@ -10,7 +10,7 @@
 <body>
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
-		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">L-TRAD</a></h1>
+		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">LTRAD</a></h1>
 			<h1><a th:if="${project.id == 51}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">FIRE</a></h1>
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 		</div>

--- a/src/main/resources/templates/superadmin/deviceNotifications.html
+++ b/src/main/resources/templates/superadmin/deviceNotifications.html
@@ -12,7 +12,7 @@
 <body>
 <header id="navbar" class="navbar">
     <div class="nav-left">
-        <h1><a th:if="${project.id == 1}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link">L-TRAD</a></h1>
+        <h1><a th:if="${project.id == 1}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link">LTRAD</a></h1>
         <h1><a th:if="${project.id == 51}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link">FIRE</a></h1>
         <h1><a th:if="${project.id == 101}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link"> VOLCANO</a></h1>
     </div>

--- a/src/main/resources/templates/superadmin/formNewSpec.html
+++ b/src/main/resources/templates/superadmin/formNewSpec.html
@@ -22,7 +22,7 @@
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
 			<h1><a th:if="${project.id == 1}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"
-					class="nav-title-link">L-TRAD</a></h1>
+					class="nav-title-link">LTRAD</a></h1>
 			<h1><a th:if="${project.id == 51}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"
 					class="nav-title-link">FIRE</a></h1>
 			<h1><a th:if="${project.id == 101}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"

--- a/src/main/resources/templates/superadmin/formNewTod.html
+++ b/src/main/resources/templates/superadmin/formNewTod.html
@@ -21,7 +21,7 @@
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
 			<h1><a th:if="${project.id == 1}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"
-					class="nav-title-link">L-TRAD</a></h1>
+					class="nav-title-link">LTRAD</a></h1>
 			<h1><a th:if="${project.id == 51}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"
 					class="nav-title-link">FIRE</a></h1>
 			<h1><a th:if="${project.id == 101}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}"

--- a/src/main/resources/templates/superadmin/formUpdateDevice.html
+++ b/src/main/resources/templates/superadmin/formUpdateDevice.html
@@ -18,7 +18,7 @@
 <body>
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
-		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">L-TRAD</a></h1>
+		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">LTRAD</a></h1>
 			<h1><a th:if="${project.id == 51}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">FIRE</a></h1>
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 		</div>

--- a/src/main/resources/templates/superadmin/manageProjectDevices.html
+++ b/src/main/resources/templates/superadmin/manageProjectDevices.html
@@ -26,7 +26,7 @@
 
 	<header id="navbar" class="navbar">
 				<div class="nav-left">
-				    <h1><a th:if="${project.id == 1}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link">L-TRAD</a></h1>
+				    <h1><a th:if="${project.id == 1}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link">LTRAD</a></h1>
 					<h1><a th:if="${project.id == 51}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link">FIRE</a></h1>
 					<h1><a th:if="${project.id == 101}" th:href="@{'/superadmin/manageProjectDevices/' + ${project.id}}" class="nav-title-link"> VOLCANO</a></h1>
 				</div>

--- a/src/main/resources/templates/superadmin/superadminHome.html
+++ b/src/main/resources/templates/superadmin/superadminHome.html
@@ -49,7 +49,7 @@
 		<h2 class="admin-title">Manage projects</h2>
 		<div class="projects">
 			<div class="project-box ltrad">
-				<h3>L-TRAD</h3>
+				<h3>LTRAD</h3>
 				<p>Technical replacement system for public lighting using drones</p>
 				<div class="admin-buttons">
 					<button id="ltrad-btn" th:data-href="@{'/superadmin/manageProjectDevices/' + ${ltrad.id}}"
@@ -84,7 +84,7 @@
 	</section>
 	<section id="info" class="features-section">
 		<div class="feature-box ltrad">
-			<h2>L-TRAD</h2>
+			<h2>LTRAD</h2>
 			<p>
 				💡 Smart system for managing public lighting with real-time fault detection and air quality monitoring
 				(Particulate, VOC, NOx) via SEN55 sensors and LoRa communication. Automated replacement with aerial

--- a/src/main/resources/templates/updateDevice.html
+++ b/src/main/resources/templates/updateDevice.html
@@ -19,7 +19,7 @@
 <body>
 	<header id="navbar" class="navbar">
 		<div class="nav-left">
-		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">L-TRAD</a></h1>
+		    <h1><a th:if="${project.id == 1}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">LTRAD</a></h1>
 			<h1><a th:if="${project.id == 51}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">FIRE</a></h1>
 			<h1><a th:if="${project.id == 101}" th:href="@{'/success'(projectId=${project.id})}" class="nav-title-link">VOLCANO</a></h1>
 


### PR DESCRIPTION
## Summary
- replace the L-TRAD branding with LTRAD across the admin, superadmin, and project templates
- ensure no remaining occurrences of the hyphenated form remain

## Testing
- rg "L-TRAD"


------
https://chatgpt.com/codex/tasks/task_e_68e28c78a108832798775f349ee06f41